### PR TITLE
Add support for PathLike classes & objects with __new__ but no __init__

### DIFF
--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -511,9 +511,7 @@ def test_metavar_4() -> None:
 
 def test_metavar_5() -> None:
     def main(
-        x: List[
-            Union[Tuple[int, int], Tuple[str, str]],
-        ] = [(1, 1), (2, 2)]
+        x: List[Union[Tuple[int, int], Tuple[str, str]]] = [(1, 1), (2, 2)]
     ) -> None:
         pass
 

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -511,7 +511,9 @@ def test_metavar_4() -> None:
 
 def test_metavar_5() -> None:
     def main(
-        x: List[Union[Tuple[int, int], Tuple[str, str]],] = [(1, 1), (2, 2)]
+        x: List[
+            Union[Tuple[int, int], Tuple[str, str]],
+        ] = [(1, 1), (2, 2)]
     ) -> None:
         pass
 

--- a/tyro/_docstrings.py
+++ b/tyro/_docstrings.py
@@ -306,7 +306,7 @@ def get_callable_description(f: Callable) -> str:
     docstring = f.__doc__
     if (
         docstring is None
-        and isinstance(f, type)
+        and inspect.isclass(f)
         # Ignore TypedDict's __init__ docstring, because it will just be `dict`
         and not is_typeddict(f)
         # Ignore NamedTuple __init__ docstring.

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -266,7 +266,8 @@ def _try_field_list_from_callable(
             f = cls.__new__
         else:
             return UnsupportedNestedTypeMessage(
-                f"Cannot instantiate class {cls} with no unique __init__ or __new__ method."
+                f"Cannot instantiate class {cls} with no unique __init__ or __new__"
+                " method."
             )
         f_origin = cls  # type: ignore
 


### PR DESCRIPTION
This solves most of the issues outlined in #36 and #37. Specifically,


1. Exactly like #37 it converts `os.PathLike` to `pathlib.Path`.
2. Additionally, if an object acts as `PathLike`, i.e., implements `os.PathLike` and is a type converter, i.e., `(arg: Union[str, Any]) -> T` then Tyro will parse this object as the "leaf node". This allows for custom `PathLike` objects like `epath.Path`.
3. Allows for recursing on objects that implement `__new__` and not `__init__`. One such object is `pathlib.Path` but there could be others out there.


Is there an argument to be made that any callable with a single positional argument that is `Union[str, Any]` should be treated as a leaf node? Or could there be a marker to specifically enable this functionality? If I remove the custom check for `PathLike` that stops the recursion you'd instead get something like `--path.args` instead of `--path` which I didn't think is desirable.

P.S. I changed `isinstance(typ, type)` -> `inspect.isclass(typ)` which I think makes things more clear. The actual implementation of `inspect.isclass` is `isinstance(typ, type)`.