### PR TITLE
Fix default values in Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     # As of 7/27/2023, flax install fails for Python 3.7 without pinning to an
     # old version. But doing so breaks other Python versions.
     "flax>=0.6.9;python_version>='3.8'", 
-    "pydantic>=2.3.0",
+    "pydantic>=2.5.2",
     "coverage[toml]>=6.5.0"
 ]
 

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -4,10 +4,10 @@ import pathlib
 from typing import cast
 
 import pytest
+import tyro._strings
 from pydantic import BaseModel, Field
 
 import tyro
-import tyro._strings
 
 
 def test_pydantic() -> None:
@@ -119,3 +119,20 @@ def test_pydantic_default_instance() -> None:
     assert tyro.cli(Outside, args=[]).i.x == 2, (
         "Expected x value from the default instance",
     )
+    assert tyro.cli(Outside, args=["--i.x", "3"]).i.x == 3
+
+
+def test_pydantic_nested_default_instance() -> None:
+    class Inside(BaseModel):
+        x: int = 1
+
+    class Middle(BaseModel):
+        i: Inside
+
+    class Outside(BaseModel):
+        m: Middle = Middle(i=Inside(x=2))
+
+    assert tyro.cli(Outside, args=[]).m.i.x == 2, (
+        "Expected x value from the default instance",
+    )
+    assert tyro.cli(Outside, args=["--m.i.x", "3"]).m.i.x == 3

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -107,3 +107,15 @@ def test_pydantic_positional_annotation() -> None:
 
     result = tyro.cli(AnnotatedAsPositional, args=["myname"])
     assert isinstance(result, AnnotatedAsPositional)
+
+
+def test_pydantic_default_instance() -> None:
+    class Inside(BaseModel):
+        x: int = 1
+
+    class Outside(BaseModel):
+        i: Inside = Inside(x=2)
+
+    assert tyro.cli(Outside, args=[]).i.x == 2, (
+        "Expected x value from the default instance",
+    )

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -606,7 +606,7 @@ def _field_list_from_pydantic(
         # We do a conditional cast because the pydantic.v1 module won't
         # actually exist in legacy versions of pydantic.
         cls_cast = cast(pydantic.v1.BaseModel, cls) if TYPE_CHECKING else cls
-        for pd_field in cls_cast.__fields__.values():  # type: ignore
+        for pd_field in cls_cast.__fields__.values():
             helptext = pd_field.field_info.description
             if helptext is None:
                 helptext = _docstrings.get_field_docstring(cls, pd_field.name)

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -975,7 +975,7 @@ def _ensure_dataclass_instance_used_as_default_is_frozen(
 
 def _get_dataclass_field_default(
     field: dataclasses.Field, parent_default_instance: Any
-) -> Optional[Any]:
+) -> Any:
     """Helper for getting the default instance for a dataclass field."""
     # If the dataclass's parent is explicitly marked MISSING, mark this field as missing
     # as well.

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -1017,8 +1017,7 @@ def _get_dataclass_field_default(
         # The only time this matters is when we our dataclass has a `__post_init__`
         # function that mutates the dataclass. We choose here to use the default values
         # before this method is called.
-        dataclasses.is_dataclass(field.type)
-        and field.default_factory is field.type
+        dataclasses.is_dataclass(field.type) and field.default_factory is field.type
     ):
         return field.default_factory()
 

--- a/tyro/_fields.py
+++ b/tyro/_fields.py
@@ -1053,7 +1053,7 @@ def _get_pydantic_field_default(
 
     # Try grabbing default, either from `default` or `default_factory`.
     # NOTE: The implementation is slightly different for Pydantic V1 and V2.
-    if pydantic_version < 2:
+    if pydantic_version < 2:  # pragma: no cover
         if not field.required:
             return field.get_default()
     else:


### PR DESCRIPTION
Default values are now properly parsed when an instance of a `pydantic.BaseModel` is provided.

```python
# a.py

import pydantic
import tyro


class Config(pydantic.BaseModel):
    a: int = 1


def main(config: Config = Config(a=2)) -> None:
    pass


tyro.cli(main)
```

```bash
$ python a.py -h
usage: a.py [-h] [--config.a INT]

╭─ arguments ───────────────────────────────────────────╮
│ -h, --help            show this help message and exit │
╰───────────────────────────────────────────────────────╯
╭─ config arguments ────────────────────────────────────╮
│ --config.a INT        (default: 2)                    │  # <-- good!
╰───────────────────────────────────────────────────────╯
```

This fixes #107 and fixes #108.