### PR TITLE
Improve PEP 585/604 annotation errors for older versions of Python

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,14 @@ import sys
 
 collect_ignore_glob = []
 
-if not (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+if not sys.version_info >= (3, 8):
     collect_ignore_glob.append("*_min_py38.py")
 
-if not (sys.version_info.major == 3 and sys.version_info.minor >= 9):
+if not sys.version_info >= (3, 9):
     collect_ignore_glob.append("*_min_py39.py")
 
-if not (sys.version_info.major == 3 and sys.version_info.minor >= 10):
+if not sys.version_info >= (3, 10):
     collect_ignore_glob.append("*_min_py310.py")
 
-if not (sys.version_info.major == 3 and sys.version_info.minor >= 11):
+if not sys.version_info >= (3, 11):
     collect_ignore_glob.append("test_py311_generated/*.py")

--- a/tests/test_base_configs_nested.py
+++ b/tests/test_base_configs_nested.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from typing import Callable, Tuple, TYPE_CHECKING
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Callable, Tuple
 
 from torch import nn
+from typing_extensions import Literal
 
 import tyro
 

--- a/tests/test_errors_new_annotations.py
+++ b/tests/test_errors_new_annotations.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import tyro
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="No error for newer versions of Python."
+)
+def test_new_union_error() -> None:
+    """PEP 604 allows `|` to be used as a type annotation in Python >=3.10."""
+
+    def main(x: int | str) -> None:
+        ...
+
+    with pytest.raises(TypeError) as e:
+        tyro.cli(main)
+    assert "You may be using a Union in the form of `X | Y`" in e.value.args[0]
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 9), reason="No error for newer versions of Python."
+)
+def test_new_collection_error() -> None:
+    """PEP 585 allows standard collections to be used as generics in Python >=3.9."""
+
+    def main(x: list[int]) -> None:
+        ...
+
+    with pytest.raises(TypeError) as e:
+        tyro.cli(main)
+    assert "You may be using a standard collection as a generic" in e.value.args[0]

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -5,8 +5,8 @@ import pathlib
 from collections.abc import Callable
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union, cast
 
-from torch import nn
 from helptext_utils import get_helptext
+from torch import nn
 from typing_extensions import Annotated, Literal
 
 

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -164,9 +164,10 @@ def test_subparser_in_nested_with_metadata() -> None:
 
     @dataclasses.dataclass
     class Nested2:
-        subcommand: Annotated[
-            A, tyro.conf.subcommand("command-a", default=A(7))
-        ] | Annotated[B, tyro.conf.subcommand("command-b", default=B(9))]
+        subcommand: (
+            Annotated[A, tyro.conf.subcommand("command-a", default=A(7))]
+            | Annotated[B, tyro.conf.subcommand("command-b", default=B(9))]
+        )
 
     @dataclasses.dataclass
     class Nested1:
@@ -271,9 +272,10 @@ def test_subparser_in_nested_with_metadata_generic_alt() -> None:
 
     @dataclasses.dataclass
     class Nested2(Generic[T]):
-        subcommand: Annotated[
-            T, tyro.conf.subcommand("command-a", default=A(7))
-        ] | Annotated[B, tyro.conf.subcommand("command-b", default=B(9))]
+        subcommand: (
+            Annotated[T, tyro.conf.subcommand("command-a", default=A(7))]
+            | Annotated[B, tyro.conf.subcommand("command-b", default=B(9))]
+        )
 
     @dataclasses.dataclass
     class Nested1:
@@ -325,11 +327,11 @@ def test_subparser_in_nested_with_metadata_default_matching() -> None:
 
     @dataclasses.dataclass
     class Nested:
-        subcommand: Annotated[
-            B, tyro.conf.subcommand("one", default=default_one)
-        ] | Annotated[B, tyro.conf.subcommand("two")] | Annotated[
-            B, tyro.conf.subcommand("three", default=default_three)
-        ]
+        subcommand: (
+            Annotated[B, tyro.conf.subcommand("one", default=default_one)]
+            | Annotated[B, tyro.conf.subcommand("two")]
+            | Annotated[B, tyro.conf.subcommand("three", default=default_three)]
+        )
 
     # Match by hash.
     def main_one(x: Nested = Nested(default_one)) -> None:

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -31,14 +31,7 @@ from typing import (
 
 import docstring_parser
 import typing_extensions
-from typing_extensions import (
-    NotRequired,
-    Required,
-    get_args,
-    get_origin,
-    get_type_hints,
-    is_typeddict,
-)
+from typing_extensions import NotRequired, Required, get_args, get_origin, is_typeddict
 
 from . import conf  # Avoid circular import.
 from . import (
@@ -460,7 +453,7 @@ def _field_list_from_typeddict(
     total = getattr(cls, "__total__", True)
     assert isinstance(total, bool)
     assert not valid_default_instance or isinstance(default_instance, dict)
-    for name, typ in get_type_hints(cls, include_extras=True).items():
+    for name, typ in _resolver.get_type_hints(cls, include_extras=True).items():
         typ_origin = get_origin(typ)
         if valid_default_instance and name in cast(dict, default_instance):
             default = cast(dict, default_instance)[name]
@@ -517,7 +510,7 @@ def _field_list_from_namedtuple(
     field_defaults = getattr(cls, "_field_defaults")
 
     # Note that _field_types is removed in Python 3.9.
-    for name, typ in get_type_hints(cls, include_extras=True).items():
+    for name, typ in _resolver.get_type_hints(cls, include_extras=True).items():
         # Get default, with priority for `default_instance`.
         default = field_defaults.get(name, MISSING_NONPROP)
         if hasattr(default_instance, name):
@@ -898,7 +891,7 @@ def _field_list_from_params(
 
     # This will throw a type error for torch.device, typing.Dict, etc.
     try:
-        hints = get_type_hints(f, include_extras=True)
+        hints = _resolver.get_type_hints(f, include_extras=True)
     except TypeError:
         return UnsupportedNestedTypeMessage(f"Could not get hints for {f}!")
 

--- a/tyro/_instantiators.py
+++ b/tyro/_instantiators.py
@@ -55,14 +55,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import (
-    Annotated,
-    Final,
-    Literal,
-    get_args,
-    get_origin,
-    get_type_hints,
-)
+from typing_extensions import Annotated, Final, Literal, get_args, get_origin
 
 from . import _resolver
 
@@ -128,7 +121,7 @@ def is_type_string_converter(typ: Union[Callable, TypeForm[Any]]) -> bool:
         # One day this should be fixed with `__text_signature__`.
         return True
 
-    type_annotations = get_type_hints(typ)
+    type_annotations = _resolver.get_type_hints_with_nicer_errors(typ)
     # Some checks we can do if the signature is available!
     for i, param in enumerate(signature.parameters.values()):
         annotation = type_annotations.get(param.name, param.annotation)

--- a/tyro/_resolver.py
+++ b/tyro/_resolver.py
@@ -300,7 +300,7 @@ def get_type_hints_with_nicer_errors(
 ) -> Dict[str, Any]:
     try:
         return get_type_hints(obj, include_extras=include_extras)
-    except TypeError as e:
+    except TypeError as e:  # pragma: no cover
         common_message = f"\n-----\n\nError calling typing.get_type_hints() on {obj}! "
         message = e.args[0]
         if message.startswith(

--- a/tyro/_resolver.py
+++ b/tyro/_resolver.py
@@ -1,5 +1,4 @@
 """Utilities for resolving types and forward references."""
-
 import collections.abc
 import copy
 import dataclasses
@@ -294,3 +293,34 @@ def narrow_union_type(typ: TypeOrCallable, default_instance: Any) -> TypeOrCalla
         pass
 
     return typ
+
+
+def get_type_hints_with_nicer_errors(
+    obj: Callable[..., Any], include_extras: bool = False
+) -> Dict[str, Any]:
+    try:
+        return get_type_hints(obj, include_extras=include_extras)
+    except TypeError as e:
+        common_message = f"\n-----\n\nError calling typing.get_type_hints() on {obj}! "
+        message = e.args[0]
+        if message.startswith(
+            "unsupported operand type(s) for |"
+        ) and sys.version_info < (3, 10):
+            # PEP 604. Requires Python 3.10.
+            raise TypeError(
+                e.args[0]
+                + common_message
+                + "You may be using a Union in the form of `X | Y`; to support Python versions that lower than 3.10, you need to use `typing.Union[X, Y]` instead of `X | Y` and `typing.Optional[X]` instead of `X | None`.",
+                *e.args[1:],
+            )
+        elif message == "'type' object is not subscriptable" and (
+            sys.version_info < (3, 9)
+        ):
+            # PEP 585. Requires Python 3.9.
+            raise TypeError(
+                e.args[0]
+                + common_message
+                + "You may be using a standard collection as a generic, like `list[T]` or `tuple[T1, T2]`. To support Python versions lower than 3.9, you need to using `typing.List[T]` and `typing.Tuple[T1, T2]`.",
+                *e.args[1:],
+            )
+        raise e


### PR DESCRIPTION
Improves error from https://github.com/huggingface/trl/issues/1032

As an example in Python 3.8, this:
```python
from __future__ import annotations


def main(x: list[int]) -> None:
    ...


import tyro

tyro.cli(main)
```

will now print:
```
Error calling typing.get_type_hints() on <function main at 0x1008261f0>! You may be using a standard collection as a generic, like `list[T]` or `tuple[T1, T2]`. To support Python versions lower than 3.9, you need to using `typing.List[T]` and `typing.Tuple[T1, T2]`.
```