### PR TITLE
Fix inconsistency between `type[T]` and `typing.Type[T]` annotations

### DIFF
--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -417,7 +417,7 @@ def apply_type_from_typevar(
                 shim_table[types.UnionType] = Union  # type: ignore
 
             for new, old in shim_table.items():
-                if isinstance(typ, new) or origin is new:  # type: ignore
+                if origin is new:  # type: ignore
                     typ = old.__getitem__(args)  # type: ignore
 
         new_args = tuple(apply_type_from_typevar(x, type_from_typevar) for x in args)

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -18,6 +18,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -409,6 +410,7 @@ def apply_type_from_typevar(
                 dict: Dict,
                 set: Set,
                 frozenset: FrozenSet,
+                type: Type,
             }
             if hasattr(types, "UnionType"):  # type: ignore
                 # PEP 604. Requires Python 3.10.

--- a/tests/test_new_style_annotations_min_py310.py
+++ b/tests/test_new_style_annotations_min_py310.py
@@ -1,4 +1,5 @@
-from typing import Any, Literal
+import dataclasses
+from typing import Any, Literal, Type
 
 import pytest
 
@@ -62,3 +63,17 @@ def test_super_nested():
     ]
     with pytest.raises(SystemExit):
         tyro.cli(main, args=["--help"])
+
+
+def test_type():
+    class Thing: ...
+
+    class SubThing(Thing): ...
+
+    @dataclasses.dataclass
+    class Config:
+        foo: int
+        barr: type[Thing] = dataclasses.field(default=SubThing)
+        bar: type[Thing] = dataclasses.field(default=SubThing)
+
+    assert tyro.cli(Config, args=["--foo", "5"]) == Config(5, SubThing, SubThing)

--- a/tests/test_new_style_annotations_min_py310.py
+++ b/tests/test_new_style_annotations_min_py310.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Literal, Type
+from typing import Any, Literal
 
 import pytest
 
@@ -67,6 +67,7 @@ def test_super_nested():
 
 def test_type():
     """Test adapted from mirceamironenco: https://github.com/brentyi/tyro/issues/164"""
+
     class Thing: ...
 
     class SubThing(Thing): ...

--- a/tests/test_new_style_annotations_min_py310.py
+++ b/tests/test_new_style_annotations_min_py310.py
@@ -66,6 +66,7 @@ def test_super_nested():
 
 
 def test_type():
+    """Test adapted from mirceamironenco: https://github.com/brentyi/tyro/issues/164"""
     class Thing: ...
 
     class SubThing(Thing): ...

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -624,7 +624,13 @@ def test_argconf_help() -> None:
     @dataclasses.dataclass
     class Struct:
         a: Annotated[
-            int, tyro.conf.arg(name="nice", help="Hello world", metavar="NUMBER")
+            int,
+            tyro.conf.arg(
+                name="nice",
+                help="Hello world",
+                help_behavior_hint="(hint)",
+                metavar="NUMBER",
+            ),
         ] = 5
         b: tyro.conf.Suppress[str] = "7"
 
@@ -635,6 +641,39 @@ def test_argconf_help() -> None:
     assert "Hello world" in helptext
     assert "INT" not in helptext
     assert "NUMBER" in helptext
+    assert "(hint)" in helptext
+    assert "(default: 5)" not in helptext
+    assert "--x.a" not in helptext
+    assert "--x.nice" in helptext
+    assert "--x.b" not in helptext
+
+    assert tyro.cli(main, args=[]) == 5
+    assert tyro.cli(main, args=["--x.nice", "3"]) == 3
+
+
+def test_argconf_help_behavior_hint_lambda() -> None:
+    @dataclasses.dataclass
+    class Struct:
+        a: Annotated[
+            int,
+            tyro.conf.arg(
+                name="nice",
+                help="Hello world",
+                help_behavior_hint=lambda default: f"(default value: {default})",
+                metavar="NUMBER",
+            ),
+        ] = 5
+        b: tyro.conf.Suppress[str] = "7"
+
+    def main(x: Any = Struct()) -> int:
+        return x.a
+
+    helptext = get_helptext_with_checks(main)
+    assert "Hello world" in helptext
+    assert "INT" not in helptext
+    assert "NUMBER" in helptext
+    assert "(default value: 5)" in helptext
+    assert "(default: 5)" not in helptext
     assert "--x.a" not in helptext
     assert "--x.nice" in helptext
     assert "--x.b" not in helptext

--- a/tests/test_py311_generated/test_new_style_annotations_min_py310_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py310_generated.py
@@ -66,6 +66,8 @@ def test_super_nested():
 
 
 def test_type():
+    """Test adapted from mirceamironenco: https://github.com/brentyi/tyro/issues/164"""
+
     class Thing: ...
 
     class SubThing(Thing): ...

--- a/tests/test_py311_generated/test_new_style_annotations_min_py310_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py310_generated.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any, Literal
 
 import pytest
@@ -62,3 +63,17 @@ def test_super_nested():
     ]
     with pytest.raises(SystemExit):
         tyro.cli(main, args=["--help"])
+
+
+def test_type():
+    class Thing: ...
+
+    class SubThing(Thing): ...
+
+    @dataclasses.dataclass
+    class Config:
+        foo: int
+        barr: type[Thing] = dataclasses.field(default=SubThing)
+        bar: type[Thing] = dataclasses.field(default=SubThing)
+
+    assert tyro.cli(Config, args=["--foo", "5"]) == Config(5, SubThing, SubThing)


### PR DESCRIPTION
These should be treated the same in Python >=3.10, but are unfortunately very different objects at runtime. Just accounted for this.

Addresses #164.