### PR TITLE
Allow subcommand_cli_from_dict to specify console_outputs

### DIFF
--- a/src/tyro/extras/_subcommand_cli_from_dict.py
+++ b/src/tyro/extras/_subcommand_cli_from_dict.py
@@ -16,6 +16,7 @@ def subcommand_cli_from_dict(
     description: Optional[str] = None,
     args: Optional[Sequence[str]] = None,
     use_underscores: bool = False,
+    console_outputs: bool = True,
 ) -> T: ...
 
 
@@ -29,6 +30,7 @@ def subcommand_cli_from_dict(
     description: Optional[str] = None,
     args: Optional[Sequence[str]] = None,
     use_underscores: bool = False,
+    console_outputs: bool = True,
 ) -> Any: ...
 
 
@@ -39,6 +41,7 @@ def subcommand_cli_from_dict(
     description: Optional[str] = None,
     args: Optional[Sequence[str]] = None,
     use_underscores: bool = False,
+    console_outputs: bool = True,
 ) -> Any:
     """Generate a subcommand CLI from a dictionary of functions.
 
@@ -86,6 +89,10 @@ def subcommand_cli_from_dict(
             This primarily impacts helptext; underscores and hyphens are treated equivalently
             when parsing happens. We default helptext to hyphens to follow the GNU style guide.
             https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+        console_outputs: If set to `False`, parsing errors and help messages will be
+            supressed. This can be useful for distributed settings, where `tyro.cli()`
+            is called from multiple workers but we only want console outputs from the
+            main one.
     """
     # We need to form a union type, which requires at least two elements.
     assert len(subcommands) >= 2, "At least two subcommands are required."
@@ -108,4 +115,5 @@ def subcommand_cli_from_dict(
         description=description,
         args=args,
         use_underscores=use_underscores,
+        console_outputs=console_outputs
     )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -214,9 +214,10 @@ def test_suppress_console_outputs_fromdict() -> None:
     target = io.StringIO()
     with pytest.raises(SystemExit), contextlib.redirect_stderr(target):
         tyro.extras.subcommand_cli_from_dict(
-        {"foo": foo, "bar": bar},
-        args="foo --reward.trac".split(" "),
-        console_outputs=False)
+            {"foo": foo, "bar": bar},
+            args="foo --reward.trac".split(" "),
+            console_outputs=False,
+        )
 
     error = target.getvalue()
     assert error == ""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -204,6 +204,24 @@ def test_suppress_console_outputs() -> None:
     assert error == ""
 
 
+def test_suppress_console_outputs_fromdict() -> None:
+    def foo(track: bool) -> None:
+        print(track)
+
+    def bar(track: bool) -> None:
+        print(track)
+
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stderr(target):
+        tyro.extras.subcommand_cli_from_dict(
+        {"foo": foo, "bar": bar},
+        args="foo --reward.trac".split(" "),
+        console_outputs=False)
+
+    error = target.getvalue()
+    assert error == ""
+
+
 def test_similar_arguments_subcommands() -> None:
     @dataclasses.dataclass
     class RewardConfig:


### PR DESCRIPTION
Ran into this issue while trying to `torchrun` an entrypoint which uses `tyro.extras.subcommand_cli_from_dict`. 

My thinking is that the API should be as close as possible to `tyro.cli`?