### PR TITLE
Apply `use_underscores` to decorator-based subcommand names

### DIFF
--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -323,9 +323,9 @@ def _cli_impl(
 
         if "=" in arg:
             arg, _, val = arg.partition("=")
-            fixed = "--" + _strings.replace_delimeter_in_part(arg[2:]) + "=" + val
+            fixed = "--" + _strings.swap_delimeters(arg[2:]) + "=" + val
         else:
-            fixed = "--" + _strings.replace_delimeter_in_part(arg[2:])
+            fixed = "--" + _strings.swap_delimeters(arg[2:])
         if (
             return_unknown_args
             and fixed in modified_args

--- a/src/tyro/_strings.py
+++ b/src/tyro/_strings.py
@@ -30,7 +30,7 @@ def get_delimeter() -> Literal["-", "_"]:
     return DELIMETER
 
 
-def replace_delimeter_in_part(p: str) -> str:
+def swap_delimeters(p: str) -> str:
     """Replace hyphens with underscores (or vice versa) except when at the start."""
     if get_delimeter() == "-":
         stripped = p.lstrip("_")
@@ -49,7 +49,7 @@ def make_field_name(parts: Sequence[str]) -> str:
     """
     out = ".".join(parts)
     return ".".join(
-        replace_delimeter_in_part(part)
+        swap_delimeters(part)
         for part in out.split(".")
         if len(part) > 0 and part != dummy_field_name
     )

--- a/tests/test_decorator_subcommands.py
+++ b/tests/test_decorator_subcommands.py
@@ -8,7 +8,7 @@ app_just_one = SubcommandApp()
 
 @app_just_one.command
 @app.command
-def greet(name: str, loud: bool = False) -> None:
+def greet_person(name: str, loud: bool = False) -> None:
     """Greet someone."""
     greeting = f"Hello, {name}!"
     if loud:
@@ -28,7 +28,7 @@ def test_app_just_one_cli(capsys):
         app_just_one.cli(args=["--help"])
     captured = capsys.readouterr()
     assert "usage: " in captured.out
-    assert "greet" not in captured.out
+    assert "greet-person" not in captured.out
     assert "addition" not in captured.out
     assert "--name" in captured.out
 
@@ -39,23 +39,23 @@ def test_app_cli(capsys):
         app.cli(args=["--help"])
     captured = capsys.readouterr()
     assert "usage: " in captured.out
-    assert "greet" in captured.out
+    assert "greet-person" in captured.out
     assert "addition" in captured.out
 
-    # Test: `python my_script.py greet --help`
+    # Test: `python my_script.py greet-person --help`
     with pytest.raises(SystemExit):
-        app.cli(args=["greet", "--help"], sort_subcommands=False)
+        app.cli(args=["greet-person", "--help"], sort_subcommands=False)
     captured = capsys.readouterr()
     assert "usage: " in captured.out
     assert "Greet someone." in captured.out
 
-    # Test: `python my_script.py greet --name Alice`
-    app.cli(args=["greet", "--name", "Alice"], sort_subcommands=True)
+    # Test: `python my_script.py greet-person --name Alice`
+    app.cli(args=["greet-person", "--name", "Alice"], sort_subcommands=True)
     captured = capsys.readouterr()
     assert captured.out.strip() == "Hello, Alice!"
 
-    # Test: `python my_script.py greet --name Bob --loud`
-    app.cli(args=["greet", "--name", "Bob", "--loud"])
+    # Test: `python my_script.py greet-person --name Bob --loud`
+    app.cli(args=["greet-person", "--name", "Bob", "--loud"])
     captured = capsys.readouterr()
     assert captured.out.strip() == "HELLO, BOB!"
 
@@ -70,3 +70,16 @@ def test_app_cli(capsys):
     app.cli(args=["addition", "--a", "5", "--b", "3"])
     captured = capsys.readouterr()
     assert captured.out.strip() == "5 + 3 = 8"
+
+
+def test_use_underscores(capsys) -> None:
+    with pytest.raises(SystemExit):
+        app.cli(args=["--help"], use_underscores=True)
+    captured = capsys.readouterr()
+    assert "greet-person" not in captured.out
+    assert "greet_person" in captured.out
+
+    # Test: `python my_script.py greet-person --name Bob --loud`
+    app.cli(args=["greet_person", "--name", "Bob", "--loud"], use_underscores=True)
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "HELLO, BOB!"

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -5,16 +5,7 @@ import io
 import json as json_
 import shlex
 import sys
-from typing import (
-    Annotated,
-    Any,
-    Dict,
-    Generic,
-    List,
-    Tuple,
-    Type,
-    TypeVar,
-)
+from typing import Annotated, Any, Dict, Generic, List, Tuple, Type, TypeVar
 
 import pytest
 from helptext_utils import get_helptext_with_checks

--- a/tests/test_py311_generated/test_decorator_subcommands_generated.py
+++ b/tests/test_py311_generated/test_decorator_subcommands_generated.py
@@ -8,7 +8,7 @@ app_just_one = SubcommandApp()
 
 @app_just_one.command
 @app.command
-def greet(name: str, loud: bool = False) -> None:
+def greet_person(name: str, loud: bool = False) -> None:
     """Greet someone."""
     greeting = f"Hello, {name}!"
     if loud:
@@ -28,7 +28,7 @@ def test_app_just_one_cli(capsys):
         app_just_one.cli(args=["--help"])
     captured = capsys.readouterr()
     assert "usage: " in captured.out
-    assert "greet" not in captured.out
+    assert "greet-person" not in captured.out
     assert "addition" not in captured.out
     assert "--name" in captured.out
 
@@ -39,23 +39,23 @@ def test_app_cli(capsys):
         app.cli(args=["--help"])
     captured = capsys.readouterr()
     assert "usage: " in captured.out
-    assert "greet" in captured.out
+    assert "greet-person" in captured.out
     assert "addition" in captured.out
 
-    # Test: `python my_script.py greet --help`
+    # Test: `python my_script.py greet-person --help`
     with pytest.raises(SystemExit):
-        app.cli(args=["greet", "--help"], sort_subcommands=False)
+        app.cli(args=["greet-person", "--help"], sort_subcommands=False)
     captured = capsys.readouterr()
     assert "usage: " in captured.out
     assert "Greet someone." in captured.out
 
-    # Test: `python my_script.py greet --name Alice`
-    app.cli(args=["greet", "--name", "Alice"], sort_subcommands=True)
+    # Test: `python my_script.py greet-person --name Alice`
+    app.cli(args=["greet-person", "--name", "Alice"], sort_subcommands=True)
     captured = capsys.readouterr()
     assert captured.out.strip() == "Hello, Alice!"
 
-    # Test: `python my_script.py greet --name Bob --loud`
-    app.cli(args=["greet", "--name", "Bob", "--loud"])
+    # Test: `python my_script.py greet-person --name Bob --loud`
+    app.cli(args=["greet-person", "--name", "Bob", "--loud"])
     captured = capsys.readouterr()
     assert captured.out.strip() == "HELLO, BOB!"
 
@@ -70,3 +70,16 @@ def test_app_cli(capsys):
     app.cli(args=["addition", "--a", "5", "--b", "3"])
     captured = capsys.readouterr()
     assert captured.out.strip() == "5 + 3 = 8"
+
+
+def test_use_underscores(capsys) -> None:
+    with pytest.raises(SystemExit):
+        app.cli(args=["--help"], use_underscores=True)
+    captured = capsys.readouterr()
+    assert "greet-person" not in captured.out
+    assert "greet_person" in captured.out
+
+    # Test: `python my_script.py greet-person --name Bob --loud`
+    app.cli(args=["greet_person", "--name", "Bob", "--loud"], use_underscores=True)
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "HELLO, BOB!"

--- a/tests/test_py311_generated/test_pydantic_with_newtype_generated.py
+++ b/tests/test_py311_generated/test_pydantic_with_newtype_generated.py
@@ -9,11 +9,13 @@ Microliter = NewType("Microliter", int)
 
 
 class Measurements(BaseModel):
-    single: Microliter = pydantic.Field(10)
+    single: Microliter = pydantic.Field(Microliter(10))
     renamed_single: Annotated[Microliter, tyro.conf.arg(name="other_single")] = (
-        pydantic.Field(10)
+        pydantic.Field(Microliter(10))
     )
-    pair: Tuple[Microliter, Microliter] = pydantic.Field((20, 30))
+    pair: Tuple[Microliter, Microliter] = pydantic.Field(
+        (Microliter(20), Microliter(30))
+    )
 
 
 IncorrectMeasurements = NewType("IncorrectMeasurements", Measurements)

--- a/tests/test_pydantic_with_newtype.py
+++ b/tests/test_pydantic_with_newtype.py
@@ -10,11 +10,13 @@ Microliter = NewType("Microliter", int)
 
 
 class Measurements(BaseModel):
-    single: Microliter = pydantic.Field(10)
+    single: Microliter = pydantic.Field(Microliter(10))
     renamed_single: Annotated[Microliter, tyro.conf.arg(name="other_single")] = (
-        pydantic.Field(10)
+        pydantic.Field(Microliter(10))
     )
-    pair: Tuple[Microliter, Microliter] = pydantic.Field((20, 30))
+    pair: Tuple[Microliter, Microliter] = pydantic.Field(
+        (Microliter(20), Microliter(30))
+    )
 
 
 IncorrectMeasurements = NewType("IncorrectMeasurements", Measurements)


### PR DESCRIPTION
Previously, this was only being applied to subcommand names generated from union types and to argument names.

Fixes #205