### PR TITLE
Feature: Markers: SelectionFromEnumValues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ lint.select = [
 lint.ignore = [
     "E741", # Ambiguous variable name. (l, O, or I)
     "E501",  # Line too long.
+    "E731",  # Do not assign a lambda expression, use a def.
     "PLR2004",  # Magic value used in comparison.
     "PLR0915",  # Too many statements.
     "PLR0913",  # Too many arguments.

--- a/src/tyro/_instantiators.py
+++ b/src/tyro/_instantiators.py
@@ -287,8 +287,9 @@ def instantiator_from_type(
         autochoice_instantiate = lambda x: {"True": True, "False": False}[x]
     elif inspect.isclass(typ) and issubclass(typ, enum.Enum):
         if _markers.EnumChoicesFromValues in markers:
-            choices = tuple(member.value for member in typ)
-            autochoice_instantiate = lambda x: typ(x)
+            value_from_str_choice = {str(member.value): member for member in typ}
+            choices = tuple(value_from_str_choice.keys())
+            autochoice_instantiate = lambda x: value_from_str_choice[x]
         else:
             choices = tuple(typ.__members__.keys())
             autochoice_instantiate = lambda x: typ[x]

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -18,7 +18,7 @@ from ._markers import OmitArgPrefixes as OmitArgPrefixes
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes
 from ._markers import Positional as Positional
 from ._markers import PositionalRequiredArgs as PositionalRequiredArgs
-from ._markers import SelectFromEnumValues as SelectFromEnumValues
+from ._markers import EnumChoicesFromValues as EnumChoicesFromValues
 from ._markers import Suppress as Suppress
 from ._markers import SuppressFixed as SuppressFixed
 from ._markers import UseAppendAction as UseAppendAction

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -12,13 +12,13 @@ from ._confstruct import arg as arg
 from ._confstruct import subcommand as subcommand
 from ._markers import AvoidSubcommands as AvoidSubcommands
 from ._markers import ConsolidateSubcommandArgs as ConsolidateSubcommandArgs
+from ._markers import EnumChoicesFromValues as EnumChoicesFromValues
 from ._markers import Fixed as Fixed
 from ._markers import FlagConversionOff as FlagConversionOff
 from ._markers import OmitArgPrefixes as OmitArgPrefixes
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes
 from ._markers import Positional as Positional
 from ._markers import PositionalRequiredArgs as PositionalRequiredArgs
-from ._markers import EnumChoicesFromValues as EnumChoicesFromValues
 from ._markers import Suppress as Suppress
 from ._markers import SuppressFixed as SuppressFixed
 from ._markers import UseAppendAction as UseAppendAction

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -18,6 +18,7 @@ from ._markers import OmitArgPrefixes as OmitArgPrefixes
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes
 from ._markers import Positional as Positional
 from ._markers import PositionalRequiredArgs as PositionalRequiredArgs
+from ._markers import SelectFromEnumValues as SelectFromEnumValues
 from ._markers import Suppress as Suppress
 from ._markers import SuppressFixed as SuppressFixed
 from ._markers import UseAppendAction as UseAppendAction

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -128,29 +128,29 @@ UseCounterAction = Annotated[T, None]
 """Use "counter" actions for integer arguments. Example usage: `verbose: UseCounterAction[int]`."""
 
 EnumChoicesFromValues = Annotated[T, None]
-"""Populate choices from enum values rather than enum names. The values must be strings.
+"""Populate choices from enum values rather than enum names.
 
-   Example:
-   ```
-        class OutputFormats(enum.StrEnum):
-            JSON = enum.auto()
-            PRETTY = enum.auto()
-            RICH = enum.auto()
-            TOML = enum.auto()
+Example:
+```
+    class OutputFormats(enum.StrEnum):
+        JSON = enum.auto()
+        PRETTY = enum.auto()
+        RICH = enum.auto()
+        TOML = enum.auto()
 
-        @dataclasses.dataclass
-        class Args:
-            display_format: Annotated[
-                OutputFormats, tyro.conf.SelectFromEnumValues
-            ] = OutputFormats.PRETTY
-   ```
+    @dataclasses.dataclass
+    class Args:
+        display_format: Annotated[
+            OutputFormats, tyro.conf.SelectFromEnumValues
+        ] = OutputFormats.PRETTY
+```
 
-   The above will result in `json`, `pretty`, `rich`, and `toml` (all lowercase) as choices,
-   since the auto values for `StrEnum` (Python 3.11+) are lowercase transformations of the
-   names. Without this marker, the choices would be `JSON`, `PRETTY`, `RICH`, and `TOML`.
+The above will result in `json`, `pretty`, `rich`, and `toml` (all lowercase) as choices,
+since the auto values for `StrEnum` (Python 3.11+) are lowercase transformations of the
+names. Without this marker, the choices would be `JSON`, `PRETTY`, `RICH`, and `TOML`.
 
-   Enum aliases are not relevant when this marker is present. The first entry matching the
-   chosen value will be selected.
+Enum aliases are not relevant when this marker is present. The first entry matching the
+chosen value will be selected.
 """
 
 

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -127,6 +127,32 @@ Can be applied to all variable-length sequences (`list[T]`, `Sequence[T]`,
 UseCounterAction = Annotated[T, None]
 """Use "counter" actions for integer arguments. Example usage: `verbose: UseCounterAction[int]`."""
 
+SelectFromEnumValues = Annotated[T, None]
+"""Populate choices from enum values rather than enum names. The values must be strings.
+
+   Example:
+   ```
+        class OutputFormats(enum.StrEnum):
+            JSON = enum.auto()
+            PRETTY = enum.auto()
+            RICH = enum.auto()
+            TOML = enum.auto()
+
+        @dataclasses.dataclass
+        class Args:
+            display_format: Annotated[
+                OutputFormats, tyro.conf.SelectFromEnumValues
+            ] = OutputFormats.PRETTY
+   ```
+
+   The above will result in `json`, `pretty`, `rich`, and `toml` (all lowercase) as choices,
+   since the auto values for `StrEnum` (Python 3.11+) are lowercase transformations of the
+   names. Without this marker, the choices would be `JSON`, `PRETTY`, `RICH`, and `TOML`.
+
+   Enum aliases are not relevant when this marker is present. The first entry matching the
+   chosen value will be selected.
+"""
+
 
 CallableType = TypeVar("CallableType", bound=Callable)
 

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -141,7 +141,7 @@ Example:
     @dataclasses.dataclass
     class Args:
         display_format: Annotated[
-            OutputFormats, tyro.conf.SelectFromEnumValues
+            OutputFormats, tyro.conf.EnumChoicesFromValues
         ] = OutputFormats.PRETTY
 ```
 

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -127,7 +127,7 @@ Can be applied to all variable-length sequences (`list[T]`, `Sequence[T]`,
 UseCounterAction = Annotated[T, None]
 """Use "counter" actions for integer arguments. Example usage: `verbose: UseCounterAction[int]`."""
 
-SelectFromEnumValues = Annotated[T, None]
+EnumChoicesFromValues = Annotated[T, None]
 """Populate choices from enum values rather than enum names. The values must be strings.
 
    Example:

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -321,11 +321,11 @@ def test_enum_values() -> None:
 
     @dataclasses.dataclass
     class EnumClassA:
-        color: Annotated[Color, tyro.conf.SelectFromEnumValues]
+        color: Annotated[Color, tyro.conf.EnumChoicesFromValues]
 
     @dataclasses.dataclass
     class EnumClassB:
-        color: Annotated[Color, tyro.conf.SelectFromEnumValues] = Color.GREEN
+        color: Annotated[Color, tyro.conf.EnumChoicesFromValues] = Color.GREEN
 
     assert tyro.cli(EnumClassA, args=["--color", "red"]) == EnumClassA(color=Color.RED)
     assert tyro.cli(EnumClassB, args=[]) == EnumClassB()
@@ -413,7 +413,7 @@ def test_literal_enum_values() -> None:
     class A:
         x: Annotated[
             Literal[Color.RED, Color.GREEN],
-            tyro.conf.SelectFromEnumValues,
+            tyro.conf.EnumChoicesFromValues,
         ]
 
     assert tyro.cli(A, args=["--x", "red"]) == A(x=Color.RED)

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -333,6 +333,28 @@ def test_enum_values() -> None:
         assert tyro.cli(EnumClassA, args=["--color", "RED"])
 
 
+def test_enum_values_ints() -> None:
+    class Color(enum.Enum):
+        RED = 0
+        GREEN = 1
+        BLUE = 2
+
+    @dataclasses.dataclass
+    class EnumClassA:
+        color: Annotated[Color, tyro.conf.EnumChoicesFromValues]
+
+    @dataclasses.dataclass
+    class EnumClassB:
+        color: Annotated[Color, tyro.conf.EnumChoicesFromValues] = Color.GREEN
+
+    assert tyro.cli(EnumClassA, args=["--color", "0"]) == EnumClassA(color=Color.RED)
+    assert tyro.cli(EnumClassB, args=[]) == EnumClassB()
+    with pytest.raises(SystemExit):
+        assert tyro.cli(EnumClassA, args=["--color", "red"])
+    with pytest.raises(SystemExit):
+        assert tyro.cli(EnumClassA, args=["--color", "RED"])
+
+
 def test_literal() -> None:
     @dataclasses.dataclass
     class A:

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -297,6 +297,8 @@ def test_enum() -> None:
 
     assert tyro.cli(EnumClassA, args=["--color", "RED"]) == EnumClassA(color=Color.RED)
     assert tyro.cli(EnumClassB, args=[]) == EnumClassB()
+    with pytest.raises(SystemExit):
+        assert tyro.cli(EnumClassA, args=["--color", "red"])
 
 
 def test_enum_alias() -> None:
@@ -311,6 +313,26 @@ def test_enum_alias() -> None:
     assert tyro.cli(A, args=["--color", "RED"]) == A(color=Color.RED)
     assert tyro.cli(A, args=["--color", "ROUGE"]) == A(color=Color.ROUGE)
     assert tyro.cli(A, args=["--color", "ROUGE"]) == A(color=Color.RED)
+
+
+def test_enum_values() -> None:
+    class Color(enum.StrEnum):
+        RED = enum.auto()
+        GREEN = enum.auto()
+        BLUE = enum.auto()
+
+    @dataclasses.dataclass
+    class EnumClassA:
+        color: Annotated[Color, tyro.conf.SelectFromEnumValues]
+
+    @dataclasses.dataclass
+    class EnumClassB:
+        color: Annotated[Color, tyro.conf.SelectFromEnumValues] = Color.GREEN
+
+    assert tyro.cli(EnumClassA, args=["--color", "red"]) == EnumClassA(color=Color.RED)
+    assert tyro.cli(EnumClassB, args=[]) == EnumClassB()
+    with pytest.raises(SystemExit):
+        assert tyro.cli(EnumClassA, args=["--color", "RED"])
 
 
 def test_literal() -> None:
@@ -379,6 +401,29 @@ def test_literal_enum() -> None:
     assert tyro.cli(A, args=["--x", "GREEN"]) == A(x=Color.GREEN)
     with pytest.raises(SystemExit):
         assert tyro.cli(A, args=["--x", "BLUE"])
+    with pytest.raises(SystemExit):
+        assert tyro.cli(A, args=["--x", "red"])
+
+
+def test_literal_enum_values() -> None:
+    class Color(enum.StrEnum):
+        RED = enum.auto()
+        GREEN = enum.auto()
+        BLUE = enum.auto()
+
+    @dataclasses.dataclass
+    class A:
+        x: Annotated[
+            Literal[Color.RED, Color.GREEN],
+            tyro.conf.SelectFromEnumValues,
+        ]
+
+    assert tyro.cli(A, args=["--x", "red"]) == A(x=Color.RED)
+    assert tyro.cli(A, args=["--x", "green"]) == A(x=Color.GREEN)
+    with pytest.raises(SystemExit):
+        assert tyro.cli(A, args=["--x", "RED"])
+    with pytest.raises(SystemExit):
+        assert tyro.cli(A, args=["--x", "blue"])
 
 
 def test_optional_literal() -> None:

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -323,11 +323,11 @@ def test_enum_values() -> None:
 
     @dataclasses.dataclass
     class EnumClassA:
-        color: Annotated[Color, tyro.conf.SelectFromEnumValues]
+        color: Annotated[Color, tyro.conf.EnumChoicesFromValues]
 
     @dataclasses.dataclass
     class EnumClassB:
-        color: Annotated[Color, tyro.conf.SelectFromEnumValues] = Color.GREEN
+        color: Annotated[Color, tyro.conf.EnumChoicesFromValues] = Color.GREEN
 
     assert tyro.cli(EnumClassA, args=["--color", "red"]) == EnumClassA(color=Color.RED)
     assert tyro.cli(EnumClassB, args=[]) == EnumClassB()
@@ -415,7 +415,7 @@ def test_literal_enum_values() -> None:
     class A:
         x: Annotated[
             Literal[Color.RED, Color.GREEN],
-            tyro.conf.SelectFromEnumValues,
+            tyro.conf.EnumChoicesFromValues,
         ]
 
     assert tyro.cli(A, args=["--x", "red"]) == A(x=Color.RED)


### PR DESCRIPTION
* Add configuration marker: SelectionFromEnumValues

* Refactor instantiator production logic for types with automatically-populated choices. Encapsulation to keep related variables tracked togther.

Resolves #166 .

@brentyi : All linter checks and tests are passing. Not sure if you want anything additional for documentation; looks like you have an automatic generator which I did not look closely at.

Also, manual proof that it works as described and intended:
```python
>>> import dataclasses, enum, typing_extensions, tyro
>>> class Formats( enum.StrEnum ):
...     JSON = enum.auto( )
...     PRETTY = enum.auto( )
...
>>> @dataclasses.dataclass
... class Args:
...     format: typing_extensions.Annotated[ Formats, tyro.conf.SelectFromEnumValues ] = Formats.PRETTY
...
>>> tyro.cli( Args, args = [ '--format', 'json' ] )
Args(format=<Formats.JSON: 'json'>)
>>> tyro.cli( Args, args = [ '--format', 'pretty' ] )
Args(format=<Formats.PRETTY: 'pretty'>)
>>> tyro.cli( Args, args = [ ] )
Args(format=<Formats.PRETTY: 'pretty'>)
>>> tyro.cli( Args, args = [ '--help' ] )
```
```
usage: [-h] [--format {json,pretty}]

╭─ options ───────────────────────────────────────────────╮
│ -h, --help              show this help message and exit │
│ --format {json,pretty}  (default: pretty)               │
╰─────────────────────────────────────────────────────────╯
```