### PR TITLE
More predictable boolean flag behavior

### DIFF
--- a/tests/test_boolean_optional.py
+++ b/tests/test_boolean_optional.py
@@ -1,0 +1,67 @@
+import dataclasses
+
+import tyro
+
+
+def test_flag_default_false() -> None:
+    """Test for argparse.BooleanOptionalAction-style usage."""
+
+    @dataclasses.dataclass
+    class A:
+        x: bool
+
+    assert tyro.cli(
+        A,
+        args=["--x"],
+        default=A(False),
+    ) == A(True)
+
+    assert tyro.cli(
+        A,
+        args=["--no-x"],
+        default=A(False),
+    ) == A(False)
+
+    assert tyro.cli(
+        A,
+        args=[],
+        default=A(False),
+    ) == A(False)
+
+    assert tyro.cli(
+        tyro.conf.FlagConversionOff[A],
+        args=["--x", "True"],
+        default=A(False),
+    ) == A(True)
+
+
+def test_flag_default_true() -> None:
+    """Test for argparse.BooleanOptionalAction-style usage."""
+
+    @dataclasses.dataclass
+    class A:
+        x: bool
+
+    assert tyro.cli(
+        A,
+        args=["--x"],
+        default=A(True),
+    ) == A(True)
+
+    assert tyro.cli(
+        A,
+        args=["--no-x"],
+        default=A(True),
+    ) == A(False)
+
+    assert tyro.cli(
+        A,
+        args=[],
+        default=A(True),
+    ) == A(True)
+
+    assert tyro.cli(
+        tyro.conf.FlagConversionOff[A],
+        args=["--x", "True"],
+        default=A(False),
+    ) == A(True)

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -574,3 +574,15 @@ def test_pathlike() -> None:
 
     helptext = get_helptext(main)
     assert "--x PATH " in helptext
+
+
+def test_nested_bool() -> None:
+    @dataclasses.dataclass
+    class Child:
+        x: bool = False
+
+    def main(child: Child) -> None:
+        pass
+
+    helptext = get_helptext(main)
+    assert "--child.x | --child.no-x" in helptext

--- a/tyro/_argparse_formatter.py
+++ b/tyro/_argparse_formatter.py
@@ -7,11 +7,14 @@ messages with ones that:
 
 This is largely built by fussing around in argparse implementation details, and is by
 far the hackiest part of `tyro`.
+
+TODO: we may want to just maintain our own fork of argparse.
 """
 import argparse
 import contextlib
 import dataclasses
 import itertools
+import re as _re
 import shutil
 from typing import Any, ContextManager, Generator, List, Optional
 
@@ -458,3 +461,122 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                 border_style=THEME.border,
                 # padding=(1, 1, 0, 1),
             )
+
+    def _format_actions_usage(self, actions, groups):
+        """Backporting from Python 3.10, primarily to call format_usage() on actions."""
+
+        # find group indices and identify actions in groups
+        group_actions = set()
+        inserts = {}
+        for group in groups:
+            if not group._group_actions:
+                raise ValueError(f"empty group {group}")
+
+            try:
+                start = actions.index(group._group_actions[0])  # type: ignore
+            except ValueError:
+                continue
+            else:
+                group_action_count = len(group._group_actions)
+                end = start + group_action_count
+                if actions[start:end] == group._group_actions:  # type: ignore
+                    suppressed_actions_count = 0
+                    for action in group._group_actions:
+                        group_actions.add(action)
+                        if action.help is argparse.SUPPRESS:
+                            suppressed_actions_count += 1
+
+                    exposed_actions_count = (
+                        group_action_count - suppressed_actions_count
+                    )
+
+                    if not group.required:
+                        if start in inserts:
+                            inserts[start] += " ["
+                        else:
+                            inserts[start] = "["
+                        if end in inserts:
+                            inserts[end] += "]"
+                        else:
+                            inserts[end] = "]"
+                    elif exposed_actions_count > 1:
+                        if start in inserts:
+                            inserts[start] += " ("
+                        else:
+                            inserts[start] = "("
+                        if end in inserts:
+                            inserts[end] += ")"
+                        else:
+                            inserts[end] = ")"
+                    for i in range(start + 1, end):
+                        inserts[i] = "|"
+
+        # collect all actions format strings
+        parts = []
+        for i, action in enumerate(actions):
+            # suppressed arguments are marked with None
+            # remove | separators for suppressed arguments
+            if action.help is argparse.SUPPRESS:
+                parts.append(None)
+                if inserts.get(i) == "|":
+                    inserts.pop(i)
+                elif inserts.get(i + 1) == "|":
+                    inserts.pop(i + 1)
+
+            # produce all arg strings
+            elif not action.option_strings:
+                default = self._get_default_metavar_for_positional(action)
+                part = self._format_args(action, default)
+
+                # if it's in a group, strip the outer []
+                if action in group_actions:
+                    if part[0] == "[" and part[-1] == "]":
+                        part = part[1:-1]
+
+                # add the action string to the list
+                parts.append(part)
+
+            # produce the first way to invoke the option in brackets
+            else:
+                option_string = action.option_strings[0]
+
+                # if the Optional doesn't take a value, format is:
+                #    -s or --long
+                if action.nargs == 0:
+                    part = (
+                        action.format_usage()
+                        if hasattr(action, "format_usage")
+                        else "%s" % option_string
+                    )
+
+                # if the Optional takes a value, format is:
+                #    -s ARGS or --long ARGS
+                else:
+                    default = self._get_default_metavar_for_optional(action)
+                    args_string = self._format_args(action, default)
+                    part = "%s %s" % (option_string, args_string)
+
+                # make it look optional if it's not required or in a group
+                if not action.required and action not in group_actions:
+                    part = "[%s]" % part
+
+                # add the action string to the list
+                parts.append(part)
+
+        # insert things at the necessary indices
+        for i in sorted(inserts, reverse=True):
+            parts[i:i] = [inserts[i]]
+
+        # join all the action items with spaces
+        text = " ".join([item for item in parts if item is not None])
+
+        # clean up separators for mutually exclusive groups
+        open = r"[\[(]"
+        close = r"[\])]"
+        text = _re.sub(r"(%s) " % open, r"\1", text)
+        text = _re.sub(r" (%s)" % close, r"\1", text)
+        text = _re.sub(r"%s *%s" % (open, close), r"", text)
+        text = text.strip()
+
+        # return the text
+        return text

--- a/tyro/_argparse_formatter.py
+++ b/tyro/_argparse_formatter.py
@@ -462,7 +462,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                 # padding=(1, 1, 0, 1),
             )
 
-    def _format_actions_usage(self, actions, groups):
+    def _format_actions_usage(self, actions, groups):  #  pragma: no cover
         """Backporting from Python 3.10, primarily to call format_usage() on actions."""
 
         # find group indices and identify actions in groups

--- a/tyro/_arguments.py
+++ b/tyro/_arguments.py
@@ -8,7 +8,19 @@ import enum
 import functools
 import itertools
 import shlex
-from typing import Any, Dict, Mapping, Optional, Sequence, Set, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import rich.markup
 import shtab
@@ -23,6 +35,62 @@ try:
 except ImportError:
     # Python 3.7.
     from backports.cached_property import cached_property  # type: ignore
+
+
+_T = TypeVar("_T")
+
+
+# TODO: refactor!
+class BooleanOptionalAction(argparse.Action):
+    """Adapted from https://github.com/python/cpython/pull/27672"""
+
+    def __init__(
+        self,
+        option_strings: Sequence[str],
+        dest: str,
+        default: _T | str | None = None,
+        type: Callable[[str], _T] | argparse.FileType | None = None,
+        choices: Iterable[_T] | None = None,
+        required: bool = False,
+        help: str | None = None,
+        metavar: str | tuple[str, ...] | None = None,
+    ) -> None:
+        _option_strings = []
+        self._no_strings = set()
+        for option_string in option_strings:
+            _option_strings.append(option_string)
+
+            if option_string.startswith("--"):
+                if "." not in option_string:
+                    option_string = "--no-" + option_string[2:]
+                else:
+                    # Loose heuristic for where to add the no- prefix.
+                    left, _, right = option_string.rpartition(".")
+                    option_string = left + ".no-" + right
+                self._no_strings.add(option_string)
+
+                _option_strings.append(option_string)
+
+        super().__init__(
+            option_strings=_option_strings,
+            dest=dest,
+            nargs=0,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in self.option_strings:
+            assert option_string is not None
+            print(self._no_strings)
+            setattr(namespace, self.dest, option_string not in self._no_strings)
+
+    def format_usage(self):
+        return " | ".join(self.option_strings)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -52,8 +120,11 @@ class ArgumentDefinition:
         # MISSING value will be detected in _calling.py and the field default will
         # directly be used. This helps reduce the likelihood of issues with converting
         # the field default to a string format, then back to the desired type.
-        if kwargs.get("action", None) != "append":
+        action = kwargs.get("action", None)
+        if action != "append":
             kwargs["default"] = _fields.MISSING_NONPROP
+        elif action == BooleanOptionalAction:
+            pass
         else:
             kwargs["default"] = []
 
@@ -136,7 +207,7 @@ class LoweredArgumentDefinition:
     default: Optional[Any] = None
     dest: Optional[str] = None
     required: bool = False
-    action: Optional[str] = None
+    action: Optional[Any] = None
     nargs: Optional[Union[int, str]] = None
     choices: Optional[Set[Any]] = None
     # Note: unlike in vanilla argparse, our metavar is always a string. We handle
@@ -173,18 +244,11 @@ def _rule_handle_boolean_flags(
     ):
         # Treat bools as a normal parameter.
         return lowered
-    elif arg.field.default is False:
+    elif arg.field.default in (True, False):
         # Default `False` => --flag passed in flips to `True`.
         return dataclasses.replace(
             lowered,
-            action="store_true",
-            instantiator=lambda x: x,  # argparse will directly give us a bool!
-        )
-    elif arg.field.default is True:
-        # Default `True` => --no-flag passed in flips to `False`.
-        return dataclasses.replace(
-            lowered,
-            action="store_false",
+            action=BooleanOptionalAction,
             instantiator=lambda x: x,  # argparse will directly give us a bool!
         )
 
@@ -352,10 +416,6 @@ def _rule_generate_helptext(
             # Intentionally not quoted via shlex, since this can't actually be passed
             # in via the commandline.
             default_text = f"(fixed to: {str(arg.field.default)})"
-        elif lowered.action == "store_true":
-            default_text = f"(sets: {arg.field.name}=True)"
-        elif lowered.action == "store_false":
-            default_text = f"(sets: {arg.field.name}=False)"
         elif lowered.action == "append" and (
             arg.field.default in _fields.MISSING_SINGLETONS
             or len(arg.field.default) == 0
@@ -393,11 +453,6 @@ def _rule_set_name_or_flag_and_dest(
     # Positional arguments: no -- prefix.
     if arg.field.is_positional():
         name_or_flag = _strings.make_field_name([arg.name_prefix, arg.field.name])
-    # Negated booleans.
-    elif lowered.action == "store_false":
-        name_or_flag = "--" + _strings.make_field_name(
-            [arg.name_prefix, "no-" + arg.field.name]
-        )
     # Prefix keyword arguments with --.
     else:
         name_or_flag = "--" + _strings.make_field_name(

--- a/tyro/_arguments.py
+++ b/tyro/_arguments.py
@@ -89,6 +89,8 @@ class BooleanOptionalAction(argparse.Action):
             print(self._no_strings)
             setattr(namespace, self.dest, option_string not in self._no_strings)
 
+    # Typically only supported in Python 3.10, but we backport some functionality in
+    # _argparse_formatters.py
     def format_usage(self):
         return " | ".join(self.option_strings)
 


### PR DESCRIPTION
New default behavior for booleans with defaults, as suggested in #48.

We backport `argparse.BooleanOptionalAction`, resulting in both `--flag` and `--no-flag` being created by default:

![image](https://user-images.githubusercontent.com/6992947/236344583-08927c95-2fd8-4ce4-a563-9aceaa06e2f7.png)
