### PR TITLE
Add support for mixed unions

### DIFF
--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -487,3 +487,8 @@ def test_list_narrowing_direct() -> None:
         "four",
         5,
     ]
+
+
+def test_tuple_direct() -> None:
+    assert tyro.cli(tuple[int, ...], args="1 2".split(" ")) == (1, 2)
+    assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -490,5 +490,5 @@ def test_list_narrowing_direct() -> None:
 
 
 def test_tuple_direct() -> None:
-    assert tyro.cli(Tuple[int, ...], args="1 2".split(" ")) == (1, 2)
-    assert tyro.cli(Tuple[int, int], args="1 2".split(" ")) == (1, 2)
+    assert tyro.cli(Tuple[int, ...], args="1 2".split(" ")) == (1, 2)  # type: ignore
+    assert tyro.cli(Tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -490,5 +490,5 @@ def test_list_narrowing_direct() -> None:
 
 
 def test_tuple_direct() -> None:
-    assert tyro.cli(tuple[int, ...], args="1 2".split(" ")) == (1, 2)
-    assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)
+    assert tyro.cli(Tuple[int, ...], args="1 2".split(" ")) == (1, 2)
+    assert tyro.cli(Tuple[int, int], args="1 2".split(" ")) == (1, 2)

--- a/tests/test_mixed_unions.py
+++ b/tests/test_mixed_unions.py
@@ -1,11 +1,8 @@
 """Tests for unsupported union types.
 
-Unions like `int | str` or `SomeDataclassA | SomeDataclassB` are generally OK (note that
-the latter will produce a pair of subcommands), but when we write things like
-`int | SomeDataclassA` handling gets more complicated; see docstring for
-`narrow_union_type()` in _resolvers.py.
-
-Hopefully we can fix/improve this in the future!
+Unions like `int | str` or `SomeDataclassA | SomeDataclassB` are OK (note that the latter
+will produce a pair of subcommands); when we write things like `int | SomeDataclassA`
+handling gets more complicated but should still be supported!
 """
 
 
@@ -78,10 +75,10 @@ def test_subparser_strip_nested() -> None:
         bc: Union[int, str, DefaultHTTPServer, DefaultSMTPServer] = 5
 
     assert (
-        tyro.cli(DefaultSubparser, args=["--x", "1", "--bc", "5"])
+        tyro.cli(DefaultSubparser, args=["--x", "1", "bc:int", "5"])
         == tyro.cli(DefaultSubparser, args=["--x", "1"])
         == DefaultSubparser(x=1, bc=5)
     )
     assert tyro.cli(
-        DefaultSubparser, args=["--x", "1", "--bc", "five"]
+        DefaultSubparser, args=["--x", "1", "bc:str", "five"]
     ) == DefaultSubparser(x=1, bc="five")

--- a/tests/test_mixed_unions.py
+++ b/tests/test_mixed_unions.py
@@ -7,7 +7,7 @@ handling gets more complicated but should still be supported!
 
 
 import dataclasses
-from typing import Union
+from typing import Any, Dict, List, Tuple, Union
 
 import pytest
 
@@ -82,3 +82,17 @@ def test_subparser_strip_nested() -> None:
     assert tyro.cli(
         DefaultSubparser, args=["--x", "1", "bc:str", "five"]
     ) == DefaultSubparser(x=1, bc="five")
+
+
+def test_with_fancy_types() -> None:
+    @dataclasses.dataclass
+    class Args:
+        y: int
+
+    def main(x: Union[Tuple[int, ...], List[str], Args, Dict[str, int]]) -> Any:
+        return x
+
+    assert tyro.cli(main, args="x:tuple-int-ellipsis 1 2 3".split(" ")) == (1, 2, 3)
+    assert tyro.cli(main, args="x:list-str 1 2 3".split(" ")) == ["1", "2", "3"]
+    assert tyro.cli(main, args="x:args --x.y 5".split(" ")) == Args(5)
+    assert tyro.cli(main, args="x:dict-str-int 1 2 3 4".split(" ")) == {"1": 2, "3": 4}

--- a/tests/test_new_style_annotations_min_py39.py
+++ b/tests/test_new_style_annotations_min_py39.py
@@ -62,3 +62,8 @@ def test_super_nested() -> None:
     ]
     with pytest.raises(SystemExit):
         tyro.cli(main, args=["--help"])
+
+
+def test_tuple_direct() -> None:
+    assert tyro.cli(tuple[int, ...], args="1 2".split(" ")) == (1, 2)  # type: ignore
+    assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore

--- a/tests/test_py311_generated/test_collections_generated.py
+++ b/tests/test_py311_generated/test_collections_generated.py
@@ -486,3 +486,8 @@ def test_list_narrowing_direct() -> None:
         "four",
         5,
     ]
+
+
+def test_tuple_direct() -> None:
+    assert tyro.cli(Tuple[int, ...], args="1 2".split(" ")) == (1, 2)  # type: ignore
+    assert tyro.cli(Tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore

--- a/tests/test_py311_generated/test_mixed_unions_generated.py
+++ b/tests/test_py311_generated/test_mixed_unions_generated.py
@@ -1,11 +1,8 @@
 """Tests for unsupported union types.
 
-Unions like `int | str` or `SomeDataclassA | SomeDataclassB` are generally OK (note that
-the latter will produce a pair of subcommands), but when we write things like
-`int | SomeDataclassA` handling gets more complicated; see docstring for
-`narrow_union_type()` in _resolvers.py.
-
-Hopefully we can fix/improve this in the future!
+Unions like `int | str` or `SomeDataclassA | SomeDataclassB` are OK (note that the latter
+will produce a pair of subcommands); when we write things like `int | SomeDataclassA`
+handling gets more complicated but should still be supported!
 """
 
 
@@ -77,10 +74,10 @@ def test_subparser_strip_nested() -> None:
         bc: int | str | DefaultHTTPServer | DefaultSMTPServer = 5
 
     assert (
-        tyro.cli(DefaultSubparser, args=["--x", "1", "--bc", "5"])
+        tyro.cli(DefaultSubparser, args=["--x", "1", "bc:int", "5"])
         == tyro.cli(DefaultSubparser, args=["--x", "1"])
         == DefaultSubparser(x=1, bc=5)
     )
     assert tyro.cli(
-        DefaultSubparser, args=["--x", "1", "--bc", "five"]
+        DefaultSubparser, args=["--x", "1", "bc:str", "five"]
     ) == DefaultSubparser(x=1, bc="five")

--- a/tests/test_py311_generated/test_mixed_unions_generated.py
+++ b/tests/test_py311_generated/test_mixed_unions_generated.py
@@ -7,6 +7,7 @@ handling gets more complicated but should still be supported!
 
 
 import dataclasses
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -81,3 +82,17 @@ def test_subparser_strip_nested() -> None:
     assert tyro.cli(
         DefaultSubparser, args=["--x", "1", "bc:str", "five"]
     ) == DefaultSubparser(x=1, bc="five")
+
+
+def test_with_fancy_types() -> None:
+    @dataclasses.dataclass
+    class Args:
+        y: int
+
+    def main(x: Tuple[int, ...] | List[str] | Args | Dict[str, int]) -> Any:
+        return x
+
+    assert tyro.cli(main, args="x:tuple-int-ellipsis 1 2 3".split(" ")) == (1, 2, 3)
+    assert tyro.cli(main, args="x:list-str 1 2 3".split(" ")) == ["1", "2", "3"]
+    assert tyro.cli(main, args="x:args --x.y 5".split(" ")) == Args(5)
+    assert tyro.cli(main, args="x:dict-str-int 1 2 3 4".split(" ")) == {"1": 2, "3": 4}

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -1,14 +1,5 @@
 import dataclasses
-from typing import (
-    Annotated,
-    Any,
-    Generic,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-)
+from typing import Annotated, Any, Generic, Literal, Mapping, Optional, Tuple, TypeVar
 
 import pytest
 from frozendict import frozendict  # type: ignore

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -1,5 +1,14 @@
 import dataclasses
-from typing import Annotated, Any, Generic, Literal, Mapping, Optional, Tuple, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    Generic,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 
 import pytest
 from frozendict import frozendict  # type: ignore

--- a/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
@@ -62,3 +62,8 @@ def test_super_nested() -> None:
     ]
     with pytest.raises(SystemExit):
         tyro.cli(main, args=["--help"])
+
+
+def test_tuple_direct() -> None:
+    assert tyro.cli(tuple[int, ...], args="1 2".split(" ")) == (1, 2)  # type: ignore
+    assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore

--- a/tyro/_calling.py
+++ b/tyro/_calling.py
@@ -238,11 +238,6 @@ def call_from_args(
             # Triggered when support_single_arg_types=True is used.
             assert len(kwargs) == 0
             assert len(positional_args) == 1
-            return positional_args[0], consumed_keywords  # type: ignore
-        if len(positional_args) > 0:
-            # Triggered when support_single_arg_types=True is used.
-            assert len(kwargs) == 0
-            assert len(positional_args) == 1
             return unwrapped_f(*positional_args), consumed_keywords  # type: ignore
         else:
             assert len(positional_args) == 0

--- a/tyro/_calling.py
+++ b/tyro/_calling.py
@@ -225,14 +225,28 @@ def call_from_args(
     unwrapped_f = list if unwrapped_f is Sequence else unwrapped_f  # type: ignore
 
     if unwrapped_f in (tuple, list, set):
-        assert len(positional_args) == 0
-        # When tuples are used as nested structures (eg Tuple[SomeDataclass]), we
-        # use keyword arguments.
-        assert len(positional_args) == 0
-        return unwrapped_f(kwargs.values()), consumed_keywords  # type: ignore
+        if len(positional_args) > 0:
+            # Triggered when support_single_arg_types=True is used.
+            assert len(kwargs) == 0
+            assert len(positional_args) == 1
+            return positional_args[0], consumed_keywords  # type: ignore
+        else:
+            assert len(positional_args) == 0
+            return unwrapped_f(kwargs.values()), consumed_keywords  # type: ignore
     elif unwrapped_f is dict:
-        assert len(positional_args) == 0
-        return kwargs, consumed_keywords  # type: ignore
+        if len(positional_args) > 0:
+            # Triggered when support_single_arg_types=True is used.
+            assert len(kwargs) == 0
+            assert len(positional_args) == 1
+            return positional_args[0], consumed_keywords  # type: ignore
+        if len(positional_args) > 0:
+            # Triggered when support_single_arg_types=True is used.
+            assert len(kwargs) == 0
+            assert len(positional_args) == 1
+            return unwrapped_f(*positional_args), consumed_keywords  # type: ignore
+        else:
+            assert len(positional_args) == 0
+            return kwargs, consumed_keywords  # type: ignore
     else:
         if field_name_prefix == "":
             # Don't catch any errors for the "root" field. If main() in tyro.cli(main)

--- a/tyro/_calling.py
+++ b/tyro/_calling.py
@@ -38,7 +38,7 @@ def call_from_args(
 
     # Resolve the type of `f`, generate a field list.
     f, type_from_typevar, field_list = _fields.field_list_from_callable(
-        f=f, default_instance=default_instance
+        f=f, default_instance=default_instance, support_single_arg_types=True
     )
 
     positional_args: List[Any] = []

--- a/tyro/_cli.py
+++ b/tyro/_cli.py
@@ -304,7 +304,7 @@ def _cli_impl(
             dataclasses.field(),
         )
         f = dataclasses.make_dataclass(
-            cls_name="",
+            cls_name="dummy",
             fields=[(_strings.dummy_field_name, cast(type, f), dummy_field)],
             frozen=True,
         )

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -592,7 +592,10 @@ except ImportError:
 
 
 def _is_pydantic(cls: TypeForm[Any]) -> bool:
-    return pydantic is not None and issubclass(cls, pydantic.BaseModel)
+    try:
+        return pydantic is not None and issubclass(cls, pydantic.BaseModel)
+    except TypeError:
+        return False
 
 
 def _field_list_from_pydantic(

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -376,7 +376,8 @@ def _try_field_list_from_callable(
         default_instance = found_subcommand_configs[0].default
 
     # Unwrap generics.
-    f, _ = _resolver.resolve_generic_types(f)
+    f, type_from_typevar = _resolver.resolve_generic_types(f)
+    f = _resolver.apply_type_from_typevar(f, type_from_typevar)
     f = _resolver.narrow_subtypes(f, default_instance)
     f = _resolver.narrow_collection_types(f, default_instance)
     f_origin = _resolver.unwrap_origin_strip_extras(cast(TypeForm, f))
@@ -592,10 +593,7 @@ except ImportError:
 
 
 def _is_pydantic(cls: TypeForm[Any]) -> bool:
-    try:
-        return pydantic is not None and issubclass(cls, pydantic.BaseModel)
-    except TypeError:
-        return False
+    return pydantic is not None and issubclass(cls, pydantic.BaseModel)
 
 
 def _field_list_from_pydantic(

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -62,7 +62,7 @@ class FieldDefinition:
     stripped."""
     default: Any
     helptext: Optional[str]
-    markers: FrozenSet[_markers._Marker]
+    markers: FrozenSet[Any]
     custom_constructor: bool
 
     argconf: _confstruct._ArgConfiguration
@@ -254,6 +254,7 @@ def is_nested_type(
 def field_list_from_callable(
     f: Union[Callable, TypeForm[Any]],
     default_instance: DefaultInstance,
+    support_single_arg_types: bool,
 ) -> Tuple[
     Union[Callable, TypeForm[Any]], Dict[TypeVar, TypeForm], List[FieldDefinition]
 ]:
@@ -273,7 +274,30 @@ def field_list_from_callable(
     field_list = _try_field_list_from_callable(f, default_instance)
 
     if isinstance(field_list, UnsupportedNestedTypeMessage):
-        raise _instantiators.UnsupportedTypeAnnotationError(field_list.message)
+        if support_single_arg_types:
+            return (
+                f,
+                type_from_typevar,
+                [
+                    FieldDefinition(
+                        intern_name="value",
+                        extern_name="value",  # Doesn't matter.
+                        type_or_callable=f,
+                        default=default_instance,
+                        helptext="",
+                        custom_constructor=False,
+                        markers=frozenset(
+                            (_markers.Positional, _markers._PositionalCall)
+                        ),
+                        argconf=_confstruct._ArgConfiguration(
+                            None, None, None, None, None, None
+                        ),
+                        call_argname="",
+                    )
+                ],
+            )
+        else:
+            raise _instantiators.UnsupportedTypeAnnotationError(field_list.message)
 
     # Recursively apply markers.
     _, parent_markers = _resolver.unwrap_annotated(f, _markers._Marker)

--- a/tyro/_parsers.py
+++ b/tyro/_parsers.py
@@ -68,6 +68,7 @@ class ParserSpecification:
         intern_prefix: str,
         extern_prefix: str,
         subcommand_prefix: str = "",
+        support_single_arg_types: bool = False,
     ) -> ParserSpecification:
         """Create a parser definition from a callable or type."""
 
@@ -79,7 +80,9 @@ class ParserSpecification:
 
         # Resolve the type of `f`, generate a field list.
         f, type_from_typevar, field_list = _fields.field_list_from_callable(
-            f=f, default_instance=default_instance
+            f=f,
+            default_instance=default_instance,
+            support_single_arg_types=support_single_arg_types,
         )
 
         # Cycle detection.
@@ -343,6 +346,7 @@ def handle_field(
                     [extern_prefix, field.extern_name]
                 ),
                 subcommand_prefix=subcommand_prefix,
+                support_single_arg_types=False,
             )
 
     # (3) Handle primitive or fixed types. These produce a single argument!
@@ -412,10 +416,11 @@ class SubparsersSpecification:
                     )
                 )
 
-        # Exit if we don't contain nested types.
-        if not all(
+        # Exit if we don't contain any nested types.
+        if not any(
             [
-                _fields.is_nested_type(cast(type, o), _fields.MISSING_NONPROP)
+                o is not none_proxy
+                and _fields.is_nested_type(cast(type, o), _fields.MISSING_NONPROP)
                 for o in options
             ]
         ):
@@ -505,6 +510,7 @@ class SubparsersSpecification:
                 intern_prefix=intern_prefix,
                 extern_prefix=extern_prefix,
                 subcommand_prefix=intern_prefix,
+                support_single_arg_types=True,
             )
 
             # Apply prefix to helptext in nested classes in subparsers.

--- a/tyro/_strings.py
+++ b/tyro/_strings.py
@@ -112,9 +112,7 @@ def _subparser_name_from_type(cls: Type) -> Tuple[str, bool]:
         elif hasattr(cls, "__name__"):
             return hyphen_separated_from_camel_case(cls.__name__)
         else:
-            raise AssertionError(
-                f"Tried to interpret {cls} as a subcommand, but could not infer name"
-            )
+            return hyphen_separated_from_camel_case(str(cls))
 
     if len(type_from_typevar) == 0:
         return get_name(cls), prefix_name  # type: ignore

--- a/tyro/_subcommand_matching.py
+++ b/tyro/_subcommand_matching.py
@@ -73,7 +73,7 @@ class _TypeTree:
         """From an object instance, return a data structure representing the types in the object."""
         try:
             typ, _type_from_typevar, field_list = _fields.field_list_from_callable(
-                typ, default_instance=default_instance
+                typ, default_instance=default_instance, support_single_arg_types=False
             )
         except _instantiators.UnsupportedTypeAnnotationError:
             return _TypeTree(typ, {})


### PR DESCRIPTION
Closes #42

This:
```python
import dataclasses
from typing import Union

import tyro


@dataclasses.dataclass
class Args:
    y: str


def main(x: Union[int, Args]) -> None:
    print(x)


tyro.cli(main)
```

Now produces:
![image](https://github.com/brentyi/tyro/assets/6992947/84cfa16f-d504-4ebc-9114-13f3b786dca7)
