### PR TITLE
Support cyclic generics

### DIFF
--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -407,6 +407,7 @@ def _cli_impl(
     # Map a callable to the relevant CLI arguments + subparsers.
     parser_spec = _parsers.ParserSpecification.from_callable_or_type(
         f,
+        markers=set(),
         description=description,
         parent_classes=set(),  # Used for recursive calls.
         default_instance=default_instance_internal,  # Overrides for default values.

--- a/src/tyro/_docstrings.py
+++ b/src/tyro/_docstrings.py
@@ -7,6 +7,7 @@ import functools
 import inspect
 import io
 import itertools
+import sys
 import tokenize
 from typing import Callable, Dict, Generic, Hashable, List, Optional, Set, Type, TypeVar
 
@@ -311,9 +312,13 @@ def get_callable_description(f: Callable) -> str:
     if isinstance(f, functools.partial):
         f = f.func
 
-    try:
-        import pydantic
-    except ImportError:
+    if "pydantic" in sys.modules.keys():
+        try:
+            import pydantic
+        except ImportError:
+            # Needed for mock import test.
+            pydantic = None
+    else:
         pydantic = None  # type: ignore
 
     # Note inspect.getdoc() causes some corner cases with TypedDicts.

--- a/src/tyro/_docstrings.py
+++ b/src/tyro/_docstrings.py
@@ -317,7 +317,7 @@ def get_callable_description(f: Callable) -> str:
             import pydantic
         except ImportError:
             # Needed for mock import test.
-            pydantic = None
+            pydantic = None  # type: ignore
     else:
         pydantic = None  # type: ignore
 

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -43,7 +43,6 @@ from typing_extensions import (
     is_typeddict,
 )
 
-from . import conf  # Avoid circular import.
 from . import (
     _docstrings,
     _instantiators,
@@ -51,6 +50,7 @@ from . import (
     _singleton,
     _strings,
     _unsafe_cache,
+    conf,  # Avoid circular import.
 )
 from ._typing import TypeForm
 from .conf import _confstruct, _markers

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -43,6 +43,7 @@ from typing_extensions import (
     is_typeddict,
 )
 
+from . import conf  # Avoid circular import.
 from . import (
     _docstrings,
     _instantiators,
@@ -50,7 +51,6 @@ from . import (
     _singleton,
     _strings,
     _unsafe_cache,
-    conf,  # Avoid circular import.
 )
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
@@ -112,9 +112,14 @@ class FieldDefinition:
         )
 
         # Narrow types.
-        type_or_callable = _resolver.type_from_typevar_constraints(type_or_callable)
-        type_or_callable = _resolver.narrow_collection_types(type_or_callable, default)
-        type_or_callable = _resolver.narrow_union_type(type_or_callable, default)
+        if type_or_callable is Any and default not in MISSING_SINGLETONS:
+            type_or_callable = type(default)
+        else:
+            type_or_callable = _resolver.type_from_typevar_constraints(type_or_callable)
+            type_or_callable = _resolver.narrow_collection_types(
+                type_or_callable, default
+            )
+            type_or_callable = _resolver.narrow_union_type(type_or_callable, default)
 
         # Try to extract argconf overrides from type.
         _, argconfs = _resolver.unwrap_annotated(

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -191,7 +191,6 @@ class FieldDefinition:
             type_or_callable=type_or_callable
             if argconf.constructor_factory is None
             else argconf.constructor_factory(),
-            # typevar_context=typevar_context,
             default=default,
             is_default_from_default_instance=is_default_from_default_instance,
             helptext=helptext,

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -615,7 +615,7 @@ def _field_list_from_dataclass(
 
 def _is_pydantic(cls: TypeForm[Any]) -> bool:
     # pydantic will already be imported if it's used.
-    if "pydantic" not in sys.modules.keys():
+    if "pydantic" not in sys.modules.keys():  # pragma: no cover
         # This is needed for the mock import test in
         # test_missing_optional_packages.py to pass.
         return False
@@ -623,6 +623,8 @@ def _is_pydantic(cls: TypeForm[Any]) -> bool:
     try:
         import pydantic
     except ImportError:
+        # This is needed for the mock import test in
+        # test_missing_optional_packages.py to pass.
         return False
 
     try:
@@ -719,7 +721,7 @@ def _field_list_from_pydantic(
 
 def _is_attrs(cls: TypeForm[Any]) -> bool:
     # attr will already be imported if it's used.
-    if "attr" not in sys.modules.keys():
+    if "attr" not in sys.modules.keys():  # pragma: no cover
         return False
 
     try:

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -43,7 +43,6 @@ from typing_extensions import (
     is_typeddict,
 )
 
-from . import conf  # Avoid circular import.
 from . import (
     _docstrings,
     _instantiators,
@@ -51,6 +50,7 @@ from . import (
     _singleton,
     _strings,
     _unsafe_cache,
+    conf,  # Avoid circular import.
 )
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
@@ -115,6 +115,9 @@ class FieldDefinition:
         if type_or_callable is Any and default not in MISSING_SINGLETONS:
             type_or_callable = type(default)
         else:
+            # TypeVar constraints are already applied in
+            # TypeParamResolver.concretize_type_params(), but that won't be
+            # called for functions.
             type_or_callable = _resolver.type_from_typevar_constraints(type_or_callable)
             type_or_callable = _resolver.narrow_collection_types(
                 type_or_callable, default

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -43,6 +43,7 @@ from typing_extensions import (
     is_typeddict,
 )
 
+from . import conf  # Avoid circular import.
 from . import (
     _docstrings,
     _instantiators,
@@ -50,12 +51,11 @@ from . import (
     _singleton,
     _strings,
     _unsafe_cache,
-    conf,  # Avoid circular import.
 )
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
 
-_field_context_markers: List[Tuple[_markers.Marker, ...]] = []
+global_context_markers: List[Tuple[_markers.Marker, ...]] = []
 
 
 @dataclasses.dataclass
@@ -91,9 +91,9 @@ class FieldDefinition:
     def marker_context(markers: Tuple[_markers.Marker, ...]):
         """Context for setting markers on fields. All fields created within the
         context will have the specified markers."""
-        _field_context_markers.append(markers)
+        global_context_markers.append(markers)
         yield
-        _field_context_markers.pop()
+        global_context_markers.pop()
 
     @staticmethod
     def make(
@@ -156,7 +156,7 @@ class FieldDefinition:
         markers = inferred_markers + markers
 
         # Include markers set via context manager.
-        for context_markers in _field_context_markers:
+        for context_markers in global_context_markers:
             markers += context_markers
 
         # Check that the default value matches the final resolved type.

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -30,7 +30,6 @@ from . import (
     _strings,
     _subcommand_matching,
 )
-from ._fields import global_context_markers
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
 

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -459,13 +459,13 @@ class SubparsersSpecification:
                 subcommand_type_from_name,
             )
 
-            # This should never be triggered because union types are expanded when
-            # a bad default value is provided.
             assert default_name is not None, (
                 f"`{extern_prefix}` was provided a default value of type"
                 f" {type(field.default)} but no matching subcommand was found. A"
                 " type may be missing in the Union type declaration for"
-                f" `{extern_prefix}`, which currently expects {options}."
+                f" `{extern_prefix}`, which currently expects {options}. "
+                "The types may also be too complex for tyro's subcommand matcher; support "
+                "is particularly limited for custom generic types."
             )
 
         # Add subcommands for each option.

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -80,23 +80,20 @@ class ParserSpecification:
 
         # Resolve the type of `f`, generate a field list.
         with _fields.FieldDefinition.marker_context(markers):
-            context = _resolver.TypeParamResolver.get_assignment_context(f)
-            with context:
-                f = context.origin_type
-                f, field_list = _fields.field_list_from_callable(
-                    f=f,
-                    default_instance=default_instance,
-                    support_single_arg_types=support_single_arg_types,
-                )
+            f, field_list = _fields.field_list_from_callable(
+                f=f,
+                default_instance=default_instance,
+                support_single_arg_types=support_single_arg_types,
+            )
 
         # Cycle detection.
         #
         # Note that 'parent' here refers to in the nesting hierarchy, not the
         # superclass.
-        if f in parent_classes and f is not dict:
-            raise _instantiators.UnsupportedTypeAnnotationError(
-                f"Found a cyclic dependency with type {f}."
-            )
+        # if f in parent_classes and f is not dict:
+        #     raise _instantiators.UnsupportedTypeAnnotationError(
+        #         f"Found a cyclic dependency with type {f}."
+        #     )
 
         # TODO: we are abusing the (minor) distinctions between types, classes, and
         # callables throughout the code. This is mostly for legacy reasons, could be
@@ -113,14 +110,13 @@ class ParserSpecification:
         subparsers_from_prefix = {}
 
         for field in field_list:
-            with field.typevar_context:
-                field_out = handle_field(
-                    field,
-                    parent_classes=parent_classes,
-                    intern_prefix=intern_prefix,
-                    extern_prefix=extern_prefix,
-                    subcommand_prefix=subcommand_prefix,
-                )
+            field_out = handle_field(
+                field,
+                parent_classes=parent_classes,
+                intern_prefix=intern_prefix,
+                extern_prefix=extern_prefix,
+                subcommand_prefix=subcommand_prefix,
+            )
             if isinstance(field_out, _arguments.ArgumentDefinition):
                 # Handle single arguments.
                 args.append(field_out)
@@ -458,7 +454,9 @@ class SubparsersSpecification:
             default_name = None
         else:
             default_name = _subcommand_matching.match_subcommand(
-                field.default, subcommand_config_from_name, subcommand_type_from_name
+                field.default,
+                subcommand_config_from_name,
+                subcommand_type_from_name,
             )
 
             # This should never be triggered because union types are expanded when

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -76,7 +76,7 @@ class ParserSpecification:
         """Create a parser definition from a callable or type."""
 
         # Consolidate subcommand types.
-        markers.update(_resolver.unwrap_annotated(f, _markers._Marker)[1])
+        markers = markers | set(_resolver.unwrap_annotated(f, _markers._Marker)[1])
         consolidate_subcommand_args = _markers.ConsolidateSubcommandArgs in markers
 
         # Resolve the type of `f`, generate a field list.

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -90,10 +90,10 @@ class ParserSpecification:
         #
         # Note that 'parent' here refers to in the nesting hierarchy, not the
         # superclass.
-        # if f in parent_classes and f is not dict:
-        #     raise _instantiators.UnsupportedTypeAnnotationError(
-        #         f"Found a cyclic dependency with type {f}."
-        #     )
+        if f in parent_classes and f is not dict:
+            raise _instantiators.UnsupportedTypeAnnotationError(
+                f"Found a cyclic dependency with type {f}."
+            )
 
         # TODO: we are abusing the (minor) distinctions between types, classes, and
         # callables throughout the code. This is mostly for legacy reasons, could be

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -567,7 +567,7 @@ def resolve_generic_types(
         hasattr(typ, "__parameters__") and hasattr(typ.__parameters__, "__len__")  # type: ignore
     ):
         typevars = typ.__parameters__  # type: ignore
-        typevar_values = (Any,) * len(typevars)
+        typevar_values = [type_from_typevar_constraints(x) for x in typevars]
         assert len(typevars) == len(typevar_values)
         type_from_typevar.update(dict(zip(typevars, typevar_values)))
 

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -124,6 +124,8 @@ def type_from_typevar_constraints(typ: TypeOrCallable) -> TypeOrCallable:
         elif len(typ.__constraints__) > 0:
             # Try to infer type from TypeVar constraints.
             return Union.__getitem__(typ.__constraints__)  # type: ignore
+        else:
+            return Any
     return typ
 
 
@@ -534,9 +536,10 @@ def resolve_generic_types(
     # Apply shims to convert from types.UnionType to typing.Union, list to
     # typing.List, etc.
     typ = standardize_builtin_generics(typ)
+    typ = resolve_newtype_and_aliases(typ)
 
     # We'll ignore NewType when getting the origin + args for generics.
-    origin_cls = get_origin(resolve_newtype_and_aliases(typ))
+    origin_cls = get_origin(typ)
     type_from_typevar: Dict[TypeVar, TypeForm[Any]] = {}
 
     # Support typing.Self.
@@ -558,6 +561,14 @@ def resolve_generic_types(
         typevar_values = get_args(resolve_newtype_and_aliases(typ))
         assert len(typevars) == len(typevar_values)
         typ = origin_cls
+        type_from_typevar.update(dict(zip(typevars, typevar_values)))
+    elif (
+        # Apply some heuristics for generic types. Should revisit this.
+        hasattr(typ, "__parameters__") and hasattr(typ.__parameters__, "__len__")  # type: ignore
+    ):
+        typevars = typ.__parameters__  # type: ignore
+        typevar_values = (Any,) * len(typevars)
+        assert len(typevars) == len(typevar_values)
         type_from_typevar.update(dict(zip(typevars, typevar_values)))
 
     if hasattr(typ, "__orig_bases__"):

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -567,7 +567,7 @@ def resolve_generic_types(
         hasattr(typ, "__parameters__") and hasattr(typ.__parameters__, "__len__")  # type: ignore
     ):
         typevars = typ.__parameters__  # type: ignore
-        typevar_values = [type_from_typevar_constraints(x) for x in typevars]
+        typevar_values = tuple(type_from_typevar_constraints(x) for x in typevars)
         assert len(typevars) == len(typevar_values)
         type_from_typevar.update(dict(zip(typevars, typevar_values)))
 

--- a/src/tyro/_strings.py
+++ b/src/tyro/_strings.py
@@ -122,9 +122,12 @@ def _subparser_name_from_type(cls: Type) -> Tuple[str, bool]:
 
     return (
         get_delimeter().join(
-            map(
-                lambda x: _subparser_name_from_type(x)[0],
-                [cls] + list(type_from_typevar.values()),
+            [get_name(cls)]
+            + list(
+                map(
+                    lambda x: _subparser_name_from_type(x)[0],
+                    list(type_from_typevar.values()),
+                )
             )
         ),
         prefix_name,

--- a/src/tyro/_subcommand_matching.py
+++ b/src/tyro/_subcommand_matching.py
@@ -119,9 +119,9 @@ class _TypeTree:
                 return False
 
         for child_name, child in self.children.items():
-            if child_name not in supertype.children:
-                return False
-            if not child.is_subtype_of(supertype.children[child_name]):
+            if child_name not in supertype.children or not child.is_subtype_of(
+                supertype.children[child_name]
+            ):
                 return False
 
         return True

--- a/src/tyro/_subcommand_matching.py
+++ b/src/tyro/_subcommand_matching.py
@@ -15,14 +15,11 @@ def match_subcommand(
     subcommand_type_from_name: Dict[str, type],
 ) -> Optional[str]:
     """Given a subcommand mapping and a default, return which subcommand the default
-    corresponds to."""
+    corresponds to.
 
-    # It's really hard to concretize a generic type at runtime, so we just...
-    # don't. :-)
-    if hasattr(type(default), "__parameters__"):
-        raise _instantiators.UnsupportedTypeAnnotationError(
-            "Default values for generic subparsers are not supported."
-        )
+    TOOD: this function is based on heuristics. While it should be robust to
+    most real-world scenarios, there's room for improvement for generic types.
+    """
 
     # Get default subcommand name: by default hash.
     default_hash = object.__hash__(default)
@@ -49,10 +46,17 @@ def match_subcommand(
             return subcommand_name
 
     # Get default subcommand name: by annotated type tree.
-    for subcommand_name, subcommand_type in subcommand_type_from_name.items():
-        if typetree.is_subtype_of(
-            _TypeTree.make(subcommand_type, _fields.MISSING_NONPROP)
-        ):
+    typetree_from_name = {
+        subcommand_name: _TypeTree.make(subcommand_type, _fields.MISSING_NONPROP)
+        for subcommand_name, subcommand_type in subcommand_type_from_name.items()
+    }
+    for subcommand_name in subcommand_type_from_name.keys():
+        # Equality check for type tree.
+        if typetree == typetree_from_name[subcommand_name]:
+            return subcommand_name
+    for subcommand_name in subcommand_type_from_name.keys():
+        # Leaky subtype check.
+        if typetree.is_subtype_of(typetree_from_name[subcommand_name]):
             return subcommand_name
 
     # Failed. This should never happen, we'll raise an error outside of this function if
@@ -71,15 +75,18 @@ class _TypeTree:
         default_instance: _fields.DefaultInstance,
     ) -> _TypeTree:
         """From an object instance, return a data structure representing the types in the object."""
+
+        typ_unwrap = _resolver.resolve_generic_types(typ)[0]
+
         try:
             typ, field_list = _fields.field_list_from_callable(
                 typ, default_instance=default_instance, support_single_arg_types=False
             )
         except _instantiators.UnsupportedTypeAnnotationError:
-            return _TypeTree(typ, {})
+            return _TypeTree(typ_unwrap, {})
 
         return _TypeTree(
-            typ,
+            typ_unwrap,
             {
                 field.intern_name: _TypeTree.make(field.type_or_callable, field.default)
                 for field in field_list
@@ -87,6 +94,8 @@ class _TypeTree:
         )
 
     def is_subtype_of(self, supertype: _TypeTree) -> bool:
+        """Best-effort subcommand matching."""
+
         # Generalize to unions.
         def _get_type_options(typ: _typing.TypeForm) -> Tuple[_typing.TypeForm, ...]:
             return get_args(typ) if get_origin(typ) is Union else (typ,)
@@ -94,15 +103,25 @@ class _TypeTree:
         self_types = _get_type_options(self.typ)
         super_types = _get_type_options(supertype.typ)
 
-        # Check against supertypes.
+        # Check against supertypes. TODO: the heuristics below could be more
+        # principled. We should revisit.
         for self_type in self_types:
             self_type = _resolver.unwrap_annotated(self_type)
             ok = False
             for super_type in super_types:
                 super_type = _resolver.unwrap_annotated(super_type)
-                if issubclass(self_type, super_type):
-                    ok = True
+                try:
+                    if issubclass(self_type, super_type):
+                        ok = True
+                except TypeError:
+                    pass
             if not ok:
+                return False
+
+        for child_name, child in self.children.items():
+            if child_name not in supertype.children:
+                return False
+            if not child.is_subtype_of(supertype.children[child_name]):
                 return False
 
         return True

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -980,11 +980,11 @@ def test_generic_subparsers() -> None:
     assert tyro.cli(main, args="x:a-float --x.x 3.2".split(" ")) == A(3.2)
     assert tyro.cli(main, args="x:a-int --x.x 3".split(" ")) == A(3)
 
-    def main_with_default(x: Union[A[int], A[float]] = A(5)) -> Any:
+    def main_with_default(x: Union[A[str], A[int]] = A(5)) -> Any:
         return x
 
-    with pytest.raises(tyro.UnsupportedTypeAnnotationError):
-        tyro.cli(main_with_default, args=[])
+    assert tyro.cli(main_with_default, args=[]) == A(5)
+    assert tyro.cli(main_with_default, args=["x:a-str", "--x.x", "3"]) == A("3")
 
 
 def test_generic_inherited() -> None:

--- a/tests/test_new_style_annotations_min_py312.py
+++ b/tests/test_new_style_annotations_min_py312.py
@@ -201,3 +201,67 @@ def test_pep695_new_type_alias() -> None:
         return arg
 
     assert tyro.cli(main, args=["1", "2"]) == [1, 2]
+
+
+def test_generic_config():
+    @dataclass(frozen=True)
+    class Container[T]:
+        a: Inner[T]
+
+    assert tyro.cli(
+        Container[bool],
+        args="--a.a True --a.b False".split(" "),
+        config=(tyro.conf.FlagConversionOff,),
+    ) == Container(Inner(True, False))
+
+
+def test_generic_config_subcommand():
+    @dataclass(frozen=True)
+    class Container[T]:
+        a: T
+
+    assert tyro.cli(
+        Container[Container[bool] | Container[str]],
+        args="a:container-bool --a.a True".split(" "),
+        default=Container(Container(a="30")),
+        config=(tyro.conf.FlagConversionOff,),
+    ) == Container(Container(True))
+    assert False
+
+
+# def test_generic_config_subcommand2():
+#     @dataclass(frozen=True)
+#     class Container[T]:
+#         a: tyro.conf.OmitSubcommandPrefixes[T]
+#
+#     assert tyro.cli(
+#         Container[Container[bool] | Container[str]],
+#         args="container-bool --a True".split(" "),
+#     ) == Container(Container(True))
+#
+#
+# def test_generic_config_subcommand3():
+#     @dataclass(frozen=True)
+#     class Container[T]:
+#         a: T
+#
+#     assert tyro.cli(
+#         Container[Container[bool] | Container[str]],
+#         args="container-bool --a True".split(" "),
+#         config=(tyro.conf.OmitSubcommandPrefixes,),
+#     ) == Container(Container(True))
+
+
+# def test_generic_union_subcommand():
+#     @dataclass(frozen=True)
+#     class Container[T]:
+#         a: T
+#         b: T
+#
+#     assert tyro.cli(
+#         Container[Container[int | str] | Container[str | int]],
+#         args="a:container-int-str --a 3 --b 3 b:container-str-int --a 3 --b 3".split(
+#             " "
+#         ),
+#         config=(tyro.conf.OmitArgPrefixes,),
+#     ) == Container(Container(3, 3), Container("3", "3"))

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -990,11 +990,11 @@ def test_generic_subparsers() -> None:
     assert tyro.cli(main, args="x:a-float --x.x 3.2".split(" ")) == A(3.2)
     assert tyro.cli(main, args="x:a-int --x.x 3".split(" ")) == A(3)
 
-    def main_with_default(x: A[int] | A[float] = A(5)) -> Any:
+    def main_with_default(x: A[str] | A[int] = A(5)) -> Any:
         return x
 
-    with pytest.raises(tyro.UnsupportedTypeAnnotationError):
-        tyro.cli(main_with_default, args=[])
+    assert tyro.cli(main_with_default, args=[]) == A(5)
+    assert tyro.cli(main_with_default, args=["x:a-str", "--x.x", "3"]) == A("3")
 
 
 def test_generic_inherited() -> None:

--- a/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
@@ -201,3 +201,67 @@ def test_pep695_new_type_alias() -> None:
         return arg
 
     assert tyro.cli(main, args=["1", "2"]) == [1, 2]
+
+
+def test_generic_config():
+    @dataclass(frozen=True)
+    class Container[T]:
+        a: Inner[T]
+
+    assert tyro.cli(
+        Container[bool],
+        args="--a.a True --a.b False".split(" "),
+        config=(tyro.conf.FlagConversionOff,),
+    ) == Container(Inner(True, False))
+
+
+def test_generic_config_subcommand():
+    @dataclass(frozen=True)
+    class Container[T]:
+        a: T
+
+    assert tyro.cli(
+        Container[Container[bool] | Container[str]],
+        args="a:container-bool --a.a True".split(" "),
+        default=Container(Container(a="30")),
+        config=(tyro.conf.FlagConversionOff,),
+    ) == Container(Container(True))
+    assert False
+
+
+# def test_generic_config_subcommand2():
+#     @dataclass(frozen=True)
+#     class Container[T]:
+#         a: tyro.conf.OmitSubcommandPrefixes[T]
+#
+#     assert tyro.cli(
+#         Container[Container[bool] | Container[str]],
+#         args="container-bool --a True".split(" "),
+#     ) == Container(Container(True))
+#
+#
+# def test_generic_config_subcommand3():
+#     @dataclass(frozen=True)
+#     class Container[T]:
+#         a: T
+#
+#     assert tyro.cli(
+#         Container[Container[bool] | Container[str]],
+#         args="container-bool --a True".split(" "),
+#         config=(tyro.conf.OmitSubcommandPrefixes,),
+#     ) == Container(Container(True))
+
+
+# def test_generic_union_subcommand():
+#     @dataclass(frozen=True)
+#     class Container[T]:
+#         a: T
+#         b: T
+#
+#     assert tyro.cli(
+#         Container[Container[int | str] | Container[str | int]],
+#         args="a:container-int-str --a 3 --b 3 b:container-str-int --a 3 --b 3".split(
+#             " "
+#         ),
+#         config=(tyro.conf.OmitArgPrefixes,),
+#     ) == Container(Container(3, 3), Container("3", "3"))


### PR DESCRIPTION
Patterns like this now work:

```python
@dataclass(frozen=True)
class Container[T]:
    a: T

tyro.cli(
    Container[Container[bool] | Container[Literal["1", "2"]]]
)
```

Also improved matching logic when the `default=` argument is specified.