### PR TITLE
Ensuring `tyro.cli` produces objects with consistent serialization

### DIFF
--- a/tyro/_cli.py
+++ b/tyro/_cli.py
@@ -299,7 +299,9 @@ def _cli_impl(
 
     # Read and fix arguments. If the user passes in --field_name instead of
     # --field-name, correct for them.
-    args = list(sys.argv[1:]) if args is None else list(args)
+    if args is None:
+        args = sys.argv[1:]
+    args = eval(str(list(args)))
 
     # Fix arguments. This will modify all option-style arguments replacing
     # underscores with dashes. This is to support the common convention of using


### PR DESCRIPTION
## Context

I need to ensure that objects pickle/serialize to consistent values (because I am using a [library that strongly depends on this](https://ai2-tango.readthedocs.io/en/latest/api/det_hash.html)).

## Finding

But I found that this was not the case for the following example.

`python test.py --a hello --b hello`

For `test.py`:

```python
import sys, dataclasses, pickle, tyro

@dataclasses.dataclass
class Args:
    a: str
    b: str

if __name__ == "__main__":
    args = Args(a="hello", b="hello")

    assert sys.argv[1:] == ["--a", "hello", "--b", "hello"]
    args_from_cli = tyro.cli(Args, args=sys.argv[1:])
    args_from_list = tyro.cli(Args, args=["--a", "hello", "--b", "hello"])

    print(pickle.dumps(args_from_cli) == pickle.dumps(args))  # False
    print(pickle.dumps(args_from_list) == pickle.dumps(args))  # True
```

I found that this issue originates from this more primitive setting.

```python
argv_list = ["test.py", "--a", "hello", "--b", "hello"]
assert sys.argv == argv_list

print(pickle.dumps(sys.argv) == pickle.dumps(argv_list))
# False
```

I believe this is because `argv_list` is compiled, but `sys.argv` is loaded dynamically at runtime. We can see that the repeated "hello" has the same address for `argv_list` but not `sys.argv` (due to this compiled optimization).

```python
print(id(sys.argv[2]) == id(sys.argv[4]))  # False
print(id(argv_list[2]) == id(argv_list[4]))  # True
```

## Solution

This is resolved if we forcefully evaluate the `sys.argv` expression dynamically at runtime! So we can use `eval(str(sys.argv))` instead, like:

```python
print(pickle.dumps(eval(str(sys.argv))) == pickle.dumps(argv_list))
#True

args_from_cli = tyro.cli(Args, args=eval(str(sys.argv[1:])))
print(pickle.dumps(args_from_cli) == pickle.dumps(args))  # True
```

In this PR, I just processed the args with `eval(str( ... ))` in the tyro CLI.

Please let me know if that was clear and what you think!

## Co-credits: @maxzuo!