### PR TITLE
Fix tyro.conf for pydantic>2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# pyenv and direnv alternative
+.rtx.toml
 *.swp
 *.pyc
 *.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     # As of 7/27/2023, flax install fails for Python 3.7 without pinning to an
     # old version. But doing so breaks other Python versions.
     "flax>=0.6.9;python_version>='3.8'", 
-    "pydantic>=1.10.2",
+    "pydantic>=2.3.0",
     "coverage[toml]>=6.5.0"
 ]
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -7,6 +7,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 import tyro
+from tyro import conf
 
 
 def test_pydantic() -> None:
@@ -97,3 +98,12 @@ def test_pydantic_field_helptext_from_docstring() -> None:
     assert "Documentation 1" in helptext
     assert "Documentation 2" in helptext
     assert "Documentation 3" in helptext
+
+
+def test_pydantic_positional_annotation() -> None:
+    class AnnotatedAsPositional(BaseModel):
+        name: conf.Positional[str]
+        """This is annotated as a positional argument."""
+
+    result = tyro.cli(AnnotatedAsPositional, args=["myname"])
+    assert isinstance(result, AnnotatedAsPositional)

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -488,6 +488,11 @@ def _field_list_from_pydantic(
                 FieldDefinition.make(
                     name=name,
                     typ=pd_field.annotation,
+                    markers=tuple(
+                        meta
+                        for meta in pd_field.metadata
+                        if isinstance(meta, _markers._Marker)
+                    ),
                     default=(
                         MISSING_NONPROP
                         if pd_field.is_required()


### PR DESCRIPTION
Unless versions `1.x.x` of pydantic, pydantic `2.x.x` pulls runtime annotations into a separate `metadata` field.

Fixes #68 