### PR TITLE
Account for indent in subcommand helptext wrapping

### DIFF
--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -736,3 +736,20 @@ def test_subparsers_wrapping2() -> None:
 
     help = get_helptext(Union[A, CheckoutCompletionn])  # type: ignore
     assert help.count("checkout-completionn") == 3
+
+
+def test_subparsers_wrapping3() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CmdCheckout012:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(Union[A, CmdCheckout012])  # type: ignore
+    assert help.count("cmd-checkout012") == 3

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -685,3 +685,54 @@ def test_multiple_subparsers_helptext_underscores() -> None:
     assert "--b.arg_x" in helptext
     assert "--b.no_arg_flag" in helptext
     assert "--b.arg_flag" in helptext
+
+
+def test_subparsers_wrapping() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CheckoutCompletion:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(Union[A, CheckoutCompletion])  # type: ignore
+    assert help.count("checkout-completion") == 3
+
+
+def test_subparsers_wrapping1() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CheckoutCompletio:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(Union[A, CheckoutCompletio])  # type: ignore
+    assert help.count("checkout-completio") == 3
+
+
+def test_subparsers_wrapping2() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CheckoutCompletionn:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(Union[A, CheckoutCompletionn])  # type: ignore
+    assert help.count("checkout-completionn") == 3

--- a/tests/test_py311_generated/test_helptext_generated.py
+++ b/tests/test_py311_generated/test_helptext_generated.py
@@ -680,3 +680,71 @@ def test_multiple_subparsers_helptext_underscores() -> None:
     assert "--b.arg_x" in helptext
     assert "--b.no_arg_flag" in helptext
     assert "--b.arg_flag" in helptext
+
+
+def test_subparsers_wrapping() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CheckoutCompletion:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(A | CheckoutCompletion)  # type: ignore
+    assert help.count("checkout-completion") == 3
+
+
+def test_subparsers_wrapping1() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CheckoutCompletio:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(A | CheckoutCompletio)  # type: ignore
+    assert help.count("checkout-completio") == 3
+
+
+def test_subparsers_wrapping2() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CheckoutCompletionn:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(A | CheckoutCompletionn)  # type: ignore
+    assert help.count("checkout-completionn") == 3
+
+
+def test_subparsers_wrapping3() -> None:
+    @dataclasses.dataclass
+    class A:
+        """Help message."""
+
+        x: int
+
+    @dataclasses.dataclass
+    class CmdCheckout012:
+        """Help message."""
+
+        y: int
+
+    help = get_helptext(A | CmdCheckout012)  # type: ignore
+    assert help.count("cmd-checkout012") == 3

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -1,14 +1,5 @@
 import dataclasses
-from typing import (
-    Annotated,
-    Any,
-    Generic,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-)
+from typing import Annotated, Any, Generic, Literal, Mapping, Optional, Tuple, TypeVar
 
 import pytest
 from frozendict import frozendict  # type: ignore

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -1,5 +1,14 @@
 import dataclasses
-from typing import Annotated, Any, Generic, Literal, Mapping, Optional, Tuple, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    Generic,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 
 import pytest
 from frozendict import frozendict  # type: ignore

--- a/tyro/_argparse_formatter.py
+++ b/tyro/_argparse_formatter.py
@@ -1006,7 +1006,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
             invocation = self.formatter._format_action_invocation(action)
             indent = self.formatter._current_indent
             help_position = min(
-                self.formatter._action_max_length + 4 + indent,
+                self.formatter._action_max_length + 4,
                 self.formatter._max_help_position,
             )
             if self.formatter._fixed_help_position:

--- a/tyro/_argparse_formatter.py
+++ b/tyro/_argparse_formatter.py
@@ -1037,7 +1037,8 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
 
             if (
                 action.help
-                and len(_strings.strip_ansi_sequences(invocation)) < help_position - 1
+                and len(_strings.strip_ansi_sequences(invocation)) + indent
+                < help_position - 1
                 and not self.formatter._fixed_help_position
             ):
                 table = Table(show_header=False, box=None, padding=0)
@@ -1065,7 +1066,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                         Padding(
                             # Unescape % signs, which need special handling in argparse.
                             helptext,
-                            pad=(0, 0, 0, help_position),
+                            pad=(0, 0, 0, help_position - indent),
                         )
                     )
 


### PR DESCRIPTION
Closes #91!

before:
![image](https://github.com/brentyi/tyro/assets/6992947/d3f9d05c-c82e-4d78-9454-bb56d811ce3a)


after:
![image](https://github.com/brentyi/tyro/assets/6992947/5a3184fd-d9f3-47c9-b0d7-2da1acbdf89f)