### PR TITLE
`typing.Annotated` workaround for pydantic v1

### DIFF
--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -674,6 +674,10 @@ def _field_list_from_pydantic(
             cls_cast = cast(pydantic_v1.BaseModel, cls)  # type: ignore
         else:
             cls_cast = cls
+
+        hints = _resolver.get_type_hints_with_backported_syntax(
+            cls, include_extras=True
+        )
         for pd1_field in cls_cast.__fields__.values():
             helptext = pd1_field.field_info.description
             if helptext is None:
@@ -686,7 +690,7 @@ def _field_list_from_pydantic(
             field_list.append(
                 FieldDefinition.make(
                     name=pd1_field.name,
-                    type_or_callable=pd1_field.outer_type_,
+                    type_or_callable=hints[pd1_field.name],
                     default=default,
                     is_default_from_default_instance=is_default_from_default_instance,
                     helptext=helptext,

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -6,6 +6,7 @@ import pathlib
 from typing import cast
 
 import pytest
+from helptext_utils import get_helptext_with_checks
 from pydantic import BaseModel, Field, v1
 from typing_extensions import Annotated
 
@@ -50,6 +51,32 @@ def test_pydantic_v1() -> None:
             "~",
         ],
     ) == ManyTypesA(i=5, s="hello", f=3.0, p=pathlib.Path("~"))
+
+
+def test_pydantic_v1_conf() -> None:
+    class ManyTypesA(v1.BaseModel):
+        i: int
+        """This is a docstring."""
+        s: tyro.conf.Suppress[str] = "hello"
+        f: float = v1.Field(default_factory=lambda: 3.0)
+
+    class ManyTypesB(ManyTypesA):
+        p: pathlib.Path
+
+    # We can directly pass a dataclass to `tyro.cli()`:
+    assert tyro.cli(
+        ManyTypesB,
+        args=[
+            "--i",
+            "5",
+            "--p",
+            "~",
+        ],
+    ) == ManyTypesB(i=5, s="hello", f=3.0, p=pathlib.Path("~"))
+    helptext = get_helptext_with_checks(ManyTypesB)
+    assert "--s" not in helptext
+    assert "--i" in helptext
+    assert "This is a docstring" in helptext
 
 
 def test_pydantic_helptext() -> None:

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 import pathlib
+import sys
 from typing import cast
 
 import pytest
@@ -80,7 +81,8 @@ def test_pydantic_v1_conf() -> None:
     # This doesn't work when combining older versions of Python with older
     # versions of pydantic. The root cause may be in the docstring_parser
     # dependency.
-    # assert "This is a docstring" in helptext
+    if sys.version_info >= (3, 10):
+        assert "This is a docstring" in helptext
 
 
 def test_pydantic_helptext() -> None:

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -76,7 +76,11 @@ def test_pydantic_v1_conf() -> None:
     helptext = get_helptext_with_checks(ManyTypesB)
     assert "--s" not in helptext
     assert "--i" in helptext
-    assert "This is a docstring" in helptext
+
+    # This doesn't work when combining older versions of Python with older
+    # versions of pydantic. The root cause may be in the docstring_parser
+    # dependency.
+    # assert "This is a docstring" in helptext
 
 
 def test_pydantic_helptext() -> None:


### PR DESCRIPTION
Older versions of pydantic didn't support `typing.Annotated`, since `typing.Annotated` didn't exist yet. I added a workaround for this.

Fixes #186