### PR TITLE
Fix type narrowing edge case for unions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tyro"
 authors = [
     {name = "brentyi", email = "brentyi@berkeley.edu"},
 ]
-version = "0.5.17"
+version = "0.5.18"
 description = "Strongly typed, zero-effort CLI interfaces"
 readme = "README.md"
 license = { text="MIT" }

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1188,3 +1188,70 @@ def test_flag_alias() -> None:
     # BooleanOptionalAction will ignore arguments that aren't prefixed with --.
     with pytest.raises(SystemExit):
         tyro.cli(Struct, args="-no-f".split(" "))
+
+
+def test_subcommand_constructor_mix() -> None:
+    def checkout(branch: str) -> str:
+        """Check out a branch."""
+        return branch
+
+    def commit(message: str, all: bool = False) -> str:
+        """Make a commit."""
+        return f"{message=} {all=}"
+
+    @dataclasses.dataclass
+    class Arg:
+        foo: int = 1
+
+    assert (
+        tyro.cli(
+            Union[
+                Annotated[
+                    Any,
+                    tyro.conf.subcommand(name="checkout", constructor=checkout),
+                ],
+                Annotated[
+                    Any,
+                    tyro.conf.subcommand(name="commit", constructor=commit),
+                ],
+                Arg,
+            ],
+            args=["arg"],
+        )
+        == Arg()
+    )
+
+    assert (
+        tyro.cli(
+            Union[
+                Annotated[
+                    Any,
+                    tyro.conf.subcommand(name="checkout", constructor=checkout),
+                ],
+                Annotated[
+                    Any,
+                    tyro.conf.subcommand(name="commit", constructor=commit),
+                ],
+                Arg,
+            ],
+            args=["checkout", "--branch", "main"],
+        )
+        == "main"
+    )
+    assert (
+        tyro.cli(
+            Union[
+                Annotated[
+                    Any,
+                    tyro.conf.subcommand(name="checkout", constructor=checkout),
+                ],
+                Annotated[
+                    Any,
+                    tyro.conf.subcommand(name="commit", constructor=commit),
+                ],
+                Arg,
+            ],
+            args=["commit", "--message", "hi", "--all"],
+        )
+        == "message='hi' all=True"
+    )

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1199,61 +1199,24 @@ def test_subcommand_constructor_mix() -> None:
 
     def commit(message: str, all: bool = False) -> str:
         """Make a commit."""
-        return f"{message=} {all=}"
+        return f"{message} {all}"
 
     @dataclasses.dataclass
     class Arg:
         foo: int = 1
 
-    assert (
-        tyro.cli(
-            Union[
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="checkout", constructor=checkout),
-                ],
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="commit", constructor=commit),
-                ],
-                Arg,
-            ],
-            args=["arg"],
-        )
-        == Arg()
-    )
+    t: Any = Union[
+        Annotated[
+            Any,
+            tyro.conf.subcommand(name="checkout", constructor=checkout),
+        ],
+        Annotated[
+            Any,
+            tyro.conf.subcommand(name="commit", constructor=commit),
+        ],
+        Arg,
+    ]
 
-    assert (
-        tyro.cli(
-            Union[
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="checkout", constructor=checkout),
-                ],
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="commit", constructor=commit),
-                ],
-                Arg,
-            ],
-            args=["checkout", "--branch", "main"],
-        )
-        == "main"
-    )
-    assert (
-        tyro.cli(
-            Union[
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="checkout", constructor=checkout),
-                ],
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="commit", constructor=commit),
-                ],
-                Arg,
-            ],
-            args=["commit", "--message", "hi", "--all"],
-        )
-        == "message='hi' all=True"
-    )
+    assert tyro.cli(t, args=["arg"]) == Arg()
+    assert tyro.cli(t, args=["checkout", "--branch", "main"]) == "main"
+    assert tyro.cli(t, args=["commit", "--message", "hi", "--all"]) == "'hi' True"

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1219,4 +1219,4 @@ def test_subcommand_constructor_mix() -> None:
 
     assert tyro.cli(t, args=["arg"]) == Arg()
     assert tyro.cli(t, args=["checkout", "--branch", "main"]) == "main"
-    assert tyro.cli(t, args=["commit", "--message", "hi", "--all"]) == "'hi' True"
+    assert tyro.cli(t, args=["commit", "--message", "hi", "--all"]) == "hi True"

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1191,6 +1191,8 @@ def test_flag_alias() -> None:
 
 
 def test_subcommand_constructor_mix() -> None:
+    """https://github.com/brentyi/tyro/issues/89"""
+
     def checkout(branch: str) -> str:
         """Check out a branch."""
         return branch

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1198,61 +1198,24 @@ def test_subcommand_constructor_mix() -> None:
 
     def commit(message: str, all: bool = False) -> str:
         """Make a commit."""
-        return f"{message=} {all=}"
+        return f"{message} {all}"
 
     @dataclasses.dataclass
     class Arg:
         foo: int = 1
 
-    assert (
-        tyro.cli(
-            Union[
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="checkout", constructor=checkout),
-                ],
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="commit", constructor=commit),
-                ],
-                Arg,
-            ],
-            args=["arg"],
-        )
-        == Arg()
-    )
+    t: Any = Union[
+        Annotated[
+            Any,
+            tyro.conf.subcommand(name="checkout", constructor=checkout),
+        ],
+        Annotated[
+            Any,
+            tyro.conf.subcommand(name="commit", constructor=commit),
+        ],
+        Arg,
+    ]
 
-    assert (
-        tyro.cli(
-            Union[
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="checkout", constructor=checkout),
-                ],
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="commit", constructor=commit),
-                ],
-                Arg,
-            ],
-            args=["checkout", "--branch", "main"],
-        )
-        == "main"
-    )
-    assert (
-        tyro.cli(
-            Union[
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="checkout", constructor=checkout),
-                ],
-                Annotated[
-                    Any,
-                    tyro.conf.subcommand(name="commit", constructor=commit),
-                ],
-                Arg,
-            ],
-            args=["commit", "--message", "hi", "--all"],
-        )
-        == "message='hi' all=True"
-    )
+    assert tyro.cli(t, args=["arg"]) == Arg()
+    assert tyro.cli(t, args=["checkout", "--branch", "main"]) == "main"
+    assert tyro.cli(t, args=["commit", "--message", "hi", "--all"]) == "hi True"

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -232,6 +232,17 @@ def is_nested_type(
 
     TODO: we should come up with a better name than 'nested type', which is a little bit
     misleading."""
+
+    # Need to swap types.
+    _, argconfs = _resolver.unwrap_annotated(
+        typ, search_type=conf._confstruct._ArgConfiguration
+    )
+    _, subcommand_confs = _resolver.unwrap_annotated(
+        typ, search_type=conf._confstruct._SubcommandConfiguration
+    )
+    for union_conf in argconfs + subcommand_confs:
+        if union_conf.constructor_factory is not None:
+            typ = union_conf.constructor_factory()
     return not isinstance(
         _try_field_list_from_callable(typ, default_instance),
         UnsupportedNestedTypeMessage,


### PR DESCRIPTION
Resolves an issue exposed by #89, where:

```diff
 import tyro
+import dataclasses
 
 def checkout(branch: str) -> None:
     """Check out a branch."""
     print(f"{branch=}")
 
 
 def commit(message: str, all: bool = False) -> None:
     """Make a commit."""
     print(f"{message=} {all=}")
 
+@dataclasses.dataclass
+class Arg:
+    foo: int = 1
+

 if __name__ == "__main__":
     tyro.cli(
         Union[
             Annotated[
                 Any,
                 tyro.conf.subcommand(name="checkout", constructor=checkout),
             ],
             Annotated[
                 Any,
                 tyro.conf.subcommand(name="commit", constructor=commit),
             ],
+            Arg,
        ]
    )
```

should produce _three_ subcommands, `checkout`, `commit`, and `arg`. The type narrowing logic was previously failing and only producing `checkout` and `commit`.