### PR TITLE
Fix edge case when combining PEP 695 aliases with `typing.Annotated[]`

### DIFF
--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -110,7 +110,7 @@ class FieldDefinition:
         markers: Tuple[_markers.Marker, ...] = (),
     ):
         # Try to extract argconf overrides from type.
-        _, argconfs = _resolver.unwrap_annotated(
+        _, argconfs = _resolver.unwrap_annotated_and_aliases(
             type_or_callable, _confstruct._ArgConfiguration
         )
         argconf = _confstruct._ArgConfiguration(
@@ -135,7 +135,7 @@ class FieldDefinition:
             if argconf.help is not None:
                 helptext = argconf.help
 
-        type_or_callable, inferred_markers = _resolver.unwrap_annotated(
+        type_or_callable, inferred_markers = _resolver.unwrap_annotated_and_aliases(
             type_or_callable, _markers._Marker
         )
         markers = inferred_markers + markers
@@ -285,7 +285,7 @@ def field_list_from_callable(
 
     # Try to generate field list.
     # We recursively apply markers.
-    _, parent_markers = _resolver.unwrap_annotated(f, _markers._Marker)
+    _, parent_markers = _resolver.unwrap_annotated_and_aliases(f, _markers._Marker)
     with FieldDefinition.marker_context(parent_markers):
         field_list = _try_field_list_from_callable(f, default_instance)
 
@@ -386,7 +386,7 @@ def _try_field_list_from_callable(
     # Check for default instances in subcommand configs. This is needed for
     # is_nested_type() when arguments are not valid without a default, and this
     # default is specified in the subcommand config.
-    f, found_subcommand_configs = _resolver.unwrap_annotated(
+    f, found_subcommand_configs = _resolver.unwrap_annotated_and_aliases(
         f, conf._confstruct._SubcommandConfiguration
     )
     if len(found_subcommand_configs) > 0:

--- a/src/tyro/_instantiators.py
+++ b/src/tyro/_instantiators.py
@@ -197,7 +197,7 @@ def instantiator_from_type(
     if maybe_newtype_name is not None:
         metavar = maybe_newtype_name.upper()
 
-    typ = _resolver.unwrap_annotated(typ)
+    typ = _resolver.unwrap_annotated_and_aliases(typ)
 
     # Address container types. If a matching container is found, this will recursively
     # call instantiator_from_type().

--- a/src/tyro/_strings.py
+++ b/src/tyro/_strings.py
@@ -80,7 +80,7 @@ def _subparser_name_from_type(cls: Type) -> Tuple[str, bool]:
     from .conf import _confstruct  # Prevent circular imports
 
     cls, type_from_typevar = _resolver.resolve_generic_types(cls)
-    cls, found_subcommand_configs = _resolver.unwrap_annotated(
+    cls, found_subcommand_configs = _resolver.unwrap_annotated_and_aliases(
         cls, _confstruct._SubcommandConfiguration
     )
 

--- a/src/tyro/_subcommand_matching.py
+++ b/src/tyro/_subcommand_matching.py
@@ -96,11 +96,11 @@ class _TypeTree:
 
         # Check against supertypes.
         for self_type in self_types:
-            self_type = _resolver.unwrap_annotated(self_type)
+            self_type = _resolver.unwrap_annotated_and_aliases(self_type)
             self_type, _ = _resolver.unwrap_newtype_and_aliases(self_type)
             ok = False
             for super_type in super_types:
-                super_type = _resolver.unwrap_annotated(super_type)
+                super_type = _resolver.unwrap_annotated_and_aliases(super_type)
                 self_type, _ = _resolver.unwrap_newtype_and_aliases(self_type)
                 if issubclass(self_type, super_type):
                     ok = True

--- a/src/tyro/extras/_serialization.py
+++ b/src/tyro/extras/_serialization.py
@@ -35,7 +35,7 @@ def _get_contained_special_types_from_type(
         else _parent_contained_dataclasses
     )
 
-    cls = _resolver.unwrap_annotated(cls)
+    cls = _resolver.unwrap_annotated_and_aliases(cls)
     cls, type_from_typevar = _resolver.resolve_generic_types(cls)
 
     contained_special_types = {cls}

--- a/src/tyro/extras/_subcommand_cli_from_dict.py
+++ b/src/tyro/extras/_subcommand_cli_from_dict.py
@@ -115,5 +115,5 @@ def subcommand_cli_from_dict(
         description=description,
         args=args,
         use_underscores=use_underscores,
-        console_outputs=console_outputs
+        console_outputs=console_outputs,
     )

--- a/tests/test_new_style_annotations_min_py312.py
+++ b/tests/test_new_style_annotations_min_py312.py
@@ -2,6 +2,7 @@
 #
 # PEP 695 isn't yet supported in mypy. (April 4, 2024)
 from dataclasses import dataclass
+from typing import Annotated
 
 import tyro
 
@@ -52,3 +53,14 @@ def test_generic_with_type_statement_2():
     assert tyro.cli(Container[Y], args="--a.a 1 --a.b 2".split(" ")) == Container(
         Inner(1, 2)
     )
+
+
+type AnnotatedBasic = Annotated[int, tyro.conf.arg(name="basic")]
+
+
+def test_annotated_alias():
+    @dataclass(frozen=True)
+    class Container:
+        a: AnnotatedBasic
+
+    assert tyro.cli(Container, args="--basic 1".split(" ")) == Container(1)

--- a/tests/test_py311_generated/test_errors_generated.py
+++ b/tests/test_py311_generated/test_errors_generated.py
@@ -203,6 +203,25 @@ def test_suppress_console_outputs() -> None:
     assert error == ""
 
 
+def test_suppress_console_outputs_fromdict() -> None:
+    def foo(track: bool) -> None:
+        print(track)
+
+    def bar(track: bool) -> None:
+        print(track)
+
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stderr(target):
+        tyro.extras.subcommand_cli_from_dict(
+            {"foo": foo, "bar": bar},
+            args="foo --reward.trac".split(" "),
+            console_outputs=False,
+        )
+
+    error = target.getvalue()
+    assert error == ""
+
+
 def test_similar_arguments_subcommands() -> None:
     @dataclasses.dataclass
     class RewardConfig:

--- a/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
@@ -2,6 +2,7 @@
 #
 # PEP 695 isn't yet supported in mypy. (April 4, 2024)
 from dataclasses import dataclass
+from typing import Annotated
 
 import tyro
 
@@ -52,3 +53,14 @@ def test_generic_with_type_statement_2():
     assert tyro.cli(Container[Y], args="--a.a 1 --a.b 2".split(" ")) == Container(
         Inner(1, 2)
     )
+
+
+type AnnotatedBasic = Annotated[int, tyro.conf.arg(name="basic")]
+
+
+def test_annotated_alias():
+    @dataclass(frozen=True)
+    class Container:
+        a: AnnotatedBasic
+
+    assert tyro.cli(Container, args="--basic 1".split(" ")) == Container(1)


### PR DESCRIPTION
First PR for issues uncovered by #177.

Type aliases were not being correctly resolved for reading metadata introduced by `typing.Annotated`:
```python
type AnnotatedBasic = Annotated[int, tyro.conf.arg(name="basic")]

def test_annotated_alias():
    @dataclass(frozen=True)
    class Container:
        a: AnnotatedBasic

    assert tyro.cli(Container, args="--basic 1".split(" ")) == Container(1)
```