### PR TITLE
(WIP) Expose registry API for third-party integrations

### DIFF
--- a/examples/04_additional/10_custom_constructors.py
+++ b/examples/04_additional/10_custom_constructors.py
@@ -6,6 +6,7 @@ Usage:
 `python ./10_custom_constructors.py --food vegetable`
 """
 
+import functools
 from typing import Literal, Protocol
 
 from typing_extensions import assert_never
@@ -53,9 +54,19 @@ def make_food(food: Literal["fruit", "vegetable"]) -> Food:
 
 
 if __name__ == "__main__":
+    # TODO: this example is temporary. We should make it more readable.
     tyro.registry.register_constructor(
         matcher=lambda typ: typ is Food,
-        constructor_factory=lambda typ: make_food,
+        constructor_factory=lambda typ, default: make_food
+        # If a default is provided (consider: def main(food: Food = Vegetable())), how
+        # should we handle it?
+        #
+        # TODO: do we need to expose both propagating and non-propagating missing types?
+        # This is surprisingly annoying : - )
+        if default in tyro._fields.MISSING_SINGLETONS
+        else functools.partial(
+            make_food, food="fruit" if isinstance(default, Fruit) else "vegetable"
+        ),
     )
 
     # Note that `Food` is a protocol and cannot be directly instantiated; we

--- a/examples/04_additional/10_custom_constructors.py
+++ b/examples/04_additional/10_custom_constructors.py
@@ -1,0 +1,64 @@
+"""TODO:
+
+Usage:
+`python ./10_custom_constructors.py --help`
+`python ./10_custom_constructors.py --food fruit`
+`python ./10_custom_constructors.py --food vegetable`
+"""
+
+from typing import Literal, Protocol
+
+from typing_extensions import assert_never
+
+import tyro
+
+# Implement a `Food` protocol and two structural subtypes: `Fruit` and `Vegetable`.
+
+
+class Food(Protocol):
+    """Interface for defining food objects, which can be eaten."""
+
+    def eat(self) -> None:
+        ...
+
+
+class Fruit:
+    def eat(self) -> None:
+        print("Ate a fruit!")
+
+
+class Vegetable:
+    def eat(self) -> None:
+        print("Ate a vegetable!")
+
+
+# Define a custom constructor for instantiating `Food` objects.
+
+
+def make_food(food: Literal["fruit", "vegetable"]) -> Food:
+    """Make a food.
+
+    Args:
+        food: Type of food.
+
+    Returns:
+        A food object.
+    """
+    if food == "fruit":
+        return Fruit()
+    elif food == "vegetable":
+        return Vegetable()
+    else:
+        assert_never(food)
+
+
+if __name__ == "__main__":
+    tyro.registry.register_constructor(
+        matcher=lambda typ: typ is Food,
+        constructor_factory=lambda typ: make_food,
+    )
+
+    # Note that `Food` is a protocol and cannot be directly instantiated; we
+    # must instead rely on an external factory function.
+    food = tyro.cli(Food)
+    food.eat()

--- a/tyro/__init__.py
+++ b/tyro/__init__.py
@@ -1,16 +1,9 @@
-from . import conf, extras
-from ._cli import cli
-from ._fields import MISSING_PUBLIC as MISSING
-from ._instantiators import UnsupportedTypeAnnotationError
-
-__all__ = [
-    "conf",
-    "extras",
-    "cli",
-    "MISSING",
-    "UnsupportedTypeAnnotationError",
-]
-
-# Deprecated interface. We use a star import to prevent these from showing up in
-# autocomplete engines, etc.
+from . import conf as conf
+from . import extras as extras
+from . import registry as registry
+from ._cli import cli as cli
 from ._deprecated import *  # noqa
+from ._fields import MISSING as MISSING
+from ._instantiators import (
+    UnsupportedTypeAnnotationError as UnsupportedTypeAnnotationError,
+)

--- a/tyro/_calling.py
+++ b/tyro/_calling.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Sequence, Set, Tuple, TypeVar, Uni
 from typing_extensions import get_args
 
 from . import _arguments, _fields, _parsers, _resolver, _strings
+from .registry import _registry
 
 
 class InstantiationError(Exception):

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -35,6 +35,7 @@ from . import conf  # Avoid circular import.
 from . import _docstrings, _instantiators, _resolver, _singleton, _strings
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
+from .registry import _registry
 
 
 @dataclasses.dataclass(frozen=True)
@@ -136,7 +137,7 @@ MISSING_NONPROP = NonpropagatingMissingType()
 EXCLUDE_FROM_CALL = ExcludeFromCallType()
 
 # Note that our "public" missing API will always be the propagating missing sentinel.
-MISSING_PUBLIC: Any = MISSING_PROP
+MISSING: Any = MISSING_PROP
 """Sentinel value to mark fields as missing. Can be used to mark fields passed in as a
 `default_instance` for `tyro.cli()` as required."""
 
@@ -211,6 +212,7 @@ def field_list_from_callable(
         typ = _resolver.type_from_typevar_constraints(typ)
         typ = _resolver.narrow_container_types(typ, field.default)
         typ = _resolver.narrow_union_type(typ, field.default)
+        typ = _registry.get_constructor_for_type(typ)
         field = dataclasses.replace(field, typ=typ)
         return field
 

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -164,6 +164,11 @@ class UnsupportedNestedTypeMessage:
     message: str
 
 
+_DefaultInstance = Union[
+    Any, PropagatingMissingType, NonpropagatingMissingType, ExcludeFromCallType
+]
+
+
 def is_nested_type(typ: TypeForm[Any], default_instance: _DefaultInstance) -> bool:
     """Determine whether a type should be treated as a 'nested type', where a single
     type can be broken down into multiple fields (eg for nested dataclasses or
@@ -171,10 +176,11 @@ def is_nested_type(typ: TypeForm[Any], default_instance: _DefaultInstance) -> bo
 
     TODO: we should come up with a better name than 'nested type', which is a little bit
     misleading."""
-    return not isinstance(
-        _try_field_list_from_callable(typ, default_instance),
-        UnsupportedNestedTypeMessage,
-    )
+    try:
+        field_list_from_callable(typ, default_instance)
+    except _instantiators.UnsupportedTypeAnnotationError:
+        return False
+    return True
 
 
 def field_list_from_callable(
@@ -196,7 +202,9 @@ def field_list_from_callable(
     f = _resolver.narrow_type(f, default_instance)
 
     # Try to generate field list.
-    field_list = _try_field_list_from_callable(f, default_instance)
+    f = _registry.get_constructor_for_type(f, default_instance)
+    # field_list = _try_field_list_from_callable(f, default_instance)
+    field_list = _field_list_from_callable_signature(f)
 
     if isinstance(field_list, UnsupportedNestedTypeMessage):
         raise _instantiators.UnsupportedTypeAnnotationError(field_list.message)
@@ -212,7 +220,7 @@ def field_list_from_callable(
         typ = _resolver.type_from_typevar_constraints(typ)
         typ = _resolver.narrow_container_types(typ, field.default)
         typ = _resolver.narrow_union_type(typ, field.default)
-        typ = _registry.get_constructor_for_type(typ)
+        typ = _registry.get_constructor_for_type(typ, field.default)
         field = dataclasses.replace(field, typ=typ)
         return field
 
@@ -222,11 +230,6 @@ def field_list_from_callable(
 
 
 # Implementation details below.
-
-
-_DefaultInstance = Union[
-    Any, PropagatingMissingType, NonpropagatingMissingType, ExcludeFromCallType
-]
 
 _known_parsable_types = set(
     filter(
@@ -241,400 +244,25 @@ _known_parsable_types = set(
 )
 
 
-def _try_field_list_from_callable(
-    f: Union[Callable, TypeForm[Any]],
-    default_instance: _DefaultInstance,
+def _field_list_from_callable_signature(
+    f: Union[Callable, TypeForm[Any]]
 ) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    f, found_subcommand_configs = _resolver.unwrap_annotated(
-        f, conf._confstruct._SubcommandConfiguration
-    )
-    if len(found_subcommand_configs) > 0:
-        default_instance = found_subcommand_configs[0].default
-
-    # Unwrap generics.
-    f, type_from_typevar = _resolver.resolve_generic_types(f)
-    f = _resolver.narrow_type(f, default_instance)
-    f_origin = _resolver.unwrap_origin_strip_extras(cast(TypeForm, f))
-
-    # If `f` is a type:
-    #     1. Set cls to the type.
-    #     2. Consider `f` to be `cls.__init__`.
-    cls: Optional[TypeForm[Any]] = None
-    if isinstance(f, type):
-        cls = f
-        f = cls.__init__  # type: ignore
-        f_origin = cls  # type: ignore
-
-    # Try field generation from class inputs.
-    if cls is not None:
-        for match, field_list_from_class in (
-            (is_typeddict, _field_list_from_typeddict),
-            (_resolver.is_namedtuple, _field_list_from_namedtuple),
-            (_resolver.is_dataclass, _field_list_from_dataclass),
-            (_is_attrs, _field_list_from_attrs),
-            (_is_pydantic, _field_list_from_pydantic),
-        ):
-            if match(cls):
-                return field_list_from_class(cls, default_instance)
-
-    # Standard container types. These are different because they can be nested structures
-    # if they contain other nested types (eg Tuple[Struct, Struct]), or treated as
-    # single arguments otherwise (eg Tuple[int, int]).
-    #
-    # Note that f_origin will be populated if we annotate as `Tuple[..]`, and cls will
-    # be populated if we annotate as just `tuple`.
-    if f_origin is tuple or cls is tuple:
-        return _field_list_from_tuple(f, default_instance)
-    elif f_origin in (collections.abc.Mapping, dict) or cls in (
-        collections.abc.Mapping,
-        dict,
-    ):
-        return _field_list_from_dict(f, default_instance)
-    elif f_origin in (list, set, typing.Sequence) or cls in (
-        list,
-        set,
-        typing.Sequence,
-    ):
-        return _field_list_from_sequence_checked(f, default_instance)
-
-    # General cases.
-    if (
-        cls is not None and cls in _known_parsable_types
-    ) or _resolver.unwrap_origin_strip_extras(f) in _known_parsable_types:
+    if (f in _known_parsable_types) or _resolver.unwrap_origin_strip_extras(
+        f
+    ) in _known_parsable_types:
         return UnsupportedNestedTypeMessage(f"{f} should be parsed directly!")
-    else:
-        return _try_field_list_from_general_callable(f, cls, default_instance)
-
-
-def _field_list_from_typeddict(
-    cls: TypeForm[Any], default_instance: _DefaultInstance
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    field_list = []
-    valid_default_instance = (
-        default_instance not in MISSING_SINGLETONS
-        and default_instance is not EXCLUDE_FROM_CALL
-    )
-    assert not valid_default_instance or isinstance(default_instance, dict)
-    for name, typ in get_type_hints(cls, include_extras=True).items():
-        if valid_default_instance:
-            default = default_instance.get(name, MISSING_PROP)  # type: ignore
-        elif getattr(cls, "__total__") is False:
-            default = EXCLUDE_FROM_CALL
-            if is_nested_type(typ, MISSING_NONPROP):
-                raise _instantiators.UnsupportedTypeAnnotationError(
-                    "`total=False` not supported for nested structures."
-                )
-        else:
-            default = MISSING_PROP
-
-        field_list.append(
-            FieldDefinition.make(
-                name=name,
-                typ=typ,
-                default=default,
-                helptext=_docstrings.get_field_docstring(cls, name),
-            )
-        )
-    return field_list
-
-
-def _field_list_from_namedtuple(
-    cls: TypeForm[Any], default_instance: _DefaultInstance
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    # Handle NamedTuples.
-    #
-    # TODO: in terms of helptext, we currently do display the default NamedTuple
-    # helptext. But we (intentionally) don't for dataclasses; this is somewhat
-    # inconsistent.
-    field_list = []
-    field_defaults = getattr(cls, "_field_defaults")
-
-    # Note that _field_types is removed in Python 3.9.
-    for name, typ in get_type_hints(cls, include_extras=True).items():
-        # Get default, with priority for `default_instance`.
-        default = field_defaults.get(name, MISSING_NONPROP)
-        if hasattr(default_instance, name):
-            default = getattr(default_instance, name)
-        if default_instance is MISSING_PROP:
-            default = MISSING_PROP
-
-        field_list.append(
-            FieldDefinition.make(
-                name=name,
-                typ=typ,
-                default=default,
-                helptext=_docstrings.get_field_docstring(cls, name),
-            )
-        )
-    return field_list
-
-
-def _field_list_from_dataclass(
-    cls: TypeForm[Any], default_instance: _DefaultInstance
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    # Handle dataclasses.
-    field_list = []
-    for dc_field in filter(lambda field: field.init, _resolver.resolved_fields(cls)):
-        default = _get_dataclass_field_default(dc_field, default_instance)
-
-        # Try to get helptext from field metadata. This is also intended to be
-        # compatible with HuggingFace-style config objects.
-        helptext = dc_field.metadata.get("help", None)
-        assert isinstance(helptext, (str, type(None)))
-
-        # Try to get helptext from docstrings. Note that this can't be generated
-        # dynamically.
-        if helptext is None:
-            helptext = _docstrings.get_field_docstring(cls, dc_field.name)
-
-        field_list.append(
-            FieldDefinition.make(
-                name=dc_field.name,
-                typ=dc_field.type,
-                default=default,
-                helptext=helptext,
-            )
-        )
-    return field_list
-
-
-# Support attrs and pydantic if they're installed.
-
-try:
-    import pydantic
-except ImportError:
-    pydantic = None  # type: ignore
-
-
-def _is_pydantic(cls: TypeForm[Any]) -> bool:
-    return pydantic is not None and issubclass(cls, pydantic.BaseModel)
-
-
-def _field_list_from_pydantic(
-    cls: TypeForm[Any], default_instance: _DefaultInstance
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    assert pydantic is not None
-
-    # Handle pydantic models.
-    field_list = []
-    for pd_field in cls.__fields__.values():  # type: ignore
-        field_list.append(
-            FieldDefinition.make(
-                name=pd_field.name,
-                typ=pd_field.outer_type_,
-                default=MISSING_NONPROP
-                if pd_field.required
-                else pd_field.get_default(),
-                helptext=pd_field.field_info.description,
-            )
-        )
-    return field_list
-
-
-try:
-    import attr
-except ImportError:
-    attr = None  # type: ignore
-
-
-def _is_attrs(cls: TypeForm[Any]) -> bool:
-    return attr is not None and attr.has(cls)
-
-
-def _field_list_from_attrs(
-    cls: TypeForm[Any], default_instance: _DefaultInstance
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    assert attr is not None
-
-    # Handle attr classes.
-    field_list = []
-    for attr_field in attr.fields(cls):
-        # Default handling.
-        default = attr_field.default
-        if default is attr.NOTHING:
-            default = MISSING_NONPROP
-        elif isinstance(default, attr.Factory):  # type: ignore
-            default = default.factory()  # type: ignore
-
-        assert attr_field.type is not None
-        field_list.append(
-            FieldDefinition.make(
-                name=attr_field.name,
-                typ=attr_field.type,
-                default=default,
-                helptext=_docstrings.get_field_docstring(cls, attr_field.name),
-            )
-        )
-    return field_list
-
-
-def _field_list_from_tuple(
-    f: Union[Callable, TypeForm[Any]], default_instance: _DefaultInstance
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    # Fixed-length tuples.
-    field_list = []
-    children = get_args(f)
-    if Ellipsis in children:
-        return _try_field_list_from_sequence_inner(
-            next(iter(set(children) - {Ellipsis})), default_instance
-        )
-
-    # Infer more specific type when tuple annotation isn't subscripted. This generally
-    # doesn't happen
-    if len(children) == 0:
-        if default_instance in MISSING_SINGLETONS:
-            raise _instantiators.UnsupportedTypeAnnotationError(
-                "If contained types of a tuple are not specified in the annotation, a"
-                " default instance must be specified."
-            )
-        else:
-            assert isinstance(default_instance, tuple)
-            children = tuple(type(x) for x in default_instance)
-
-    if (
-        default_instance in MISSING_SINGLETONS
-        # EXCLUDE_FROM_CALL indicates we're inside a TypedDict, with total=False.
-        or default_instance is EXCLUDE_FROM_CALL
-    ):
-        default_instance = (default_instance,) * len(children)
-
-    for i, child in enumerate(children):
-        default_i = default_instance[i]  # type: ignore
-        field_list.append(
-            FieldDefinition.make(
-                # Ideally we'd have --tuple[0] instead of --tuple.0 as the command-line
-                # argument, but in practice the brackets are annoying because they
-                # require escaping.
-                name=str(i),
-                typ=child,
-                default=default_i,
-                helptext="",
-                # This should really set the positional marker, but the CLI is more
-                # intuitive for mixed nested/non-nested types in tuples when we stick
-                # with kwargs. Tuples are special-cased in _calling.py.
-            )
-        )
-
-    contains_nested = False
-    for field in field_list:
-        contains_nested |= is_nested_type(field.typ, field.default)
-    if not contains_nested:
-        # We could also check for variable length children, which can be populated when
-        # the tuple is interpreted as a nested field but not a directly parsed one.
-        return UnsupportedNestedTypeMessage(
-            "Tuple does not contain any nested structures."
-        )
-
-    return field_list
-
-
-def _field_list_from_sequence_checked(
-    f: Union[Callable, TypeForm[Any]], default_instance: _DefaultInstance
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    contained_type: Any
-    if len(get_args(f)) == 0:
-        if default_instance in MISSING_SINGLETONS:
-            raise _instantiators.UnsupportedTypeAnnotationError(
-                f"Sequence type {f} needs either an explicit type or a"
-                " default to infer from."
-            )
-        assert isinstance(default_instance, Iterable)
-        contained_type = next(iter(default_instance))
-    else:
-        (contained_type,) = get_args(f)
-    return _try_field_list_from_sequence_inner(contained_type, default_instance)
-
-
-def _try_field_list_from_sequence_inner(
-    contained_type: TypeForm[Any],
-    default_instance: _DefaultInstance,
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    # When no default instance is specified:
-    #     If we have List[int] => this can be parsed as a single field.
-    #     If we have List[SomeStruct] => OK.
-    if default_instance in MISSING_SINGLETONS and not is_nested_type(
-        contained_type, MISSING_NONPROP
-    ):
-        return UnsupportedNestedTypeMessage(
-            f"Sequence containing type {contained_type} should be parsed directly!"
-        )
-
-    # If we have a default instance:
-    #     [int, int, int] => this can be parsed as a single field.
-    #     [SomeStruct, int, int] => OK.
-    if isinstance(default_instance, Iterable) and all(
-        [not is_nested_type(type(x), x) for x in default_instance]
-    ):
-        return UnsupportedNestedTypeMessage(
-            f"Sequence with default {default_instance} should be parsed directly!"
-        )
-    if default_instance in MISSING_SINGLETONS:
-        # We use the broader error type to prevent it from being caught by
-        # is_possibly_nested_type(). This is for sure a bad annotation!
-        raise _instantiators.UnsupportedTypeAnnotationError(
-            "For variable-length sequences over nested types, we need a default value"
-            " to infer length from."
-        )
-
-    field_list = []
-    for i, default_i in enumerate(default_instance):  # type: ignore
-        field_list.append(
-            FieldDefinition.make(
-                name=str(i),
-                typ=contained_type,
-                default=default_i,
-                helptext="",
-            )
-        )
-    return field_list
-
-
-def _field_list_from_dict(
-    f: Union[Callable, TypeForm[Any]],
-    default_instance: _DefaultInstance,
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    if default_instance in MISSING_SINGLETONS:
-        return UnsupportedNestedTypeMessage(
-            "Nested dictionary structures must have a default instance specified."
-        )
-    field_list = []
-    for k, v in cast(dict, default_instance).items():
-        field_list.append(
-            FieldDefinition.make(
-                name=str(k) if not isinstance(k, enum.Enum) else k.name,
-                typ=type(v),
-                default=v,
-                helptext=None,
-                # Dictionary specific key:
-                call_argname_override=k,
-            )
-        )
-    return field_list
-
-
-def _try_field_list_from_general_callable(
-    f: Union[Callable, TypeForm[Any]],
-    cls: Optional[TypeForm[Any]],
-    default_instance: _DefaultInstance,
-) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
-    # Handle general callables.
-    if default_instance not in MISSING_SINGLETONS:
-        return UnsupportedNestedTypeMessage(
-            "`default_instance` is supported only for select types:"
-            " dataclasses, lists, NamedTuple, TypedDict, etc."
-        )
 
     # Generate field list from function signature.
     if not callable(f):
         return UnsupportedNestedTypeMessage(
             f"Cannot extract annotations from {f}, which is not a callable type."
         )
-    params = list(inspect.signature(f).parameters.values())
-    if cls is not None:
-        # Ignore self parameter.
-        params = params[1:]
+    try:
+        params = list(inspect.signature(f).parameters.values())
+    except ValueError:
+        return UnsupportedNestedTypeMessage(f"Could not inspect signature of {f}!")
 
-    out = _field_list_from_params(f, cls, params)
+    out = _field_list_from_params(f, params)
     if not isinstance(out, UnsupportedNestedTypeMessage):
         return out
 
@@ -644,37 +272,41 @@ def _try_field_list_from_general_callable(
 
 
 def _field_list_from_params(
-    f: Union[Callable, TypeForm[Any]],
-    cls: Optional[TypeForm[Any]],
-    params: List[inspect.Parameter],
+    f: Union[Callable, TypeForm[Any]], params: List[inspect.Parameter]
 ) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
     # Unwrap functools.wraps and functools.partial.
     done = False
     while not done:
         done = True
         if hasattr(f, "__wrapped__"):
-            f = f.__wrapped__
+            f = f.__wrapped__  # type: ignore
             done = False
         if isinstance(f, functools.partial):
             f = f.func
             done = False
 
-    # Sometime functools.* is applied to a class.
-    if isinstance(f, type):
-        cls = f
-        f = f.__init__  # type: ignore
-
     # Get type annotations, docstrings.
-    docstring = inspect.getdoc(f)
     docstring_from_arg_name = {}
-    if docstring is not None:
+
+    def populate_docstring_from_arg_name(f):
+        docstring = inspect.getdoc(f)
+        if docstring is None:
+            return
         for param_doc in docstring_parser.parse(docstring).params:
             docstring_from_arg_name[param_doc.arg_name] = param_doc.description
-    del docstring
+
+    is_class = hasattr(f, "__init__") and type(f) is type
+
+    populate_docstring_from_arg_name(f)
+    if is_class:
+        populate_docstring_from_arg_name(f.__init__)
 
     # This will throw a type error for torch.device, typing.Dict, etc.
     try:
-        hints = get_type_hints(f, include_extras=True)
+        if is_class:
+            hints = get_type_hints(f.__init__, include_extras=True)
+        else:
+            hints = get_type_hints(f, include_extras=True)
     except TypeError:
         return UnsupportedNestedTypeMessage(f"Could not get hints for {f}!")
 
@@ -685,8 +317,6 @@ def _field_list_from_params(
 
         # Get helptext from docstring.
         helptext = docstring_from_arg_name.get(param.name)
-        if helptext is None and cls is not None:
-            helptext = _docstrings.get_field_docstring(cls, param.name)
 
         if param.name not in hints:
             out = UnsupportedNestedTypeMessage(
@@ -714,72 +344,3 @@ def _field_list_from_params(
         )
 
     return field_list
-
-
-def _ensure_dataclass_instance_used_as_default_is_frozen(
-    field: dataclasses.Field, default_instance: Any
-) -> None:
-    """Ensure that a dataclass type used directly as a default value is marked as
-    frozen."""
-    assert dataclasses.is_dataclass(default_instance)
-    cls = type(default_instance)
-    if not cls.__dataclass_params__.frozen:  # type: ignore
-        warnings.warn(
-            f"Mutable type {cls} is used as a default value for `{field.name}`. This is"
-            " dangerous! Consider using `dataclasses.field(default_factory=...)` or"
-            f" marking {cls} as frozen."
-        )
-
-
-def _get_dataclass_field_default(
-    field: dataclasses.Field, parent_default_instance: Any
-) -> Optional[Any]:
-    """Helper for getting the default instance for a field."""
-    # If the dataclass's parent is explicitly marked MISSING, mark this field as missing
-    # as well.
-    if parent_default_instance is MISSING_PROP:
-        return MISSING_PROP
-
-    # Try grabbing default from parent instance.
-    if (
-        parent_default_instance not in MISSING_SINGLETONS
-        and parent_default_instance is not None
-    ):
-        # Populate default from some parent, eg `default_instance` in `tyro.cli()`.
-        if hasattr(parent_default_instance, field.name):
-            return getattr(parent_default_instance, field.name)
-        else:
-            warnings.warn(
-                f"Could not find field {field.name} in default instance"
-                f" {parent_default_instance}, which has"
-                f" type {type(parent_default_instance)},",
-                stacklevel=2,
-            )
-
-    # Try grabbing default from dataclass field.
-    if field.default not in MISSING_SINGLETONS:
-        default = field.default
-        # Note that dataclasses.is_dataclass() will also return true for dataclass
-        # _types_, not just instances.
-        if type(default) is not type and dataclasses.is_dataclass(default):
-            _ensure_dataclass_instance_used_as_default_is_frozen(field, default)
-        return default
-
-    # Populate default from `dataclasses.field(default_factory=...)`.
-    if field.default_factory is not dataclasses.MISSING and not (
-        # Special case to ignore default_factory if we write:
-        # `field: Dataclass = dataclasses.field(default_factory=Dataclass)`.
-        #
-        # In other words, treat it the same way as: `field: Dataclass`.
-        #
-        # The only time this matters is when we our dataclass has a `__post_init__`
-        # function that mutates the dataclass. We choose here to use the default values
-        # before this method is called.
-        dataclasses.is_dataclass(field.type)
-        and field.default_factory is field.type
-    ):
-        return field.default_factory()
-
-    # Otherwise, no default. This is different from MISSING, because MISSING propagates
-    # to children. We could revisit this design to make it clearer.
-    return MISSING_NONPROP

--- a/tyro/_parsers.py
+++ b/tyro/_parsers.py
@@ -31,6 +31,7 @@ from . import (
 )
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
+from .registry import _registry
 
 T = TypeVar("T")
 

--- a/tyro/_parsers.py
+++ b/tyro/_parsers.py
@@ -439,6 +439,7 @@ class SubparsersSpecification:
                 subcommand_config = dataclasses.replace(
                     subcommand_config, default=field.default
                 )
+
             subparser = ParserSpecification.from_callable_or_type(
                 # Recursively apply markers.
                 Annotated.__class_getitem__((option,) + tuple(field.markers))  # type: ignore

--- a/tyro/registry/__init__.py
+++ b/tyro/registry/__init__.py
@@ -1,0 +1,1 @@
+from ._registry import register_constructor as register_constructor

--- a/tyro/registry/__init__.py
+++ b/tyro/registry/__init__.py
@@ -1,1 +1,1 @@
-from ._registry import register_constructor as register_constructor
+from ._registry import register_constructor

--- a/tyro/registry/_extensions.py
+++ b/tyro/registry/_extensions.py
@@ -1,0 +1,94 @@
+import dataclasses
+import functools
+import inspect
+import warnings
+from typing import Any, Callable, Type, TypeVar
+
+from .. import _docstrings
+from .._fields import MISSING_PROP, MISSING_SINGLETONS
+from .._resolver import is_dataclass
+from ._registry import register_constructor
+
+T = TypeVar("T")
+
+
+def _ensure_dataclass_instance_used_as_default_is_frozen(
+    field: dataclasses.Field, default_instance: Any
+) -> None:
+    """Ensure that a dataclass type used directly as a default value is marked as
+    frozen."""
+    assert dataclasses.is_dataclass(default_instance)
+    cls = type(default_instance)
+    if not cls.__dataclass_params__.frozen:  # type: ignore
+        warnings.warn(
+            f"Mutable type {cls} is used as a default value for `{field.name}`. This is"
+            " dangerous! Consider using `dataclasses.field(default_factory=...)` or"
+            f" marking {cls} as frozen."
+        )
+
+
+def _get_dataclass_field_default(
+    field: dataclasses.Field, parent_default_instance: Any
+) -> Any:
+    """Helper for getting the default instance for a field."""
+    # If the dataclass's parent is explicitly marked MISSING, mark this field as missing
+    # as well.
+    if parent_default_instance is MISSING_PROP:
+        return MISSING_PROP
+
+    # Try grabbing default from parent instance.
+    if (
+        parent_default_instance not in MISSING_SINGLETONS
+        and parent_default_instance is not None
+    ):
+        # Populate default from some parent, eg `default_instance` in `tyro.cli()`.
+        if hasattr(parent_default_instance, field.name):
+            return getattr(parent_default_instance, field.name)
+        else:
+            warnings.warn(
+                f"Could not find field {field.name} in default instance"
+                f" {parent_default_instance}, which has"
+                f" type {type(parent_default_instance)},",
+                stacklevel=2,
+            )
+
+    # Try grabbing default from dataclass field.
+    if field.default not in MISSING_SINGLETONS:
+        default = field.default
+        # Note that dataclasses.is_dataclass() will also return true for dataclass
+        # _types_, not just instances.
+        if type(default) is not type and dataclasses.is_dataclass(default):
+            _ensure_dataclass_instance_used_as_default_is_frozen(field, default)
+        return default
+
+    # Populate default from `dataclasses.field(default_factory=...)`.
+    if field.default_factory is not dataclasses.MISSING and not (
+        # Special case to ignore default_factory if we write:
+        # `field: Dataclass = dataclasses.field(default_factory=Dataclass)`.
+        #
+        # In other words, treat it the same way as: `field: Dataclass`.
+        #
+        # The only time this matters is when we our dataclass has a `__post_init__`
+        # function that mutates the dataclass. We choose here to use the default values
+        # before this method is called.
+        dataclasses.is_dataclass(field.type)
+        and field.default_factory is field.type
+    ):
+        return field.default_factory()
+
+    # Otherwise, no default.
+    return inspect.Parameter.empty
+
+
+def dataclass_constructor_factory(typ: Type[T], default: T) -> Callable[..., Type[T]]:
+    # TODO: docstrings, etc.
+    kwdefaults = {
+        f.name: _get_dataclass_field_default(f, default)
+        for f in dataclasses.fields(typ)
+    }
+    return functools.partial(typ, **kwdefaults)
+
+
+def register_builtins() -> None:
+    # TODO: add back support for all other nested types.
+    register_constructor(is_dataclass, dataclass_constructor_factory)

--- a/tyro/registry/_registry.py
+++ b/tyro/registry/_registry.py
@@ -2,6 +2,9 @@ import dataclasses
 import functools
 from typing import Any, Callable, List, Optional, Protocol, Tuple, Type, TypeVar, Union
 
+from typing_extensions import Annotated
+
+from .. import _resolver
 from .._typing import TypeForm
 
 T = TypeVar("T")
@@ -44,4 +47,5 @@ def get_constructor_for_type(typ: TypeT, default: Any) -> TypeT:
     for matcher, constructor_factory in registered_constructors:
         if matcher(typ):
             return constructor_factory(typ, default)  # type: ignore
+
     return typ

--- a/tyro/registry/_registry.py
+++ b/tyro/registry/_registry.py
@@ -7,7 +7,7 @@ from .._typing import TypeForm
 T = TypeVar("T")
 
 MatchingFunction = Callable[[Type], bool]
-ConstructorFactoryFunction = Callable[[Type[T]], Callable[..., T]]
+ConstructorFactoryFunction = Callable[[Type[T], T], Callable[..., T]]
 
 
 registered_constructors: List[Tuple[MatchingFunction, ConstructorFactoryFunction]] = []
@@ -30,8 +30,18 @@ def register_constructor(
 TypeT = TypeVar("TypeT", bound=Union[TypeForm, Callable])
 
 
-def get_constructor_for_type(typ: TypeT) -> TypeT:
+builtsin_registered = False
+
+
+def get_constructor_for_type(typ: TypeT, default: Any) -> TypeT:
+    global builtins_registered
+    if not builtsin_registered:
+        from . import _extensions
+
+        _extensions.register_builtins()
+        builtins_registered = True
+
     for matcher, constructor_factory in registered_constructors:
         if matcher(typ):
-            return constructor_factory(typ)  # type: ignore
+            return constructor_factory(typ, default)  # type: ignore
     return typ

--- a/tyro/registry/_registry.py
+++ b/tyro/registry/_registry.py
@@ -1,0 +1,37 @@
+import dataclasses
+import functools
+from typing import Any, Callable, List, Optional, Protocol, Tuple, Type, TypeVar, Union
+
+from .._typing import TypeForm
+
+T = TypeVar("T")
+
+MatchingFunction = Callable[[Type], bool]
+ConstructorFactoryFunction = Callable[[Type[T]], Callable[..., T]]
+
+
+registered_constructors: List[Tuple[MatchingFunction, ConstructorFactoryFunction]] = []
+
+
+def register_constructor(
+    matcher: MatchingFunction,
+    constructor_factory: ConstructorFactoryFunction,
+) -> None:
+    """Register custom constructors.
+
+    When tyro encounters a type `t` where `matcher(t)` is True, it will be parsed using
+    the signature of the function returned by `constructor_factory(t)` instead of the
+    default constructor."""
+    registered_constructors.append((matcher, constructor_factory))
+
+
+# Be a little bit permissive with types here, since we often blur the lines between
+# Callable[..., T] and TypeForm[T]... this could be cleaned up!
+TypeT = TypeVar("TypeT", bound=Union[TypeForm, Callable])
+
+
+def get_constructor_for_type(typ: TypeT) -> TypeT:
+    for matcher, constructor_factory in registered_constructors:
+        if matcher(typ):
+            return constructor_factory(typ)  # type: ignore
+    return typ


### PR DESCRIPTION
Motivated by #23, just starting a PR to track progress.

The current goal is to:
1. Expose an API for configuring custom behavior/constructors for types that match some criteria. This is particularly useful for protocols, which can only be instantiated by an external function.
2. Prove that this API is powerful enough by internally migrating support for dataclasses, attrs, TypedDict, etc, over to it.

Turns out, however, that the engineering complexity of (2) is pretty high when we start considering all of the corner cases concerning things like partials, generics, helptext generation, forward references, etc, that the existing architecture was designed to handle.

Given time constraints, may need to choose between (a) not landing this feature for the forseeable future or (b) reverting a bunch of changes and making the PR less ambitious.