### PR TITLE
More succinct usage when a lot of options are present

### DIFF
--- a/examples/02_nesting/01_nesting.py
+++ b/examples/02_nesting/01_nesting.py
@@ -52,6 +52,7 @@ class ExperimentConfig:
 def train(
     out_dir: pathlib.Path,
     config: ExperimentConfig,
+    /,
     restore_checkpoint: bool = False,
     checkpoint_interval: int = 1000,
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tyro"
 authors = [
     {name = "brentyi", email = "brentyi@berkeley.edu"},
 ]
-version = "0.6.2"
+version = "0.6.3"
 description = "Strongly typed, zero-effort CLI interfaces"
 readme = "README.md"
 license = { text="MIT" }

--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -739,7 +739,7 @@ class TyroArgumentParser(argparse.ArgumentParser):
                     prev_arg_option_strings = arg_info.option_strings
                     prev_argument_help = arg_info.help
 
-        elif message.startswith("the following options are required:"):
+        elif message.startswith("the following arguments are required:"):
             message_title = "Required options"
 
             info_from_required_arg: Dict[str, Optional[_ArgumentInfo]] = {}

--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -971,7 +971,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                         len(column_parts),
                     ),
                 )
-                if column_count > 1:
+                if column_count > 1:  # pragma: no cover
                     column_width = self.formatter._width // column_count - 1
                     # Correct the line count for each panel using the known column
                     # width. This will account for word wrap.

--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -20,10 +20,11 @@ import dataclasses
 import difflib
 import itertools
 import re as _re
+import shlex
 import shutil
 import sys
 from gettext import gettext as _
-from typing import Any, Dict, Generator, List, NoReturn, Optional, Set, Tuple
+from typing import Any, Dict, Generator, Iterable, List, NoReturn, Optional, Set, Tuple
 
 from rich.columns import Columns
 from rich.console import Console, Group, RenderableType
@@ -564,15 +565,15 @@ class TyroArgumentParser(argparse.ArgumentParser):
         extra_info: List[RenderableType] = []
         global global_unrecognized_args
         if len(global_unrecognized_args) == 0 and message.startswith(
-            "unrecognized arguments: "
+            "unrecognized options: "
         ):
             global_unrecognized_args = message.partition(":")[2].strip().split(" ")
 
         message_title = "Parsing error"
 
         if len(global_unrecognized_args) > 0:
-            message_title = "Unrecognized arguments"
-            message = f"Unrecognized arguments: {' '.join(global_unrecognized_args)}"
+            message_title = "Unrecognized options"
+            message = f"Unrecognized options: {' '.join(global_unrecognized_args)}"
             unrecognized_arguments = set(
                 arg
                 for arg in global_unrecognized_args
@@ -588,7 +589,7 @@ class TyroArgumentParser(argparse.ArgumentParser):
             )
 
             if has_subcommands and same_exists:
-                message = f"Unrecognized or misplaced arguments: {' '.join(global_unrecognized_args)}"
+                message = f"Unrecognized or misplaced options: {' '.join(global_unrecognized_args)}"
 
             # Show similar arguments for keyword options.
             for unrecognized_argument in unrecognized_arguments:
@@ -738,8 +739,8 @@ class TyroArgumentParser(argparse.ArgumentParser):
                     prev_arg_option_strings = arg_info.option_strings
                     prev_argument_help = arg_info.help
 
-        elif message.startswith("the following arguments are required:"):
-            message_title = "Required arguments"
+        elif message.startswith("the following options are required:"):
+            message_title = "Required options"
 
             info_from_required_arg: Dict[str, Optional[_ArgumentInfo]] = {}
             for arg in message.partition(":")[2].strip().split(", "):
@@ -1289,7 +1290,30 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
         return text
 
     @override
-    def _format_usage(self, usage, actions, groups, prefix) -> str:
+    def _format_usage(
+        self, usage, actions: Iterable[argparse.Action], groups, prefix
+    ) -> str:
+        assert isinstance(actions, list)
+        if len(actions) > 4:
+            new_actions = []
+            prog_parts = shlex.split(self._prog)
+            optional_args_action = argparse.Action(
+                [
+                    "OPTIONS"
+                    if len(prog_parts) == 1
+                    else prog_parts[-1].upper() + " OPTIONS"
+                ],
+                dest="",
+            )
+            for action in actions:
+                if action.dest == "help" or len(action.option_strings) == 0:
+                    new_actions.append(action)
+                elif (
+                    len(new_actions) == 0 or new_actions[-1] is not optional_args_action
+                ):
+                    new_actions.append(optional_args_action)
+            actions = new_actions
+
         # Format the usage label.
         if prefix is None:
             prefix = str_from_rich("[bold]usage[/bold]: ")

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -221,14 +221,14 @@ class ParserSpecification:
         if subparser_group is not None:
             parser._action_groups.append(subparser_group)
 
-        # Break some API boundaries to rename the "optional arguments" => "arguments".
+        # Break some API boundaries to rename the "optional arguments" => "options".
         assert parser._action_groups[1].title in (
             # python <= 3.9
             "optional arguments",
             # python >= 3.10
             "options",
         )
-        parser._action_groups[1].title = "arguments"
+        parser._action_groups[1].title = "options"
 
         return leaves
 
@@ -240,7 +240,7 @@ class ParserSpecification:
 
         # Make argument groups.
         def format_group_name(prefix: str) -> str:
-            return (prefix + " arguments").strip()
+            return (prefix + " options").strip()
 
         group_from_prefix: Dict[str, argparse._ArgumentGroup] = {
             "": parser._action_groups[1],

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -171,10 +171,9 @@ def test_similar_arguments_basic() -> None:
         tyro.cli(Class, args="--reward.trac".split(" "))
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
 
-    # --reward.track should appear in both the usage string and as a similar argument.
     assert error.count("--reward.track") == 1
     assert error.count("--help") == 1
 
@@ -197,7 +196,7 @@ def test_similar_arguments_subcommands() -> None:
         tyro.cli(Union[ClassA, ClassB], args="--reward.trac".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track") == 1
     assert error.count("--help") == 3
@@ -222,7 +221,7 @@ def test_similar_arguments_subcommands_multiple() -> None:
         tyro.cli(Union[ClassA, ClassB], args="--fjdkslaj --reward.trac".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Arguments similar to --reward.trac" in error
     assert error.count("--reward.track {True,False}") == 1
     assert error.count("--reward.trace INT") == 1
@@ -248,7 +247,7 @@ def test_similar_arguments_subcommands_multiple_contains_match() -> None:
         tyro.cli(Union[ClassA, ClassB], args="--rd.trac".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track {True,False}") == 1
     assert error.count("--reward.trace INT") == 1
@@ -274,7 +273,7 @@ def test_similar_arguments_subcommands_multiple_contains_match_alt() -> None:
         tyro.cli(Union[ClassA, ClassB], args="--track".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track {True,False}") == 1
     assert (
@@ -316,7 +315,7 @@ def test_similar_arguments_subcommands_overflow_different() -> None:
         tyro.cli(Union[ClassA, ClassB], args="--track".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track") == 10
     assert "[...]" not in error
@@ -384,7 +383,7 @@ def test_similar_arguments_subcommands_overflow_same() -> None:
         )
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track") == 1
     assert "[...]" in error
@@ -443,7 +442,7 @@ def test_similar_arguments_subcommands_overflow_same_startswith_multiple() -> No
         )
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Arguments similar to --track" in error
     assert error.count("--rewar") == 1
     assert "rewarde" not in error

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -413,6 +413,8 @@ def test_multiple_subparsers_helptext() -> None:
             default_factory=Subcommand3
         )
 
+        d: bool = False
+
     helptext = get_helptext(MultipleSubparsers)
 
     assert "2% milk." in helptext
@@ -436,6 +438,7 @@ def test_multiple_subparsers_helptext() -> None:
 
     # Not enough args for usage shortening to kick in.
     assert "[OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND1 OPTIONS]" not in helptext
     assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
 
 
@@ -478,6 +481,10 @@ def test_multiple_subparsers_helptext_shortened_usage() -> None:
         )
 
         d: bool = False
+        f: bool = False
+        g: bool = False
+        h: bool = False
+        i: bool = False
 
     helptext = get_helptext(MultipleSubparsers)
 
@@ -499,9 +506,9 @@ def test_multiple_subparsers_helptext_shortened_usage() -> None:
     assert "Field c description." in helptext
     assert "(default: c:subcommand3)" in helptext
 
-    # Not enough args for usage shortening to kick in.
     assert "[OPTIONS]" not in helptext
-    assert "[B:SUBCOMMAND2 OPTIONS]" in helptext
+    assert "[B:SUBCOMMAND1 OPTIONS]" in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
 
 
 def test_optional_helptext() -> None:

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -420,6 +420,10 @@ def test_multiple_subparsers_helptext() -> None:
     assert "Field b description." not in helptext
     assert "Field c description." not in helptext
 
+    # Not enough args for usage shortening to kick in.
+    assert "[OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
+
     helptext = get_helptext(
         MultipleSubparsers, args=["a:subcommand1", "b:subcommand1", "--help"]
     )
@@ -429,6 +433,75 @@ def test_multiple_subparsers_helptext() -> None:
     assert "Field b description." not in helptext
     assert "Field c description." in helptext
     assert "(default: c:subcommand3)" in helptext
+
+    # Not enough args for usage shortening to kick in.
+    assert "[OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
+
+
+def test_multiple_subparsers_helptext_shortened_usage() -> None:
+    @dataclasses.dataclass
+    class Subcommand1:
+        """2% milk."""  # % symbol is prone to bugs in argparse.
+
+        a: int = 0
+        b: int = 0
+        c: int = 0
+        d: int = 0
+        e: int = 0
+
+    @dataclasses.dataclass
+    class Subcommand2:
+        a: int = 0
+        b: int = 0
+        c: int = 0
+        d: int = 0
+        e: int = 0
+
+    @dataclasses.dataclass
+    class Subcommand3:
+        a: int = 0
+        b: int = 0
+        c: int = 0
+        d: int = 0
+        e: int = 0
+
+    @dataclasses.dataclass
+    class MultipleSubparsers:
+        # Field a description.
+        a: Union[Subcommand1, Subcommand2, Subcommand3]
+        # Field b description.
+        b: Union[Subcommand1, Subcommand2, Subcommand3]
+        # Field c description.
+        c: Union[Subcommand1, Subcommand2, Subcommand3] = dataclasses.field(
+            default_factory=Subcommand3
+        )
+
+        d: bool = False
+
+    helptext = get_helptext(MultipleSubparsers)
+
+    assert "2% milk." in helptext
+    assert "Field a description." in helptext
+    assert "Field b description." not in helptext
+    assert "Field c description." not in helptext
+
+    assert "[OPTIONS]" in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
+
+    helptext = get_helptext(
+        MultipleSubparsers, args=["a:subcommand1", "b:subcommand1", "--help"]
+    )
+
+    assert "2% milk." in helptext
+    assert "Field a description." not in helptext
+    assert "Field b description." not in helptext
+    assert "Field c description." in helptext
+    assert "(default: c:subcommand3)" in helptext
+
+    # Not enough args for usage shortening to kick in.
+    assert "[OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" in helptext
 
 
 def test_optional_helptext() -> None:

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -1,6 +1,7 @@
 """Tests for tyro.MISSING."""
-
+import contextlib
 import dataclasses
+import io
 from typing import Tuple
 
 import pytest
@@ -12,8 +13,15 @@ def test_missing() -> None:
     def main(a: int = 5, b: int = tyro.MISSING, c: int = 3) -> Tuple[int, int, int]:
         return a, b, c
 
-    with pytest.raises(SystemExit):
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stdout(target):
         tyro.cli(main, args=[])
+    message = target.getvalue()
+    assert "Required options" in message
+    assert "Argument helptext" in message
+    assert "--a INT" not in message
+    assert "--b INT" in message
+    assert "(required)" in message
     assert tyro.cli(main, args=["--b", "7"]) == (5, 7, 3)
 
 

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -378,7 +378,9 @@ def test_subparser_with_default_and_newtype() -> None:
         y: int
 
     DefaultHTTPServer__ = NewType("DefaultHTTPServer__", DefaultHTTPServer_)
-    DefaultHTTPServer = NewType("DefaultHTTPServer", DefaultHTTPServer__)
+    DefaultHTTPServer = NewType("DefaultHTTPServer", DefaultHTTPServer__)  # type: ignore
+    # ^nesting NewType is not technically allowed and pyright will complain,
+    # but we should try to be robust to it anyways.
 
     def make_http_server(y: int) -> DefaultHTTPServer:
         return DefaultHTTPServer(DefaultHTTPServer__(DefaultHTTPServer_(y)))

--- a/tests/test_py311_generated/test_errors_generated.py
+++ b/tests/test_py311_generated/test_errors_generated.py
@@ -170,10 +170,9 @@ def test_similar_arguments_basic() -> None:
         tyro.cli(Class, args="--reward.trac".split(" "))
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
 
-    # --reward.track should appear in both the usage string and as a similar argument.
     assert error.count("--reward.track") == 1
     assert error.count("--help") == 1
 
@@ -196,7 +195,7 @@ def test_similar_arguments_subcommands() -> None:
         tyro.cli(ClassA | ClassB, args="--reward.trac".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track") == 1
     assert error.count("--help") == 3
@@ -221,7 +220,7 @@ def test_similar_arguments_subcommands_multiple() -> None:
         tyro.cli(ClassA | ClassB, args="--fjdkslaj --reward.trac".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Arguments similar to --reward.trac" in error
     assert error.count("--reward.track {True,False}") == 1
     assert error.count("--reward.trace INT") == 1
@@ -247,7 +246,7 @@ def test_similar_arguments_subcommands_multiple_contains_match() -> None:
         tyro.cli(ClassA | ClassB, args="--rd.trac".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track {True,False}") == 1
     assert error.count("--reward.trace INT") == 1
@@ -273,7 +272,7 @@ def test_similar_arguments_subcommands_multiple_contains_match_alt() -> None:
         tyro.cli(ClassA | ClassB, args="--track".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track {True,False}") == 1
     assert (
@@ -315,7 +314,7 @@ def test_similar_arguments_subcommands_overflow_different() -> None:
         tyro.cli(ClassA | ClassB, args="--track".split(" "))  # type: ignore
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track") == 10
     assert "[...]" not in error
@@ -389,7 +388,7 @@ def test_similar_arguments_subcommands_overflow_same() -> None:
         )
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Perhaps you meant:" in error
     assert error.count("--reward.track") == 1
     assert "[...]" in error
@@ -454,7 +453,7 @@ def test_similar_arguments_subcommands_overflow_same_startswith_multiple() -> No
         )
 
     error = target.getvalue()
-    assert "Unrecognized argument" in error
+    assert "Unrecognized option" in error
     assert "Arguments similar to --track" in error
     assert error.count("--rewar") == 1
     assert "rewarde" not in error

--- a/tests/test_py311_generated/test_helptext_generated.py
+++ b/tests/test_py311_generated/test_helptext_generated.py
@@ -11,8 +11,10 @@ from typing import (
     Generic,
     List,
     Literal,
+    NotRequired,
     Optional,
     Tuple,
+    TypedDict,
     TypeVar,
     cast,
 )
@@ -423,12 +425,18 @@ def test_multiple_subparsers_helptext() -> None:
             default_factory=Subcommand3
         )
 
+        d: bool = False
+
     helptext = get_helptext(MultipleSubparsers)
 
     assert "2% milk." in helptext
     assert "Field a description." in helptext
     assert "Field b description." not in helptext
     assert "Field c description." not in helptext
+
+    # Not enough args for usage shortening to kick in.
+    assert "[OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
 
     helptext = get_helptext(
         MultipleSubparsers, args=["a:subcommand1", "b:subcommand1", "--help"]
@@ -439,6 +447,80 @@ def test_multiple_subparsers_helptext() -> None:
     assert "Field b description." not in helptext
     assert "Field c description." in helptext
     assert "(default: c:subcommand3)" in helptext
+
+    # Not enough args for usage shortening to kick in.
+    assert "[OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND1 OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
+
+
+def test_multiple_subparsers_helptext_shortened_usage() -> None:
+    @dataclasses.dataclass
+    class Subcommand1:
+        """2% milk."""  # % symbol is prone to bugs in argparse.
+
+        a: int = 0
+        b: int = 0
+        c: int = 0
+        d: int = 0
+        e: int = 0
+
+    @dataclasses.dataclass
+    class Subcommand2:
+        a: int = 0
+        b: int = 0
+        c: int = 0
+        d: int = 0
+        e: int = 0
+
+    @dataclasses.dataclass
+    class Subcommand3:
+        a: int = 0
+        b: int = 0
+        c: int = 0
+        d: int = 0
+        e: int = 0
+
+    @dataclasses.dataclass
+    class MultipleSubparsers:
+        # Field a description.
+        a: Subcommand1 | Subcommand2 | Subcommand3
+        # Field b description.
+        b: Subcommand1 | Subcommand2 | Subcommand3
+        # Field c description.
+        c: Subcommand1 | Subcommand2 | Subcommand3 = dataclasses.field(
+            default_factory=Subcommand3
+        )
+
+        d: bool = False
+        f: bool = False
+        g: bool = False
+        h: bool = False
+        i: bool = False
+
+    helptext = get_helptext(MultipleSubparsers)
+
+    assert "2% milk." in helptext
+    assert "Field a description." in helptext
+    assert "Field b description." not in helptext
+    assert "Field c description." not in helptext
+
+    assert "[OPTIONS]" in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
+
+    helptext = get_helptext(
+        MultipleSubparsers, args=["a:subcommand1", "b:subcommand1", "--help"]
+    )
+
+    assert "2% milk." in helptext
+    assert "Field a description." not in helptext
+    assert "Field b description." not in helptext
+    assert "Field c description." in helptext
+    assert "(default: c:subcommand3)" in helptext
+
+    assert "[OPTIONS]" not in helptext
+    assert "[B:SUBCOMMAND1 OPTIONS]" in helptext
+    assert "[B:SUBCOMMAND2 OPTIONS]" not in helptext
 
 
 def test_optional_helptext() -> None:
@@ -853,3 +935,11 @@ def test_append_with_default() -> None:
 
     help = get_helptext(f)
     assert "repeatable, appends to: 'hello world' hello" in help, help
+
+
+def test_typeddict_exclude() -> None:
+    class Special(TypedDict):
+        x: NotRequired[int]
+
+    help = get_helptext(Special)
+    assert "unset by default" in help, help

--- a/tests/test_py311_generated/test_missing_generated.py
+++ b/tests/test_py311_generated/test_missing_generated.py
@@ -1,6 +1,7 @@
 """Tests for tyro.MISSING."""
-
+import contextlib
 import dataclasses
+import io
 from typing import Tuple
 
 import pytest
@@ -12,8 +13,15 @@ def test_missing() -> None:
     def main(a: int = 5, b: int = tyro.MISSING, c: int = 3) -> Tuple[int, int, int]:
         return a, b, c
 
-    with pytest.raises(SystemExit):
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stdout(target):
         tyro.cli(main, args=[])
+    message = target.getvalue()
+    assert "Required options" in message
+    assert "Argument helptext" in message
+    assert "--a INT" not in message
+    assert "--b INT" in message
+    assert "(required)" in message
     assert tyro.cli(main, args=["--b", "7"]) == (5, 7, 3)
 
 

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -387,7 +387,9 @@ def test_subparser_with_default_and_newtype() -> None:
         y: int
 
     DefaultHTTPServer__ = NewType("DefaultHTTPServer__", DefaultHTTPServer_)
-    DefaultHTTPServer = NewType("DefaultHTTPServer", DefaultHTTPServer__)
+    DefaultHTTPServer = NewType("DefaultHTTPServer", DefaultHTTPServer__)  # type: ignore
+    # ^nesting NewType is not technically allowed and pyright will complain,
+    # but we should try to be robust to it anyways.
 
     def make_http_server(y: int) -> DefaultHTTPServer:
         return DefaultHTTPServer(DefaultHTTPServer__(DefaultHTTPServer_(y)))
@@ -526,7 +528,9 @@ def test_subparser_with_default_bad_alt() -> None:
         c: int
 
     with pytest.warns(UserWarning):
-        assert tyro.cli(A | B, default=C(3), args=["c", "--c", "2"]) == C(2)  # type: ignore
+        assert tyro.cli(
+            A | Annotated[B, None], default=C(3), args=["c", "--c", "2"]
+        ) == C(2)  # type: ignore
 
 
 def test_optional_subparser() -> None:

--- a/tests/test_py311_generated/test_union_from_mapping_generated.py
+++ b/tests/test_py311_generated/test_union_from_mapping_generated.py
@@ -35,7 +35,7 @@ def test_union_from_mapping_in_function():
     else:
         ConfigUnion = tyro.extras.subcommand_type_from_defaults(base_configs)
 
-    def main(config: ConfigUnion, flag: bool = False) -> Optional[A]:
+    def main(config: ConfigUnion, flag: bool = False) -> Optional[A]:  # type: ignore
         if flag:
             return config
         return None

--- a/tests/test_union_from_mapping.py
+++ b/tests/test_union_from_mapping.py
@@ -35,7 +35,7 @@ def test_union_from_mapping_in_function():
     else:
         ConfigUnion = tyro.extras.subcommand_type_from_defaults(base_configs)
 
-    def main(config: ConfigUnion, flag: bool = False) -> Optional[A]:
+    def main(config: ConfigUnion, flag: bool = False) -> Optional[A]:  # type: ignore
         if flag:
             return config
         return None


### PR DESCRIPTION
Addresses #113!

Before:
![image](https://github.com/brentyi/tyro/assets/6992947/c6bb628b-029a-4cb3-8e3b-daeebdfd92fb)

After:
![image](https://github.com/brentyi/tyro/assets/6992947/fb0508de-8a36-4efe-a47c-64769182ca3a)

The shorter usage is enabled when we have >4 arguments. Some more examples:
![image](https://github.com/brentyi/tyro/assets/6992947/b614c389-2b77-410e-a25c-88595f8ebea2)
![image](https://github.com/brentyi/tyro/assets/6992947/54ebdffb-9f7d-41f8-86d2-d5925b662943)

