### PR TITLE
Fix `%` character as default str argument in dataclass

### DIFF
--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -188,6 +188,7 @@ def test_helptext_defaults() -> None:
     class HelptextWithVariousDefaults:
         x: pathlib.Path = pathlib.Path("/some/path/to/a/file")
         y: Color = Color.RED
+        z: str = "%"
 
     helptext = get_helptext(HelptextWithVariousDefaults)
     assert "show this help message and exit" in helptext
@@ -195,6 +196,8 @@ def test_helptext_defaults() -> None:
     assert "(default: /some/path/to/a/file)" in helptext
     assert "--y {RED,GREEN,BLUE}" in helptext
     assert "(default: RED)" in helptext
+    assert "--z STR" in helptext
+    assert "(default: %)" in helptext
 
 
 def test_multiline_helptext() -> None:

--- a/tyro/_argparse_formatter.py
+++ b/tyro/_argparse_formatter.py
@@ -380,7 +380,6 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
             description_part = None
             item_parts = []
             for func, args in self.items:
-                item_content = func(*args)
                 if (
                     getattr(func, "__func__", None)
                     is TyroArgparseHelpFormatter._format_action
@@ -390,6 +389,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                     item_parts.extend(self._format_action(action))
 
                 else:
+                    item_content = func(*args)
                     assert isinstance(item_content, str)
                     if item_content.strip() != "":
                         assert (


### PR DESCRIPTION
Previously, if a `str` type argument's default value contains `%`, the `--help` action fails.  Reproducible example:

```bash
$ cat >percent-char.py <<EOF
import tyro
from dataclasses import dataclass

@dataclass
class A:
    name: str = "%"

def main(args: A):
    print(args.name)

if __name__ == "__main__":
    tyro.cli(main)
EOF

$ python percent-char.py --help
[...truncated...]
  File "/.../lib/python3.9/argparse.py", line 630, in _expand_help
    return self._get_help_string(action) % params
ValueError: unsupported format character ')' (0x29) at index 29
```

This commit fixes this and updates the test for default help text to cover this case.