### PR TITLE
Fix: `tyro.cli` description

### DIFF
--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -237,9 +237,6 @@ class ParserSpecification:
     ) -> None:
         """Create defined arguments and subparsers."""
 
-        # Generate helptext.
-        parser.description = self.description
-
         # Make argument groups.
         def format_group_name(prefix: str) -> str:
             return (prefix + " options").strip()


### PR DESCRIPTION
Fixes #123.

An unintended side-effect of #118 introduced a regression that broke the `tyro.cli(description=...)` field for hierarchical configs. This was due to an extraneous setting of the `argparse.ArgumentParser.description` field, which was causing the description to be set by the description of a leaf node in the tree.

The description was initially set in the `.apply()` method here: https://github.com/brentyi/tyro/blob/30803e8a4ee871693f7b021be84265780ddc0146/src/tyro/_parsers.py#L201

Later, there is a call into the `.apply_args()` method that sets the description again:
https://github.com/brentyi/tyro/blob/30803e8a4ee871693f7b021be84265780ddc0146/src/tyro/_parsers.py#L241

This is problematic after #118 because we now recurse into the `.apply_args()` method: https://github.com/brentyi/tyro/blob/30803e8a4ee871693f7b021be84265780ddc0146/src/tyro/_parsers.py#L291

I have a strong feeling I am overlooking something. I will see if tests pass or not. I can also add a test if you want to check the description field.