### PR TITLE
More complete wrappers in `tyro.extras` (for `torchrun`, etc)

### DIFF
--- a/src/tyro/extras/_subcommand_app.py
+++ b/src/tyro/extras/_subcommand_app.py
@@ -91,6 +91,8 @@ class SubcommandApp:
         description: Optional[str] = None,
         args: Optional[Sequence[str]] = None,
         use_underscores: bool = False,
+        console_outputs: bool = True,
+        config: Optional[Sequence[Any]] = None,
         sort_subcommands: bool = False,
     ) -> Any:
         """Run the command-line interface.
@@ -110,6 +112,9 @@ class SubcommandApp:
                 This primarily impacts helptext; underscores and hyphens are treated equivalently
                 when parsing happens. We default helptext to hyphens to follow the GNU style guide.
                 https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+            console_outputs: If set to `False`, parsing errors and help messages will be
+                suppressed.
+            config: Sequence of config marker objects, from `tyro.conf`.
             sort_subcommands: If True, sort the subcommands alphabetically by name.
         """
         assert self._subcommands is not None
@@ -129,6 +134,8 @@ class SubcommandApp:
                 description=description,
                 args=args,
                 use_underscores=use_underscores,
+                console_outputs=console_outputs,
+                config=config,
             )
         else:
             return tyro.extras.subcommand_cli_from_dict(
@@ -137,4 +144,6 @@ class SubcommandApp:
                 description=description,
                 args=args,
                 use_underscores=use_underscores,
+                console_outputs=console_outputs,
+                config=config,
             )

--- a/src/tyro/extras/_subcommand_cli_from_dict.py
+++ b/src/tyro/extras/_subcommand_cli_from_dict.py
@@ -2,6 +2,8 @@ from typing import Any, Callable, Dict, Optional, Sequence, TypeVar, Union, over
 
 from typing_extensions import Annotated
 
+from tyro.conf._markers import Marker
+
 from .._cli import cli
 from ..conf import subcommand
 
@@ -17,6 +19,7 @@ def subcommand_cli_from_dict(
     args: Optional[Sequence[str]] = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    config: Optional[Sequence[Marker]] = None,
 ) -> T: ...
 
 
@@ -31,6 +34,7 @@ def subcommand_cli_from_dict(
     args: Optional[Sequence[str]] = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    config: Optional[Sequence[Marker]] = None,
 ) -> Any: ...
 
 
@@ -42,6 +46,7 @@ def subcommand_cli_from_dict(
     args: Optional[Sequence[str]] = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    config: Optional[Sequence[Marker]] = None,
 ) -> Any:
     """Generate a subcommand CLI from a dictionary of functions.
 
@@ -93,6 +98,7 @@ def subcommand_cli_from_dict(
             supressed. This can be useful for distributed settings, where `tyro.cli()`
             is called from multiple workers but we only want console outputs from the
             main one.
+        config: Sequence of config marker objects, from `tyro.conf`.
     """
     # We need to form a union type, which requires at least two elements.
     assert len(subcommands) >= 2, "At least two subcommands are required."
@@ -115,5 +121,6 @@ def subcommand_cli_from_dict(
         description=description,
         args=args,
         use_underscores=use_underscores,
-        console_outputs=console_outputs
+        console_outputs=console_outputs,
+        config=config,
     )


### PR DESCRIPTION
Extends #175 slightly!