### PR TITLE
Rough Draft

### DIFF
--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -67,6 +67,9 @@ class BooleanOptionalAction(argparse.Action):
         for option_string in option_strings:
             _option_strings.append(option_string)
 
+            if option_string.endswith(":None"):
+                continue
+
             if option_string.startswith("--"):
                 if "." not in option_string:
                     option_string = (
@@ -421,6 +424,11 @@ def _rule_generate_helptext(
     help_parts = []
 
     primary_help = arg.field.helptext
+    if arg.field.call_argname == "None":
+        if arg.extern_prefix:
+            primary_help = f"set {arg.extern_prefix} to None"
+        else:
+            primary_help = f"set options to None"
 
     if primary_help is None and _markers.Positional in arg.field.markers:
         primary_help = _strings.make_field_name(

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -67,7 +67,7 @@ class BooleanOptionalAction(argparse.Action):
         for option_string in option_strings:
             _option_strings.append(option_string)
 
-            if option_string.endswith(":None"):
+            if option_string == "--None" or option_string.endswith(":None"):
                 continue
 
             if option_string.startswith("--"):

--- a/src/tyro/_calling.py
+++ b/src/tyro/_calling.py
@@ -53,67 +53,6 @@ def call_from_args(
         ), f"{prefixed_field_name} not in {value_from_prefixed_field_name}"
         return value_from_prefixed_field_name[prefixed_field_name]
 
-    def parse_standard_arg(
-            prefixed_field_name: str,
-            field: _fields.FieldDefinition,
-            any_arguments_provided: bool,
-            value_from_prefixed_field_name: Dict[str, Any],
-            consumed_keywords: Set[str],
-            arg_from_prefixed_field_name: Dict[str, _arguments.ArgumentDefinition],
-            get_value_from_arg: Callable[[str], Any]
-    ) -> Tuple[Any, bool]:
-        assert prefixed_field_name not in consumed_keywords
-
-        # Standard arguments.
-        arg = arg_from_prefixed_field_name[prefixed_field_name]
-        name_maybe_prefixed = prefixed_field_name
-        consumed_keywords.add(name_maybe_prefixed)
-        if not arg.lowered.is_fixed():
-            value = get_value_from_arg(name_maybe_prefixed)
-
-            if value in _fields.MISSING_SINGLETONS:
-                value = arg.field.default
-
-                # Consider a function with a positional sequence argument:
-                #
-                #     def f(x: tuple[int, ...], /)
-                #
-                # If we run this script with no arguments, we should interpret this
-                # as empty input for x. But the argparse default will be a MISSING
-                # value, and the field default will be inspect.Parameter.empty.
-                if (
-                    value in _fields.MISSING_SINGLETONS
-                    and field.is_positional_call()
-                    and arg.lowered.nargs in ("?", "*")
-                ):
-                    value = []
-            else:
-                any_arguments_provided = True
-                if arg.lowered.nargs == "?":
-                    # Special case for optional positional arguments: this is the
-                    # only time that arguments don't come back as a list.
-                    value = [value]
-
-                try:
-                    assert arg.lowered.instantiator is not None
-                    value = arg.lowered.instantiator(value)
-                except ValueError as e:
-                    raise InstantiationError(
-                        e.args[0],
-                        arg,
-                    )
-        else:
-            assert arg.field.default not in _fields.MISSING_SINGLETONS
-            value = arg.field.default
-            parsed_value = value_from_prefixed_field_name.get(prefixed_field_name)
-            if parsed_value not in _fields.MISSING_SINGLETONS:
-                raise InstantiationError(
-                    f"{arg.lowered.name_or_flag} was passed in, but"
-                    " is a fixed argument that cannot be parsed",
-                    arg,
-                )
-        return value, any_arguments_provided
-
     arg_from_prefixed_field_name: Dict[str, _arguments.ArgumentDefinition] = {}
     for arg in parser_definition.args:
         arg_from_prefixed_field_name[
@@ -131,15 +70,56 @@ def call_from_args(
         # Resolve field type.
         field_type = field.type_or_callable
         if prefixed_field_name in arg_from_prefixed_field_name:
-            value, any_arguments_provided = parse_standard_arg(
-                prefixed_field_name,
-                field,
-                any_arguments_provided,
-                value_from_prefixed_field_name,
-                consumed_keywords,
-                arg_from_prefixed_field_name,
-                get_value_from_arg
-            )
+            assert prefixed_field_name not in consumed_keywords
+
+            # Standard arguments.
+            arg = arg_from_prefixed_field_name[prefixed_field_name]
+            name_maybe_prefixed = prefixed_field_name
+            consumed_keywords.add(name_maybe_prefixed)
+            if not arg.lowered.is_fixed():
+                value = get_value_from_arg(name_maybe_prefixed)
+
+                if value in _fields.MISSING_SINGLETONS:
+                    value = arg.field.default
+
+                    # Consider a function with a positional sequence argument:
+                    #
+                    #     def f(x: tuple[int, ...], /)
+                    #
+                    # If we run this script with no arguments, we should interpret this
+                    # as empty input for x. But the argparse default will be a MISSING
+                    # value, and the field default will be inspect.Parameter.empty.
+                    if (
+                        value in _fields.MISSING_SINGLETONS
+                        and field.is_positional_call()
+                        and arg.lowered.nargs in ("?", "*")
+                    ):
+                        value = []
+                else:
+                    any_arguments_provided = True
+                    if arg.lowered.nargs == "?":
+                        # Special case for optional positional arguments: this is the
+                        # only time that arguments don't come back as a list.
+                        value = [value]
+
+                    try:
+                        assert arg.lowered.instantiator is not None
+                        value = arg.lowered.instantiator(value)
+                    except ValueError as e:
+                        raise InstantiationError(
+                            e.args[0],
+                            arg,
+                        )
+            else:
+                assert arg.field.default not in _fields.MISSING_SINGLETONS
+                value = arg.field.default
+                parsed_value = value_from_prefixed_field_name.get(prefixed_field_name)
+                if parsed_value not in _fields.MISSING_SINGLETONS:
+                    raise InstantiationError(
+                        f"{arg.lowered.name_or_flag} was passed in, but"
+                        " is a fixed argument that cannot be parsed",
+                        arg,
+                    )
         elif (
             prefixed_field_name
             in parser_definition.helptext_from_nested_class_field_name
@@ -213,25 +193,26 @@ def call_from_args(
         else:
             kwargs[field.call_argname] = value
 
-        if f"{prefixed_field_name}:None" in arg_from_prefixed_field_name:
-            value, any_arguments_provided = parse_standard_arg(
-                f"{prefixed_field_name}:None",
-                field,
-                any_arguments_provided,
-                value_from_prefixed_field_name,
-                consumed_keywords,
-                arg_from_prefixed_field_name,
-                get_value_from_arg
-            )
-            if value is True:
-                if kwargs[field.call_argname] != field.default:
-                    conflicts = "\n  --".join([kw for kw in consumed_keywords if kw.startswith(f"{prefixed_field_name}.")])
+    none_field = kwargs.get('None')
+    if none_field is not None:
+        del kwargs['None']
+        if none_field:
+            conflicts: list = []
+            field_name_prefix += ':' if field_name_prefix else ''
+            for field in field_list:
+                if field.call_argname != "None" and kwargs[field.call_argname] != field.default:
+                    if _resolver.unwrap_origin_strip_extras(field.type_or_callable) is not Union:
+                        conflicts.append(f'--{field_name_prefix}{field.call_argname}*')
+                    else:
+                        conflicts.append(f'{field_name_prefix}{field.call_argname}*')
+            if conflicts:
+                    conflicts = "\n  ".join(conflicts)
                     raise InstantiationError(
-                        f"--{field.call_argname}:None is mutually exclusive with --{field.call_argname}.* parameters. Found:\n"
-                        f"  --{conflicts}",
+                        f"--{field_name_prefix}None is mutually exclusive with below option(s):\n"
+                        f"  {conflicts}",
                         field_name_prefix,
                     )
-                kwargs[field.call_argname] = None
+            return None, consumed_keywords  # type: ignore
 
     # Logic for _markers._OPTIONAL_GROUP.
     is_missing_list = [
@@ -288,11 +269,6 @@ def call_from_args(
         if field_name_prefix == "":
             # Don't catch any errors for the "root" field. If main() in tyro.cli(main)
             # raises a ValueError, this shouldn't be caught.
-            if kwargs.get('None') is not None:
-                if kwargs.get('None'):
-                    kwargs = {}
-                else:
-                    del kwargs['None']
             return unwrapped_f(*positional_args, **kwargs), consumed_keywords  # type: ignore
         else:
             # Try to catch ValueErrors raised by field constructors.

--- a/src/tyro/_calling.py
+++ b/src/tyro/_calling.py
@@ -288,6 +288,11 @@ def call_from_args(
         if field_name_prefix == "":
             # Don't catch any errors for the "root" field. If main() in tyro.cli(main)
             # raises a ValueError, this shouldn't be caught.
+            if kwargs.get('None') is not None:
+                if kwargs.get('None'):
+                    kwargs = {}
+                else:
+                    del kwargs['None']
             return unwrapped_f(*positional_args, **kwargs), consumed_keywords  # type: ignore
         else:
             # Try to catch ValueErrors raised by field constructors.

--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -312,7 +312,7 @@ def _cli_impl(
         f = [o for o in get_args(typ) if o is not type(None)][0]
         for annotate in annotations:
             f = annotate[f] # type: ignore
-        f = Annotated[f, _fields.ADD_NONE_FIELD_ANNOTATION_STR] # type: ignore
+        f = Annotated[f, _fields.ADD_NONE_FIELD_ANNOTATION_STR, conf._markers._OPTIONAL_GROUP] # type: ignore
 
     # We wrap our type with a dummy dataclass if it can't be treated as a nested type.
     # For example: passing in f=int will result in a dataclass with a single field

--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -307,7 +307,7 @@ def _cli_impl(
         and len(get_args(typ)) <= 2
     ):
         f = [o for o in get_args(typ) if o is not type(None)][0]
-        for annotate in annotations + (conf._markers._HAS_NONE_FIELD,):
+        for annotate in annotations:
             f = annotate[f] # type: ignore
 
     # We wrap our type with a dummy dataclass if it can't be treated as a nested type.

--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -299,6 +299,7 @@ def _cli_impl(
         _fields.MISSING_NONPROP if default is None else default
     )
 
+    f = conf._markers._ROOT_FIELD[f] # type: ignore
     # We wrap our type with a dummy dataclass if it can't be treated as a nested type.
     # For example: passing in f=int will result in a dataclass with a single field
     # typed as int.
@@ -309,7 +310,7 @@ def _cli_impl(
         )
         f = dataclasses.make_dataclass(
             cls_name="dummy",
-            fields=[(_strings.dummy_field_name, cast(type, f), dummy_field)],
+            fields=[(_strings.dummy_field_name, conf._markers._ROOT_FIELD[cast(type, f)], dummy_field)],
             frozen=True,
         )
         default_instance_internal = f(default_instance_internal)  # type: ignore

--- a/src/tyro/_docstrings.py
+++ b/src/tyro/_docstrings.py
@@ -200,7 +200,11 @@ def get_field_docstring(cls: Type, field_name: str) -> Optional[str]:
     if final_token_on_line.token_type == tokenize.COMMENT:
         comment: str = final_token_on_line.content
         assert comment.startswith("#")
-        return _strings.remove_single_line_breaks(comment[1:].strip())
+        if comment.startswith("#:"):
+            return _strings.remove_single_line_breaks(comment[2:].strip())
+        else:
+            return _strings.remove_single_line_breaks(comment[1:].strip())
+
 
     # Check for comments that come before the field. This is intentionally written to
     # support comments covering multiple (grouped) fields, for example:
@@ -245,7 +249,10 @@ def get_field_docstring(cls: Type, field_name: str) -> Optional[str]:
         ):
             (comment_token,) = actual_line_tokens
             assert comment_token.content.startswith("#")
-            comments.append(comment_token.content[1:].strip())
+            if comment_token.content.startswith("#:"):
+                comments.append(comment_token.content[2:].strip())
+            else:
+                comments.append(comment_token.content[1:].strip())
         elif len(comments) > 0:
             # Comments should be contiguous.
             break

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -140,6 +140,12 @@ class FieldDefinition:
             markers=self.markers.union(markers),
         )
 
+    def remove_markers(self, markers: Tuple[Any, ...]) -> FieldDefinition:
+        return dataclasses.replace(
+            self,
+            markers=self.markers - set(markers),
+        )
+
     def is_positional(self) -> bool:
         """Returns True if the argument should be positional in the commandline."""
         return (
@@ -370,6 +376,9 @@ def _try_field_list_from_callable(
     f: Union[Callable, TypeForm[Any]],
     default_instance: DefaultInstance,
 ) -> Union[List[FieldDefinition], UnsupportedNestedTypeMessage]:
+    root_field: bool = (
+        _markers._ROOT_FIELD in _resolver.unwrap_annotated(f, _markers._Marker)[1]
+    )
     f, found_subcommand_configs = _resolver.unwrap_annotated(
         f, conf._confstruct._SubcommandConfiguration
     )
@@ -382,6 +391,17 @@ def _try_field_list_from_callable(
     f = _resolver.unwrap_newtype_and_narrow_subtypes(f, default_instance)
     f = _resolver.narrow_collection_types(f, default_instance)
     f_origin = _resolver.unwrap_origin_strip_extras(cast(TypeForm, f))
+
+    # For Union[T | None], try to evaluate as T with "added none field"
+    try_add_none_field = (
+        not root_field
+        and get_origin(f) in (Union, Optional)
+        and type(None) in get_args(f)
+        and len(get_args(f)) == 2
+    )
+
+    if try_add_none_field:
+        f = [o for o in get_args(f) if o is not type(None)][0] # type: ignore
 
     # If `f` is a type:
     #     1. Set cls to the type.
@@ -402,15 +422,29 @@ def _try_field_list_from_callable(
 
     # Try field generation from class inputs.
     if cls is not None:
-        for match, field_list_from_class in (
+        for is_match, field_list_from_class in (
             (is_typeddict, _field_list_from_typeddict),
             (_resolver.is_namedtuple, _field_list_from_namedtuple),
             (_resolver.is_dataclass, _field_list_from_dataclass),
             (_is_attrs, _field_list_from_attrs),
             (_is_pydantic, _field_list_from_pydantic),
         ):
-            if match(cls):
-                return field_list_from_class(cls, default_instance)
+            if is_match(cls):
+                fields = field_list_from_class(cls, default_instance)
+                if not isinstance(fields, UnsupportedNestedTypeMessage) and try_add_none_field:
+                    fields.append(FieldDefinition.make( # type: ignore
+                        name="None",
+                        type_or_callable=bool,
+                        default=False,
+                        helptext=None,
+                    ))
+                return fields
+
+    # Restore original type information if it was stripped off
+    if try_add_none_field:
+        f = Optional[f] # type: ignore
+        f_origin = _resolver.unwrap_origin_strip_extras(cast(TypeForm, f))
+        cls = None
 
     # Standard container types. These are different because they can be nested structures
     # if they contain other nested types (eg Tuple[Struct, Struct]), or treated as

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -445,7 +445,7 @@ def _try_field_list_from_callable(
 
                             fields[i] = dataclasses.replace(
                                 fields[i],
-                                type_or_callable=Annotated[option, ADD_NONE_FIELD_ANNOTATION_STR]
+                                type_or_callable=Annotated[option, ADD_NONE_FIELD_ANNOTATION_STR, _markers._OPTIONAL_GROUP]
                             )
 
                     if add_none_field:

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -311,17 +311,7 @@ def handle_field(
             extern_prefix=_strings.make_field_name([extern_prefix, field.extern_name]),
         )
         if subparsers_attempt is not None:
-            type_, annotations = _resolver.unwrap_annotated(field.type_or_callable)
             if (
-                _markers.AvoidNoneSubcommands in field.markers
-                and _markers._HAS_NONE_FIELD not in annotations
-                and type(None) in get_args(type_)
-                and len(get_args(type_)) <= 2
-            ):
-                # Don't make a subparser.
-                option = [o for o in get_args(type_) if o is not type(None)][0] # type: ignore
-                field = dataclasses.replace(field, type_or_callable=_markers._HAS_NONE_FIELD[option])
-            elif (
                 not subparsers_attempt.required
                 and _markers.AvoidSubcommands in field.markers
             ):

--- a/src/tyro/_strings.py
+++ b/src/tyro/_strings.py
@@ -59,7 +59,10 @@ def make_field_name(parts: Sequence[str]) -> str:
     out: List[str] = []
     for p in _strip_dummy_field_names(parts):
         out.extend(map(replace_delimeter_in_part, p.split(".")))
-    return ".".join(out)
+    if not out or out[-1] != "None" or len(out) == 1:
+        return ".".join(out)
+    else:
+        return ":".join([".".join(out[:-1]), "None"])
 
 
 def make_subparser_dest(name: str) -> str:

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -11,6 +11,7 @@ Features here are supported, but generally unnecessary and should be used sparin
 from ._confstruct import arg as arg
 from ._confstruct import subcommand as subcommand
 from ._markers import AvoidSubcommands as AvoidSubcommands
+from ._markers import AvoidNoneSubcommands as AvoidNoneSubcommands
 from ._markers import ConsolidateSubcommandArgs as ConsolidateSubcommandArgs
 from ._markers import Fixed as Fixed
 from ._markers import FlagConversionOff as FlagConversionOff

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -11,6 +11,7 @@ Features here are supported, but generally unnecessary and should be used sparin
 from ._confstruct import arg as arg
 from ._confstruct import subcommand as subcommand
 from ._markers import AvoidSubcommands as AvoidSubcommands
+from ._markers import HideNoneSubcommands as HideNoneSubcommands
 from ._markers import AvoidNoneSubcommands as AvoidNoneSubcommands
 from ._markers import ConsolidateSubcommandArgs as ConsolidateSubcommandArgs
 from ._markers import Fixed as Fixed

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -66,7 +66,7 @@ applied to nested types."""
 
 AvoidNoneSubcommands = Annotated[T, None]
 """Avoid creating None subcommands when a NoneType is present in a Union. Instead,
-a command can be set to None using --cmd:None"""
+a command can be set to None using `--cmd:None`."""
 
 ConsolidateSubcommandArgs = Annotated[T, None]
 """Consolidate arguments applied to subcommands. Makes CLI less sensitive to argument

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -32,8 +32,8 @@ _UnpackKwargsCall = Annotated[T, None]
 # Private marker.
 _OPTIONAL_GROUP = Annotated[T, None]
 
-# Private marker for root field.
-_ROOT_FIELD = Annotated[T, None]
+# Private marker for added None field.
+_HAS_NONE_FIELD = Annotated[T, None]
 
 # TODO: the verb tenses here are inconsistent, naming could be revisited.
 # Perhaps Suppress should be Suppressed? But SuppressedFixed would be weird.

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -32,9 +32,6 @@ _UnpackKwargsCall = Annotated[T, None]
 # Private marker.
 _OPTIONAL_GROUP = Annotated[T, None]
 
-# Private marker for added None field.
-_HAS_NONE_FIELD = Annotated[T, None]
-
 # TODO: the verb tenses here are inconsistent, naming could be revisited.
 # Perhaps Suppress should be Suppressed? But SuppressedFixed would be weird.
 
@@ -63,6 +60,9 @@ This simplifies CLI interfaces, but makes them less expressive.
 
 Can be used directly on union types, `AvoidSubcommands[Union[...]]`, or recursively
 applied to nested types."""
+
+HideNoneSubcommands = Annotated[T, None]
+"""Hide None subcommands when a NoneType is present in a Union."""
 
 AvoidNoneSubcommands = Annotated[T, None]
 """Avoid creating None subcommands when a NoneType is present in a Union. Instead,

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -32,6 +32,9 @@ _UnpackKwargsCall = Annotated[T, None]
 # Private marker.
 _OPTIONAL_GROUP = Annotated[T, None]
 
+# Private marker for root field.
+_ROOT_FIELD = Annotated[T, None]
+
 # TODO: the verb tenses here are inconsistent, naming could be revisited.
 # Perhaps Suppress should be Suppressed? But SuppressedFixed would be weird.
 
@@ -60,6 +63,10 @@ This simplifies CLI interfaces, but makes them less expressive.
 
 Can be used directly on union types, `AvoidSubcommands[Union[...]]`, or recursively
 applied to nested types."""
+
+AvoidNoneSubcommands = Annotated[T, None]
+"""Avoid creating None subcommands when a NoneType is present in a Union. Instead,
+a command can be set to None using --cmd:None"""
 
 ConsolidateSubcommandArgs = Annotated[T, None]
 """Consolidate arguments applied to subcommands. Makes CLI less sensitive to argument


### PR DESCRIPTION
Hey @brentyi!

Here's a rough draft of what we covered in #60. I have to set this down for now but wanted to drop this here in case you could pull it across the finish line 😄 

It mostly works. I haven't added tests etc. but did make sure all the existing tests pass. It should provide a decent feel for what we're trying to accomplish. There is still cleanup needed around required field handling and associated help text, lots of testing, etc.

One additional item I added was "HideNoneSubcommands". I think this would be really nice to have as well. For our use case, `None` is only intended as an invalid field that can be overridden (i.e., not used to invalidate an already valid object).

Mutual exclusion I took the stance of using defaults, there are probably better ways to enforce this.

Lastly, it seems with the current implementation most of this will need to be constrained to the field list generation. There may be better ways to accomplish this. I had issues with types getting interpreted differently if I tried to resolve it at a higher level (i.e., mainly `field_list_from_callable`).