### PR TITLE
Support setting Tuple, Dict, and Union to empty in the command line.

### DIFF
--- a/docs/source/examples/03_config_systems/01_base_configs.rst
+++ b/docs/source/examples/03_config_systems/01_base_configs.rst
@@ -16,10 +16,9 @@ use the CLI to either override (existing) or fill in (missing) values.
 
 
         from dataclasses import dataclass
-        from typing import Callable, Literal, Tuple, Union
+        from typing import Callable, Literal, Tuple
 
         from torch import nn
-        from typing_extensions import Annotated
 
         import tyro
 

--- a/examples/03_config_systems/01_base_configs.py
+++ b/examples/03_config_systems/01_base_configs.py
@@ -14,10 +14,9 @@ Usage:
 """
 
 from dataclasses import dataclass
-from typing import Callable, Literal, Tuple, Union
+from typing import Callable, Literal, Tuple
 
 from torch import nn
-from typing_extensions import Annotated
 
 import tyro
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -64,10 +64,9 @@ def test_tuple_with_literal_and_default() -> None:
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=(1, 2, 3))
     assert tyro.cli(A, args=[]) == A(x=(1, 2))
+    assert tyro.cli(A, args=["--x"]) == A(x=())
     with pytest.raises(SystemExit):
         tyro.cli(A, args=["--x", "1", "2", "3", "4"])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
 
 
 def test_positional_tuple_with_literal_and_default() -> None:
@@ -116,8 +115,7 @@ def test_tuples_variable() -> None:
         x: Tuple[int, ...]
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=(1, 2, 3))
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=())
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -130,8 +128,7 @@ def test_tuples_variable_bool() -> None:
     assert tyro.cli(A, args=["--x", "True", "True", "False"]) == A(
         x=(True, True, False)
     )
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=())
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -142,8 +139,7 @@ def test_tuples_variable_optional() -> None:
         x: Optional[Tuple[int, ...]] = None
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=(1, 2, 3))
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=())
     assert tyro.cli(A, args=[]) == A(x=None)
 
 
@@ -153,8 +149,7 @@ def test_sequences() -> None:
         x: Sequence[int]
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=[1, 2, 3])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=[])
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -165,8 +160,7 @@ def test_lists() -> None:
         x: List[int]
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=[1, 2, 3])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=[])
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -177,10 +171,9 @@ def test_list_with_literal() -> None:
         x: List[Literal[1, 2, 3]]
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=[1, 2, 3])
+    assert tyro.cli(A, args=["--x"]) == A(x=[])
     with pytest.raises(SystemExit):
         tyro.cli(A, args=["--x", "1", "2", "3", "4"])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -198,10 +191,9 @@ def test_list_with_enums() -> None:
     assert tyro.cli(A, args=["--x", "RED", "RED", "BLUE"]) == A(
         x=[Color.RED, Color.RED, Color.BLUE]
     )
+    assert tyro.cli(A, args=["--x"]) == A(x=[])
     with pytest.raises(SystemExit):
         tyro.cli(A, args=["--x", "RED", "RED", "YELLOW"])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -232,8 +224,7 @@ def test_lists_bool() -> None:
     assert tyro.cli(A, args=["--x", "True", "False", "True"]) == A(
         x=[True, False, True]
     )
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=[])
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -244,8 +235,7 @@ def test_sets() -> None:
         x: Set[int]
 
     assert tyro.cli(A, args=["--x", "1", "2", "3", "3"]) == A(x={1, 2, 3})
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(set())
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -256,8 +246,7 @@ def test_frozen_sets() -> None:
         x: FrozenSet[int]
 
     assert tyro.cli(A, args=["--x", "1", "2", "3", "3"]) == A(x=frozenset({1, 2, 3}))
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=frozenset())
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -270,8 +259,7 @@ def test_deque() -> None:
     assert tyro.cli(A, args=["--x", "1", "2", "3", "3"]) == A(
         x=collections.deque([1, 2, 3, 3])
     )
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(collections.deque())
     with pytest.raises(SystemExit):
         tyro.cli(A, args=[])
 
@@ -283,8 +271,7 @@ def test_sets_with_default() -> None:
 
     assert tyro.cli(A, args=[]) == A(x={0, 1, 2})
     assert tyro.cli(A, args=["--x", "1", "2", "3", "3"]) == A(x={1, 2, 3})
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=set())
 
 
 def test_optional_sequences() -> None:
@@ -293,8 +280,8 @@ def test_optional_sequences() -> None:
         x: Optional[Sequence[int]] = None
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=[1, 2, 3])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=[])
+    assert tyro.cli(A, args=["--x", "None"]) == A(x=None)
     assert tyro.cli(A, args=[]) == A(x=None)
 
 
@@ -304,8 +291,8 @@ def test_optional_lists() -> None:
         x: Optional[List[int]] = None
 
     assert tyro.cli(A, args=["--x", "1", "2", "3"]) == A(x=[1, 2, 3])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
+    assert tyro.cli(A, args=["--x"]) == A(x=[])
+    assert tyro.cli(A, args=["--x", "None"]) == A(x=None)
     assert tyro.cli(A, args=[]) == A(x=None)
 
 

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -677,11 +677,14 @@ def test_variadics() -> None:
         main, args="--args 1 2 3 --kwargs learning_rate 1e-4 beta1 0.99".split(" ")
     ) == ((1, 2, 3), {"learning_rate": 1e-4, "beta1": 0.99})
 
+
 def test_empty_container() -> None:
     @dataclasses.dataclass
     class A:
         x: Tuple[int, ...] = (1, 2, 3)
-        y: Union[int, str, List[bool]] = dataclasses.field(default_factory=lambda: [1, 2, 3])
+        y: Union[int, str, List[bool]] = dataclasses.field(
+            default_factory=lambda: [False, False, True]
+        )
 
     assert tyro.cli(A, args="--x".split(" ")).x == ()
     assert tyro.cli(A, args="--y".split(" ")).y == []

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -676,3 +676,12 @@ def test_variadics() -> None:
     assert tyro.cli(
         main, args="--args 1 2 3 --kwargs learning_rate 1e-4 beta1 0.99".split(" ")
     ) == ((1, 2, 3), {"learning_rate": 1e-4, "beta1": 0.99})
+
+def test_empty_container() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: Tuple[int, ...] = (1, 2, 3)
+        y: Union[int, str, List[bool]] = dataclasses.field(default_factory=lambda: [1, 2, 3])
+
+    assert tyro.cli(A, args="--x".split(" ")).x == ()
+    assert tyro.cli(A, args="--y".split(" ")).y == []

--- a/tests/test_dict_namedtuple.py
+++ b/tests/test_dict_namedtuple.py
@@ -24,12 +24,11 @@ def test_basic_dict() -> None:
         "hey": 5,
         "hello": 2,
     }
+    assert tyro.cli(main, args="--params".split(" ")) == {}
     with pytest.raises(SystemExit):
         tyro.cli(main, args="--params hey 5 hello hey".split(" "))
     with pytest.raises(SystemExit):
         tyro.cli(main, args="--params hey 5 hello".split(" "))
-    with pytest.raises(SystemExit):
-        tyro.cli(main, args="--params".split(" "))
 
 
 def test_dict_with_default() -> None:

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -359,7 +359,7 @@ def test_generic_list_helptext() -> None:
         x: List[T]
 
     helptext = get_helptext(GenericTupleHelptext[int])
-    assert "--x INT [INT ...]" in helptext
+    assert "--x [INT [INT ...]]" in helptext
 
 
 def test_literal_helptext() -> None:
@@ -445,7 +445,7 @@ def test_optional_helptext() -> None:
     assert cast(str, cast(str, OptionalHelptext.__doc__)[:20]) in helptext
     assert "2% milk" in helptext
     assert "--x {None}|INT" in helptext
-    assert "--y {None}|INT [{None}|INT ...]" in helptext
+    assert "--y [{None}|INT [{None}|INT ...]]" in helptext
     assert "[--z {None}|INT]" in helptext
 
 
@@ -469,7 +469,7 @@ def test_metavar_1() -> None:
 
     # The comma formatting is unfortunate, but matches argparse's default behavior.
     helptext = get_helptext(main)
-    assert "--x {0,1,2,3,hey,there,hello}|{INT [INT ...]}" in helptext
+    assert "--x {0,1,2,3,hey,there,hello}|{[INT [INT ...]]}" in helptext
 
 
 def test_metavar_2() -> None:
@@ -519,7 +519,7 @@ def test_metavar_5() -> None:
         pass
 
     helptext = get_helptext(main)
-    assert "[--x {INT INT}|{STR STR} [{INT INT}|{STR STR} ...]]" in helptext
+    assert "[--x [{INT INT}|{STR STR} [{INT INT}|{STR STR} ...]]]" in helptext
 
 
 def test_metavar_6() -> None:
@@ -528,7 +528,7 @@ def test_metavar_6() -> None:
 
     helptext = get_helptext(main)
     assert (
-        "--x {INT INT}|{STR STR} INT INT [{INT INT}|{STR STR} INT INT ...]" in helptext
+        "--x [{INT INT}|{STR STR} INT INT [{INT INT}|{STR STR} INT INT ...]]" in helptext
     )
 
 

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -528,7 +528,8 @@ def test_metavar_6() -> None:
 
     helptext = get_helptext(main)
     assert (
-        "--x [{INT INT}|{STR STR} INT INT [{INT INT}|{STR STR} INT INT ...]]" in helptext
+        "--x [{INT INT}|{STR STR} INT INT [{INT INT}|{STR STR} INT INT ...]]"
+        in helptext
     )
 
 

--- a/tests/test_positional_ignore_py37.py
+++ b/tests/test_positional_ignore_py37.py
@@ -96,8 +96,7 @@ def test_optional_list():
 
     assert tyro.cli(main, args=["None"]) is None
     assert tyro.cli(main, args=["1", "2"]) == [1, 2]
-    with pytest.raises(SystemExit):
-        tyro.cli(main, args=[])
+    assert tyro.cli(main, args=[]) == []
     with pytest.raises(SystemExit):
         tyro.cli(main, args=["hm"])
 

--- a/tyro/__init__.py
+++ b/tyro/__init__.py
@@ -1,8 +1,9 @@
+from typing import TYPE_CHECKING
+
 from . import conf, extras
 from ._cli import cli
 from ._fields import MISSING_PUBLIC as MISSING
 from ._instantiators import UnsupportedTypeAnnotationError
-from typing import TYPE_CHECKING
 
 __all__ = [
     "conf",

--- a/tyro/_calling.py
+++ b/tyro/_calling.py
@@ -72,6 +72,17 @@ def call_from_args(
 
                 if value in _fields.MISSING_SINGLETONS:
                     value = arg.field.default
+
+                    # Consider a function with a positional sequence argument:
+                    #
+                    #     def f(x: tuple[int, ...], /)
+                    #
+                    # If we run this script with no arguments, we should interpret this
+                    # as empty input for x. But the argparse default will be a MISSING
+                    # value, and the field default will be inspect.Parameter.empty.
+                    if value in _fields.MISSING_SINGLETONS:
+                        assert field.is_positional() and arg.lowered.nargs in ("?", "*")
+                        value = []
                 else:
                     if arg.lowered.nargs == "?":
                         # Special case for optional positional arguments: this is the

--- a/tyro/_instantiators.py
+++ b/tyro/_instantiators.py
@@ -89,7 +89,7 @@ NoneType = type(None)
 class InstantiatorMetadata:
     # Unlike in vanilla argparse, we never set nargs to None. To make things simpler, we
     # instead use nargs=1.
-    nargs: Optional[Union[int, Literal["+"]]]
+    nargs: Optional[Union[int, Literal["*"]]]
     # Unlike in vanilla argparse, our metavar is always a string. We handle
     # sequences, multiple arguments, etc, manually.
     metavar: str
@@ -290,7 +290,7 @@ def _instantiator_from_type_inner(
     """Thin wrapper over instantiator_from_type, with some extra asserts for catching
     errors."""
     out = instantiator_from_type(typ, type_from_typevar, markers)
-    if out[1].nargs == "+":
+    if out[1].nargs == "*":
         # We currently only use allow_sequences=False for options in Literal types,
         # which are evaluated using `type()`. It should not be possible to hit this
         # condition from polling a runtime type.
@@ -444,7 +444,7 @@ def _instantiator_from_union(
     # right.
     instantiators = []
     metas = []
-    nargs: Optional[Union[int, Literal["+"]]] = 1
+    nargs: Optional[Union[int, Literal["*"]]] = 1
     first = True
     for t in options:
         a, b = _instantiator_from_type_inner(
@@ -461,7 +461,7 @@ def _instantiator_from_union(
                 first = False
             elif nargs != b.nargs:
                 # Just be as general as possible if we see inconsistencies.
-                nargs = "+"
+                nargs = "*"
 
     metavar: str
     metavar = _join_union_metavars(map(lambda x: cast(str, x.metavar), metas))
@@ -480,7 +480,7 @@ def _instantiator_from_union(
                 continue
 
             # Try passing input into instantiator.
-            if len(strings) == metadata.nargs or (metadata.nargs == "+"):
+            if len(strings) == metadata.nargs or (metadata.nargs == "*"):
                 try:
                     return instantiator(strings)  # type: ignore
                 except ValueError as e:
@@ -533,7 +533,7 @@ def _instantiator_from_dict(
             return out
 
         return append_dict_instantiator, InstantiatorMetadata(
-            nargs=key_nargs + val_nargs if isinstance(val_nargs, int) else "+",
+            nargs=key_nargs + val_nargs if isinstance(val_nargs, int) else "*",
             metavar=pair_metavar,
             choices=None,
             action="append",
@@ -579,7 +579,7 @@ def _instantiator_from_dict(
             return out
 
         return dict_instantiator, InstantiatorMetadata(
-            nargs="+",
+            nargs="*",
             metavar=_strings.multi_metavar_from_single(pair_metavar),
             choices=None,
             action=None,
@@ -650,7 +650,7 @@ def _instantiator_from_sequence(
             return container_type(out)
 
         return sequence_instantiator, InstantiatorMetadata(
-            nargs="+",
+            nargs="*",
             metavar=_strings.multi_metavar_from_single(inner_meta.metavar),
             choices=inner_meta.choices,
             action=None,

--- a/tyro/_strings.py
+++ b/tyro/_strings.py
@@ -129,9 +129,9 @@ def strip_ansi_sequences(x: str):
 def multi_metavar_from_single(single: str) -> str:
     if len(strip_ansi_sequences(single)) >= 32:
         # Shorten long metavars
-        return f"{single} [...]"
+        return f"[{single} [...]]"
     else:
-        return f"{single} [{single} ...]"
+        return f"[{single} [{single} ...]]"
 
 
 def remove_single_line_breaks(helptext: str) -> str:


### PR DESCRIPTION
Hi Brent, thanks for your kind suggestions on issue #56!

This commit makes it possible to set Tuple, Dict, and Union to empty by passing in `-` in the command line as the only argument. The functionality is tested with an additional test in `test_dcargs.py`.

Note that I'm currently using `-` instead of `*` as the indicator of an empty container because `*` is usually expanded into the file names in the working directory, in which case the user has to pass in `"*"` to disable the expansion.

For the example below,
```python
# main.py
from dataclasses import dataclass

@dataclass()
class BaseConfig:
    x: tuple[str, ...] = ("a", "b", "c")

if __name__ == "__main__":
    print(tyro.cli(BaseConfig).x)
```
we can now set the item `x` to empty with the following command:
```shell
python main.py --x -
```
Output:
```shell
()
```