### PR TITLE
Append action for variable-length containers

### DIFF
--- a/docs/source/examples/04_additional/02_dictionaries.rst
+++ b/docs/source/examples/04_additional/02_dictionaries.rst
@@ -16,8 +16,6 @@ Dictionary inputs can be specified using either a standard ``Dict[K, V]`` annota
 
         from typing import Dict, Mapping, Tuple, TypedDict
 
-        from frozendict import frozendict  # type: ignore
-
         import tyro
 
 
@@ -37,19 +35,11 @@ Dictionary inputs can be specified using either a standard ``Dict[K, V]`` annota
                 "beta1": 0.9,
                 "beta2": 0.999,
             },
-            frozen_dict: Mapping[str, float] = frozendict(
-                {
-                    "num_epochs": 20,
-                    "batch_size": 64,
-                }
-            ),
         ) -> None:
             assert isinstance(typed_dict, dict)
             assert isinstance(standard_dict, dict)
-            assert isinstance(frozen_dict, frozendict)
             print("Typed dict:", typed_dict)
             print("Standard dict:", standard_dict)
-            print("Frozen dict:", frozen_dict)
 
 
         if __name__ == "__main__":

--- a/examples/04_additional/02_dictionaries.py
+++ b/examples/04_additional/02_dictionaries.py
@@ -11,8 +11,6 @@ Usage:
 
 from typing import Dict, Mapping, Tuple, TypedDict
 
-from frozendict import frozendict  # type: ignore
-
 import tyro
 
 
@@ -32,19 +30,11 @@ def main(
         "beta1": 0.9,
         "beta2": 0.999,
     },
-    frozen_dict: Mapping[str, float] = frozendict(
-        {
-            "num_epochs": 20,
-            "batch_size": 64,
-        }
-    ),
 ) -> None:
     assert isinstance(typed_dict, dict)
     assert isinstance(standard_dict, dict)
-    assert isinstance(frozen_dict, frozendict)
     print("Typed dict:", typed_dict)
     print("Standard dict:", standard_dict)
-    print("Frozen dict:", frozen_dict)
 
 
 if __name__ == "__main__":

--- a/examples/04_additional/02_dictionaries.py
+++ b/examples/04_additional/02_dictionaries.py
@@ -9,7 +9,7 @@ Usage:
 `python ./02_dictionaries.py --typed-dict.betas 0.9 0.999`
 """
 
-from typing import Dict, Mapping, Tuple, TypedDict
+from typing import Dict, Tuple, TypedDict
 
 import tyro
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -673,7 +673,7 @@ def test_omit_subcommand_prefix_and_consolidate_subcommand_args_in_function() ->
 def test_append_lists() -> None:
     @dataclasses.dataclass
     class A:
-        x: tyro.conf.UseAppendActions[List[int]]
+        x: tyro.conf.UseAppendAction[List[int]]
 
     assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
     assert tyro.cli(A, args=[]) == A(x=[])
@@ -686,7 +686,7 @@ def test_append_lists() -> None:
 def test_append_tuple() -> None:
     @dataclasses.dataclass
     class A:
-        x: tyro.conf.UseAppendActions[Tuple[int, ...]]
+        x: tyro.conf.UseAppendAction[Tuple[int, ...]]
 
     assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=(1, 2, 3))
     assert tyro.cli(A, args=[]) == A(x=())
@@ -699,7 +699,7 @@ def test_append_tuple() -> None:
 def test_append_tuple_with_default() -> None:
     @dataclasses.dataclass
     class A:
-        x: tyro.conf.UseAppendActions[Tuple[int, ...]] = (1, 2)
+        x: tyro.conf.UseAppendAction[Tuple[int, ...]] = (1, 2)
 
     assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=(1, 2, 1, 2, 3))
     assert tyro.cli(A, args=[]) == A(x=(1, 2))
@@ -712,7 +712,7 @@ def test_append_tuple_with_default() -> None:
 def test_append_dict() -> None:
     @dataclasses.dataclass
     class A:
-        x: tyro.conf.UseAppendActions[Dict[str, int]]
+        x: tyro.conf.UseAppendAction[Dict[str, int]]
 
     assert tyro.cli(A, args="--x 1 1 --x 2 2 --x 3 3".split(" ")) == A(
         x={"1": 1, "2": 2, "3": 3}
@@ -729,7 +729,7 @@ def test_append_dict_with_default() -> None:
 
     @dataclasses.dataclass
     class A:
-        x: tyro.conf.UseAppendActions[Dict[str, int]] = dataclasses.field(
+        x: tyro.conf.UseAppendAction[Dict[str, int]] = dataclasses.field(
             default_factory=lambda: {"1": 1}
         )
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -709,7 +709,7 @@ def test_append_tuple_with_default() -> None:
         tyro.cli(A, args=["--x", "1", "2", "3"])
 
 
-def test_append_nested_tuple() -> None:
+def test_append_nested_tuple_fixed_length() -> None:
     @dataclasses.dataclass
     class A:
         x: tyro.conf.UseAppendAction[Tuple[Tuple[str, int], ...]]
@@ -724,7 +724,7 @@ def test_append_nested_tuple() -> None:
         tyro.cli(A, args=["--x", "1", "2", "3"])
 
 
-def test_append_nested_tuple_with_default() -> None:
+def test_append_nested_tuple_with_default_fixed_length() -> None:
     @dataclasses.dataclass
     class A:
         x: tyro.conf.UseAppendAction[Tuple[Tuple[str, int], ...]] = (("1", 1), ("2", 2))

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -769,3 +769,56 @@ def test_append_dict_with_default() -> None:
         assert tyro.cli(A, args="--x 2 2 --x 3 3".split(" ")) == A(
             x={"1": 1, "2": 2, "3": 3}
         )
+
+
+def test_append_nested_tuple() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[Tuple[Tuple[str, ...], ...]]
+
+    assert tyro.cli(A, args="--x 1 2 3 --x 4 5".split(" ")) == A(
+        x=(("1", "2", "3"), ("4", "5"))
+    )
+    assert tyro.cli(A, args=[]) == A(x=())
+
+
+def test_append_nested_tuple_with_default() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[Tuple[Tuple[str, ...], ...]] = (("1", "2"),)
+
+    assert tyro.cli(A, args="--x 1 2 3 --x 4 5".split(" ")) == A(
+        x=(("1", "2"), ("1", "2", "3"), ("4", "5"))
+    )
+    assert tyro.cli(A, args=[]) == A(x=(("1", "2"),))
+
+
+def test_append_nested_list() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[List[List[int]]]
+
+    assert tyro.cli(A, args="--x 1 2 3 --x 4 5".split(" ")) == A(x=[[1, 2, 3], [4, 5]])
+    assert tyro.cli(A, args=[]) == A(x=[])
+
+
+def test_append_nested_dict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[List[Dict[str, int]]]
+
+    assert tyro.cli(A, args="--x 1 2 3 4 --x 4 5".split(" ")) == A(
+        x=[{"1": 2, "3": 4}, {"4": 5}]
+    )
+    assert tyro.cli(A, args=[]) == A(x=[])
+
+
+def test_append_nested_dict_double() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[Dict[str, Dict[str, int]]]
+
+    assert tyro.cli(A, args="--x 0 1 2 3 4 --x 4 5 6".split(" ")) == A(
+        x={"0": {"1": 2, "3": 4}, "4": {"5": 6}}
+    )
+    assert tyro.cli(A, args=[]) == A(x={})

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -709,6 +709,36 @@ def test_append_tuple_with_default() -> None:
         tyro.cli(A, args=["--x", "1", "2", "3"])
 
 
+def test_append_nested_tuple() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[Tuple[Tuple[str, int], ...]]
+
+    assert tyro.cli(A, args="--x 1 1 --x 2 2 --x 3 3".split(" ")) == A(
+        x=(("1", 1), ("2", 2), ("3", 3))
+    )
+    assert tyro.cli(A, args=[]) == A(x=())
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
+
+
+def test_append_nested_tuple_with_default() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[Tuple[Tuple[str, int], ...]] = (("1", 1), ("2", 2))
+
+    assert tyro.cli(A, args="--x 1 1 --x 2 2 --x 3 3".split(" ")) == A(
+        x=(("1", 1), ("2", 2), ("1", 1), ("2", 2), ("3", 3))
+    )
+    assert tyro.cli(A, args=[]) == A(x=(("1", 1), ("2", 2)))
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
+
+
 def test_append_dict() -> None:
     @dataclasses.dataclass
     class A:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -16,6 +16,15 @@ def test_ambiguous_collection_0() -> None:
 
 
 def test_ambiguous_collection_1() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: List[List[int]]
+
+    with pytest.raises(tyro.UnsupportedTypeAnnotationError):
+        tyro.cli(A, args=["--x", "0", "1"])
+
+
+def test_ambiguous_collection_2() -> None:
     def main(x: Tuple[List[str], List[str]]) -> None:
         pass
 
@@ -23,7 +32,7 @@ def test_ambiguous_collection_1() -> None:
         tyro.cli(main, args=["--help"])
 
 
-def test_ambiguous_collection_2() -> None:
+def test_ambiguous_collection_3() -> None:
     def main(x: List[Union[Tuple[int, int], Tuple[int, int, int]]]) -> None:
         pass
 

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -829,7 +829,7 @@ def test_subparser_in_nested() -> None:
 
 def test_frozen_dict() -> None:
     def main(
-        x: Mapping[str, float] = frozendict(
+        x: Mapping[str, float] = frozendict(  # type: ignore
             {
                 "num_epochs": 20,
                 "batch_size": 64,
@@ -839,7 +839,7 @@ def test_frozen_dict() -> None:
         return x
 
     assert hash(tyro.cli(main, args="--x.num-epochs 10".split(" "))) == hash(
-        frozendict({"num_epochs": 10, "batch_size": 64})
+        frozendict({"num_epochs": 10, "batch_size": 64})  # type: ignore
     )
 
 

--- a/tyro/_docstrings.py
+++ b/tyro/_docstrings.py
@@ -308,7 +308,7 @@ def get_callable_description(f: Callable) -> str:
     docstring = _strings.dedent(docstring)
 
     if dataclasses.is_dataclass(f):
-        default_doc = f.__name__ + str(inspect.signature(f)).replace(" -> None", "")
+        default_doc = f.__name__ + str(inspect.signature(f)).replace(" -> None", "")  # type: ignore
         if docstring == default_doc:
             return ""
 

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -402,8 +402,8 @@ def _field_list_from_dataclass(
         #
         # We generally want to avoid importing flax, since it requires a lot of heavy
         # imports.
-        if "flax" in sys.modules.keys():
-            import flax
+        if "flax.linen" in sys.modules.keys():
+            import flax.linen
 
             if issubclass(cls, flax.linen.Module):
                 is_flax_module = True

--- a/tyro/_instantiators.py
+++ b/tyro/_instantiators.py
@@ -608,10 +608,19 @@ def _instantiator_from_sequence(
         return container_type(out)
 
     if _markers.UseAppendAction in markers:
-        return lambda x: sequence_instantiator(
-            x if x is not None else []
-        ), InstantiatorMetadata(
-            nargs=None,
+
+        def append_sequence_instantiator(strings: Optional[List[List[str]]]) -> Any:
+            if strings is None:
+                assert container_type is not None
+                return container_type()
+
+            flattened = []
+            for s in strings:
+                flattened.extend(s)
+            return sequence_instantiator(flattened)
+
+        return append_sequence_instantiator, InstantiatorMetadata(
+            nargs=inner_meta.nargs,
             metavar=inner_meta.metavar,
             choices=inner_meta.choices,
             action="append",

--- a/tyro/_instantiators.py
+++ b/tyro/_instantiators.py
@@ -547,6 +547,8 @@ def _instantiator_from_dict(
 
             index = 0
             for _ in range(len(strings) // pair_nargs):
+                assert isinstance(key_nargs, int)
+                assert isinstance(val_nargs, int)
                 k = strings[index : index + key_nargs]
                 index += key_nargs
                 v = strings[index : index + val_nargs]

--- a/tyro/_instantiators.py
+++ b/tyro/_instantiators.py
@@ -41,6 +41,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    FrozenSet,
     Hashable,
     Iterable,
     List,
@@ -63,14 +64,16 @@ from typing_extensions import (
 
 from . import _strings
 from ._typing import TypeForm
+from .conf import _markers
 
 _StandardInstantiator = Callable[[List[str]], Any]
+_AppendNargsInstantiator = Callable[[List[List[str]]], Any]
 # Special case: the only time that argparse doesn't give us a string is when the
 # argument action is set to `store_true` or `store_false`. In this case, we get
 # a bool directly, and the field action can be a no-op.
 _FlagInstantiator = Callable[[bool], bool]
 
-Instantiator = Union[_StandardInstantiator, _FlagInstantiator]
+Instantiator = Union[_StandardInstantiator, _AppendNargsInstantiator, _FlagInstantiator]
 
 NoneType = type(None)
 
@@ -79,11 +82,12 @@ NoneType = type(None)
 class InstantiatorMetadata:
     # Unlike in vanilla argparse, we never set nargs to None. To make things simpler, we
     # instead use nargs=1.
-    nargs: Union[int, Literal["+"]]
+    nargs: Optional[Union[int, Literal["+"]]]
     # Unlike in vanilla argparse, our metavar is always a string. We handle
     # sequences, multiple arguments, etc, manually.
     metavar: str
     choices: Optional[Tuple[str, ...]]
+    action: Optional[Literal["append"]]
 
     def check_choices(self, strings: List[str]) -> None:
         if self.choices is not None and any(s not in self.choices for s in strings):
@@ -136,7 +140,9 @@ def is_type_string_converter(typ: Union[Callable, TypeForm[Any]]) -> bool:
 
 
 def instantiator_from_type(
-    typ: TypeForm, type_from_typevar: Dict[TypeVar, TypeForm[Any]]
+    typ: TypeForm,
+    type_from_typevar: Dict[TypeVar, TypeForm[Any]],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     """Recursive helper for parsing type annotations.
 
@@ -163,6 +169,7 @@ def instantiator_from_type(
             nargs=1,
             metavar="{None}",
             choices=("None",),
+            action=None,
         )
 
     # Instantiate os.PathLike annotations using pathlib.Path.
@@ -173,7 +180,7 @@ def instantiator_from_type(
 
     # Address container types. If a matching container is found, this will recursively
     # call instantiator_from_type().
-    container_out = _instantiator_from_container_type(typ, type_from_typevar)
+    container_out = _instantiator_from_container_type(typ, type_from_typevar, markers)
     if container_out is not None:
         return container_out
 
@@ -233,6 +240,7 @@ def instantiator_from_type(
             else "{" + ",".join(map(str, auto_choices)) + "}"
         ),
         choices=auto_choices,
+        action=None,
     )
 
 
@@ -241,6 +249,7 @@ def _instantiator_from_type_inner(
     typ: TypeForm,
     type_from_typevar: Dict[TypeVar, TypeForm[Any]],
     allow_sequences: Literal["fixed_length"],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     ...
 
@@ -250,6 +259,7 @@ def _instantiator_from_type_inner(
     typ: TypeForm,
     type_from_typevar: Dict[TypeVar, TypeForm[Any]],
     allow_sequences: Literal[False],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[_StandardInstantiator, InstantiatorMetadata]:
     ...
 
@@ -259,6 +269,7 @@ def _instantiator_from_type_inner(
     typ: TypeForm,
     type_from_typevar: Dict[TypeVar, TypeForm[Any]],
     allow_sequences: Literal[True],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     ...
 
@@ -267,10 +278,13 @@ def _instantiator_from_type_inner(
     typ: TypeForm,
     type_from_typevar: Dict[TypeVar, TypeForm[Any]],
     allow_sequences: Literal["fixed_length", True, False],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     """Thin wrapper over instantiator_from_type, with some extra asserts for catching
     errors."""
-    out = instantiator_from_type(typ, type_from_typevar)
+    out = instantiator_from_type(typ, type_from_typevar, markers)
+
+    # TODO(5/3/2023): revisit this next condition. It looks wrong.
     if out[1].nargs is not None:
         # We currently only use allow_sequences=False for options in Literal types,
         # which are evaluated using `type()`. It should not be possible to hit this
@@ -284,7 +298,9 @@ def _instantiator_from_type_inner(
 
 
 def _instantiator_from_container_type(
-    typ: TypeForm, type_from_typevar: Dict[TypeVar, TypeForm[Any]]
+    typ: TypeForm,
+    type_from_typevar: Dict[TypeVar, TypeForm[Any]],
+    markers: FrozenSet[_markers.Marker],
 ) -> Optional[Tuple[Instantiator, InstantiatorMetadata]]:
     """Attempt to create an instantiator from a container type. Returns `None` is no
     container type is found."""
@@ -296,7 +312,7 @@ def _instantiator_from_container_type(
     # Unwrap Annotated and Final types.
     if type_origin in (Annotated, Final):
         contained_type = get_args(typ)[0]
-        return instantiator_from_type(contained_type, type_from_typevar)
+        return instantiator_from_type(contained_type, type_from_typevar, markers)
 
     for make, matched_origins in {
         _instantiator_from_sequence: (
@@ -312,7 +328,7 @@ def _instantiator_from_container_type(
         _instantiator_from_literal: (Literal,),
     }.items():
         if type_origin in matched_origins:
-            return make(typ, type_from_typevar)
+            return make(typ, type_from_typevar, markers)
 
     raise UnsupportedTypeAnnotationError(  # pragma: no cover
         f"Unsupported type {typ} with origin {type_origin}"
@@ -320,7 +336,9 @@ def _instantiator_from_container_type(
 
 
 def _instantiator_from_tuple(
-    typ: TypeForm, type_from_typevar: Dict[TypeVar, TypeForm[Any]]
+    typ: TypeForm,
+    type_from_typevar: Dict[TypeVar, TypeForm[Any]],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     types = get_args(typ)
     typeset = set(types)  # Note that sets are unordered.
@@ -330,7 +348,7 @@ def _instantiator_from_tuple(
         # Ellipsis: variable argument counts. When an ellipsis is used, tuples must
         # contain only one type.
         assert len(typeset_no_ellipsis) == 1
-        return _instantiator_from_sequence(typ, type_from_typevar)
+        return _instantiator_from_sequence(typ, type_from_typevar, markers)
 
     else:
         instantiators: List[_StandardInstantiator] = []
@@ -338,9 +356,7 @@ def _instantiator_from_tuple(
         nargs = 0
         for t in types:
             a, b = _instantiator_from_type_inner(
-                t,
-                type_from_typevar,
-                allow_sequences="fixed_length",
+                t, type_from_typevar, allow_sequences="fixed_length", markers=markers
             )
             instantiators.append(a)  # type: ignore
             metas.append(b)
@@ -364,6 +380,7 @@ def _instantiator_from_tuple(
             nargs=nargs,
             metavar=" ".join(m.metavar for m in metas),
             choices=None,
+            action=None,
         )
 
 
@@ -404,7 +421,9 @@ def _join_union_metavars(metavars: Iterable[str]) -> str:
 
 
 def _instantiator_from_union(
-    typ: TypeForm, type_from_typevar: Dict[TypeVar, TypeForm[Any]]
+    typ: TypeForm,
+    type_from_typevar: Dict[TypeVar, TypeForm[Any]],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     options = list(get_args(typ))
     if NoneType in options:
@@ -418,13 +437,11 @@ def _instantiator_from_union(
     # right.
     instantiators = []
     metas = []
-    nargs: Union[int, Literal["+"]] = 1
+    nargs: Optional[Union[int, Literal["+"]]] = 1
     first = True
     for t in options:
         a, b = _instantiator_from_type_inner(
-            t,
-            type_from_typevar,
-            allow_sequences=True,
+            t, type_from_typevar, allow_sequences=True, markers=markers
         )
         instantiators.append(a)
         metas.append(b)
@@ -476,22 +493,21 @@ def _instantiator_from_union(
         nargs=nargs,
         metavar=metavar,
         choices=None,
+        action=None,
     )
 
 
 def _instantiator_from_dict(
-    typ: TypeForm, type_from_typevar: Dict[TypeVar, TypeForm[Any]]
+    typ: TypeForm,
+    type_from_typevar: Dict[TypeVar, TypeForm[Any]],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     key_type, val_type = get_args(typ)
     key_instantiator, key_meta = _instantiator_from_type_inner(
-        key_type,
-        type_from_typevar,
-        allow_sequences="fixed_length",
+        key_type, type_from_typevar, allow_sequences="fixed_length", markers=markers
     )
     val_instantiator, val_meta = _instantiator_from_type_inner(
-        val_type,
-        type_from_typevar,
-        allow_sequences="fixed_length",
+        val_type, type_from_typevar, allow_sequences="fixed_length", markers=markers
     )
 
     key_nargs = cast(int, key_meta.nargs)  # Casts needed for mypy but not pyright!
@@ -528,15 +544,33 @@ def _instantiator_from_dict(
         return out
 
     pair_metavar = f"{key_meta.metavar} {val_meta.metavar}"
-    return dict_instantiator, InstantiatorMetadata(
-        nargs="+",
-        metavar=_strings.multi_metavar_from_single(pair_metavar),
-        choices=None,
-    )
+    if _markers.UseAppendActions in markers:
+
+        def append_dict_instantiator(strings: List[List[str]]) -> Any:
+            flattened = []
+            for s in strings:
+                flattened.extend(s)
+            return dict_instantiator(flattened)
+
+        return append_dict_instantiator, InstantiatorMetadata(
+            nargs=2,
+            metavar=pair_metavar,
+            choices=None,
+            action="append",
+        )
+    else:
+        return dict_instantiator, InstantiatorMetadata(
+            nargs="+",
+            metavar=_strings.multi_metavar_from_single(pair_metavar),
+            choices=None,
+            action=None,
+        )
 
 
 def _instantiator_from_sequence(
-    typ: TypeForm, type_from_typevar: Dict[TypeVar, TypeForm[Any]]
+    typ: TypeForm,
+    type_from_typevar: Dict[TypeVar, TypeForm[Any]],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     """Instantiator for variable-length sequences: list, sets, Tuple[T, ...], etc."""
     container_type = get_origin(typ)
@@ -553,6 +587,7 @@ def _instantiator_from_sequence(
         contained_type,
         type_from_typevar,
         allow_sequences="fixed_length",
+        markers=markers,
     )
 
     def sequence_instantiator(strings: List[str]) -> Any:
@@ -572,15 +607,28 @@ def _instantiator_from_sequence(
         assert container_type is not None
         return container_type(out)
 
-    return sequence_instantiator, InstantiatorMetadata(
-        nargs="+",
-        metavar=_strings.multi_metavar_from_single(inner_meta.metavar),
-        choices=inner_meta.choices,
-    )
+    if _markers.UseAppendActions in markers:
+        return lambda x: sequence_instantiator(
+            x if x is not None else []
+        ), InstantiatorMetadata(
+            nargs=None,
+            metavar=inner_meta.metavar,
+            choices=inner_meta.choices,
+            action="append",
+        )
+    else:
+        return sequence_instantiator, InstantiatorMetadata(
+            nargs="+",
+            metavar=_strings.multi_metavar_from_single(inner_meta.metavar),
+            choices=inner_meta.choices,
+            action=None,
+        )
 
 
 def _instantiator_from_literal(
-    typ: TypeForm, type_from_typevar: Dict[TypeVar, TypeForm[Any]]
+    typ: TypeForm,
+    type_from_typevar: Dict[TypeVar, TypeForm[Any]],
+    markers: FrozenSet[_markers.Marker],
 ) -> Tuple[Instantiator, InstantiatorMetadata]:
     choices = get_args(typ)
     str_choices = tuple(x.name if isinstance(x, enum.Enum) else str(x) for x in choices)
@@ -592,5 +640,6 @@ def _instantiator_from_literal(
             nargs=1,
             metavar="{" + ",".join(str_choices) + "}",
             choices=str_choices,
+            action=None,
         ),
     )

--- a/tyro/_instantiators.py
+++ b/tyro/_instantiators.py
@@ -544,7 +544,7 @@ def _instantiator_from_dict(
         return out
 
     pair_metavar = f"{key_meta.metavar} {val_meta.metavar}"
-    if _markers.UseAppendActions in markers:
+    if _markers.UseAppendAction in markers:
 
         def append_dict_instantiator(strings: List[List[str]]) -> Any:
             flattened = []
@@ -607,7 +607,7 @@ def _instantiator_from_sequence(
         assert container_type is not None
         return container_type(out)
 
-    if _markers.UseAppendActions in markers:
+    if _markers.UseAppendAction in markers:
         return lambda x: sequence_instantiator(
             x if x is not None else []
         ), InstantiatorMetadata(

--- a/tyro/conf/__init__.py
+++ b/tyro/conf/__init__.py
@@ -18,7 +18,7 @@ from ._markers import (
     Positional,
     Suppress,
     SuppressFixed,
-    UseAppendActions,
+    UseAppendAction,
     configure,
 )
 
@@ -33,6 +33,6 @@ __all__ = [
     "Positional",
     "Suppress",
     "SuppressFixed",
-    "UseAppendActions",
+    "UseAppendAction",
     "configure",
 ]

--- a/tyro/conf/__init__.py
+++ b/tyro/conf/__init__.py
@@ -18,6 +18,7 @@ from ._markers import (
     Positional,
     Suppress,
     SuppressFixed,
+    UseAppendActions,
     configure,
 )
 
@@ -32,5 +33,6 @@ __all__ = [
     "Positional",
     "Suppress",
     "SuppressFixed",
+    "UseAppendActions",
     "configure",
 ]

--- a/tyro/conf/_markers.py
+++ b/tyro/conf/_markers.py
@@ -88,6 +88,13 @@ By default, `--cmd.arg` may be generated as a flag for each dataclass in the uni
 If subcommand prefixes are omitted, we would instead simply have `--arg`.
 """
 
+UseAppendActions = Annotated[T, None]
+"""Use "append" actions for variable-length arguments.
+
+Given an annotation like `x: List[int]`, this means that `x = [0, 1, 2]` can be set via
+the CLI syntax `--x 0 --x 1 --x 2` instead of the default of `--x 0 1 2`.
+"""
+
 CallableType = TypeVar("CallableType", bound=Callable)
 
 # Dynamically generate marker singletons.

--- a/tyro/conf/_markers.py
+++ b/tyro/conf/_markers.py
@@ -94,6 +94,9 @@ UseAppendAction = Annotated[T, None]
 Given an annotation like `x: List[int]`, this means that `x = [0, 1, 2]` can be set via
 the CLI syntax `--x 0 --x 1 --x 2` instead of the default of `--x 0 1 2`.
 
+The resulting syntax may be more user-friendly; for `tyro`, it also enables support for
+otherwise ambiguous annotations like `List[List[int]]`.
+
 Can be applied to all variable-length sequences (`List[T]`, `Sequence[T]`,
 `Tuple[T, ...]`, etc), including dictionaries without default values.
 """

--- a/tyro/conf/_markers.py
+++ b/tyro/conf/_markers.py
@@ -88,11 +88,14 @@ By default, `--cmd.arg` may be generated as a flag for each dataclass in the uni
 If subcommand prefixes are omitted, we would instead simply have `--arg`.
 """
 
-UseAppendActions = Annotated[T, None]
+UseAppendAction = Annotated[T, None]
 """Use "append" actions for variable-length arguments.
 
 Given an annotation like `x: List[int]`, this means that `x = [0, 1, 2]` can be set via
 the CLI syntax `--x 0 --x 1 --x 2` instead of the default of `--x 0 1 2`.
+
+Can be applied to all variable-length sequences (`List[T]`, `Sequence[T]`,
+`Tuple[T, ...]`, etc), including dictionaries without default values.
 """
 
 CallableType = TypeVar("CallableType", bound=Callable)


### PR DESCRIPTION
Addresses #46 by introducing `tyro.conf.UseAppendAction`, which sets `action="append"` for variable-length sequence types. If we want to populate `x = [1, 2, 3]`, `x: List[str]` expects `--x 1 2 3`; `x: UseAppendAction[List[str]]` will expect `--x 1 --x 2 --x 3`.

Basic usage:

```python
from typing import Tuple

import tyro
from tyro.conf import UseAppendAction


def main(filter: UseAppendAction[Tuple[str, ...]]) -> None:
    """Main script.

    Args:
        filter: Filter to apply.
    """
    print(filter)


if __name__ == "__main__":
    tyro.cli(main)
```

And resulting help message:
![image](https://user-images.githubusercontent.com/6992947/236141718-f00f9ecf-31d6-4c41-b43d-ccbdbd6b3295.png)

