### PR TITLE
Fix typos

### DIFF
--- a/docs/source/examples/02_nesting/04_nesting_in_containers.rst
+++ b/docs/source/examples/02_nesting/04_nesting_in_containers.rst
@@ -7,7 +7,7 @@ Nesting in Containers
 
 Structures can be nested inside of standard containers.
 
-Note that lengths must be inferrable, either via a fixed-length tuple annotation or by
+Note that lengths must be inferable, either via a fixed-length tuple annotation or by
 parsing default values.
 
 

--- a/docs/source/examples/03_config_systems/01_base_configs.rst
+++ b/docs/source/examples/03_config_systems/01_base_configs.rst
@@ -11,7 +11,7 @@ use the CLI to either override (existing) or fill in (missing) values.
 
 Note that our interfaces don't prescribe any of the mechanics used for storing
 base configurations. A Hydra-style YAML approach could just as easily
-be used for the config libary (although we generally prefer to avoid YAMLs; staying in
+be used for the config library (although we generally prefer to avoid YAMLs; staying in
 Python is convenient for autocompletion and type checking).
 
 

--- a/examples/02_nesting/04_nesting_in_containers.py
+++ b/examples/02_nesting/04_nesting_in_containers.py
@@ -2,7 +2,7 @@
 
 Structures can be nested inside of standard containers.
 
-Note that lengths must be inferrable, either via a fixed-length tuple annotation or by
+Note that lengths must be inferable, either via a fixed-length tuple annotation or by
 parsing default values.
 
 

--- a/examples/03_config_systems/01_base_configs.py
+++ b/examples/03_config_systems/01_base_configs.py
@@ -6,7 +6,7 @@ use the CLI to either override (existing) or fill in (missing) values.
 
 Note that our interfaces don't prescribe any of the mechanics used for storing
 base configurations. A Hydra-style YAML approach could just as easily
-be used for the config libary (although we generally prefer to avoid YAMLs; staying in
+be used for the config library (although we generally prefer to avoid YAMLs; staying in
 Python is convenient for autocompletion and type checking).
 
 Usage:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -311,7 +311,7 @@ def test_optional_lists():
 
 def test_nested_optional_types():
     """We support "None" as a special-case keyword. (note: this is a bit weird because
-    Optional[str] might interprete "None" as either a string or an actual `None`
+    Optional[str] might interpret "None" as either a string or an actual `None`
     value)"""
 
     @dataclasses.dataclass


### PR DESCRIPTION
Found via `codespell -S .mypy_cache`