### PR TITLE
Fix instantiation edge cases for custom struct types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "PyYAML>=6.0",
-    "frozendict>=2.3.4",
     "pytest>=7.1.2",
     "pytest-cov>=3.0.0",
     "omegaconf>=2.2.2",

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -281,7 +281,7 @@ def _rule_apply_primitive_specs(
     if lowered.instance_from_str is not None:
         return
 
-    spec = ConstructorRegistry._get_active_registry().get_primitive_spec(
+    spec = ConstructorRegistry.get_primitive_spec(
         PrimitiveTypeInfo.make(
             cast(type, arg.field.type),
             arg.field.markers,

--- a/src/tyro/_calling.py
+++ b/src/tyro/_calling.py
@@ -230,14 +230,8 @@ def callable_with_args(
             field_name_prefix,
         )
 
-    # Note: we unwrap types both before and after narrowing. This is because narrowing
-    # sometimes produces types like `Tuple[T1, T2, ...]`, where we actually want just
-    # `tuple`.
-    unwrapped_f = f
-    unwrapped_f = _resolver.swap_type_using_confstruct(unwrapped_f)
-    unwrapped_f = _resolver.unwrap_origin_strip_extras(unwrapped_f)
+    unwrapped_f = parser_definition.f
     unwrapped_f = _resolver.narrow_subtypes(unwrapped_f, default_instance)
-    unwrapped_f = _resolver.unwrap_origin_strip_extras(unwrapped_f)
 
     if unwrapped_f in (tuple, list, set):
         if len(positional_args) > 0:

--- a/src/tyro/_calling.py
+++ b/src/tyro/_calling.py
@@ -231,8 +231,6 @@ def callable_with_args(
         )
 
     unwrapped_f = parser_definition.f
-    unwrapped_f = _resolver.narrow_subtypes(unwrapped_f, default_instance)
-
     if unwrapped_f in (tuple, list, set):
         if len(positional_args) > 0:
             # Triggered when support_single_arg_types=True is used.

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -228,11 +228,10 @@ def field_list_from_type_or_callable(
     """
 
     f = _resolver.swap_type_using_confstruct(f)
-    registry = ConstructorRegistry._get_active_registry()
     type_info = StructTypeInfo.make(f, default_instance)
 
     with type_info._typevar_context:
-        spec = registry.get_struct_spec(type_info)
+        spec = ConstructorRegistry.get_struct_spec(type_info)
 
         with FieldDefinition.marker_context(type_info.markers):
             if spec is not None:
@@ -240,11 +239,7 @@ def field_list_from_type_or_callable(
                     FieldDefinition.from_field_spec(f) for f in spec.fields
                 ]
 
-            is_primitive = not isinstance(
-                registry.get_primitive_spec(PrimitiveTypeInfo.make(f, set())),
-                UnsupportedTypeAnnotationError,
-            )
-
+            is_primitive = ConstructorRegistry._is_primitive_type(f, set())
             if is_primitive and support_single_arg_types:
                 with FieldDefinition.marker_context(
                     (_markers.Positional, _markers._PositionalCall)

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -17,7 +17,6 @@ from ._singleton import MISSING_AND_MISSING_NONPROP, MISSING_NONPROP
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
 from .constructors._primitive_spec import (
-    PrimitiveTypeInfo,
     UnsupportedTypeAnnotationError,
 )
 from .constructors._registry import ConstructorRegistry

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -236,7 +236,9 @@ def field_list_from_type_or_callable(
 
         with FieldDefinition.marker_context(type_info.markers):
             if spec is not None:
-                return f, [FieldDefinition.from_field_spec(f) for f in spec.fields]
+                return spec.instantiate, [
+                    FieldDefinition.from_field_spec(f) for f in spec.fields
+                ]
 
             is_primitive = not isinstance(
                 registry.get_primitive_spec(PrimitiveTypeInfo.make(f, set())),
@@ -248,7 +250,7 @@ def field_list_from_type_or_callable(
                     (_markers.Positional, _markers._PositionalCall)
                 ):
                     return (
-                        f,
+                        lambda x: x,
                         [
                             FieldDefinition.make(
                                 name="value",
@@ -281,6 +283,10 @@ def _field_list_from_function(
     except ValueError:
         return UnsupportedStructTypeMessage(f"Could not get signature for {f}!")
 
+    # `f` that is called (output) may be different from what we want to
+    # inspect.
+    f_out = f
+
     # Unwrap functools.wraps and functools.partial.
     done = False
     while not done:
@@ -296,9 +302,10 @@ def _field_list_from_function(
     if inspect.isabstract(f):
         return UnsupportedStructTypeMessage("Abstract classes cannot be instantiated!")
 
-    # `f` that is called (output) may be different from what we want to
-    # inspect.
-    f_out = f
+    # If `f` is class, we want to inspect its __init__ method for the
+    # signature. But the docstrings may still be in the class signature itself.
+    f_before_init_unwrap = f
+
     if inspect.isclass(f):
         if hasattr(f, "__init__") and f.__init__ is not object.__init__:
             f = f.__init__  # type: ignore
@@ -328,8 +335,8 @@ def _field_list_from_function(
         helptext = docstring_from_arg_name.get(param.name)
 
         # TODO: re-add.
-        if helptext is None and inspect.isclass(f_out):
-            helptext = _docstrings.get_field_docstring(f_out, param.name)
+        if helptext is None and inspect.isclass(f_before_init_unwrap):
+            helptext = _docstrings.get_field_docstring(f_before_init_unwrap, param.name)
 
         if param.name not in hints:
             out = UnsupportedStructTypeMessage(

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -321,8 +321,6 @@ def handle_field(
 ]:
     """Determine what to do with a single field definition."""
 
-    registry = ConstructorRegistry._get_active_registry()
-
     # Check that the default value matches the final resolved type.
     # There's some similar Union-specific logic for this in narrow_union_type(). We
     # may be able to consolidate this.
@@ -351,18 +349,11 @@ def handle_field(
 
     # Force primitive if (1) the field is annotated with a primitive constructor spec, or (2) if
     # a custom primitive exists for the type.
-    force_primitive = False
-
-    if len(_resolver.unwrap_annotated(field.type, PrimitiveConstructorSpec)[1]) > 0:
-        force_primitive = True
-    elif len(registry._custom_primitive_rules) > 0:
-        # Can we parse this as a primitive?
-        force_primitive = not isinstance(
-            registry.get_primitive_spec(
-                PrimitiveTypeInfo.make(field.type, field.markers)
-            ),
-            UnsupportedTypeAnnotationError,
-        )
+    force_primitive = (
+        len(_resolver.unwrap_annotated(field.type, PrimitiveConstructorSpec)[1]) > 0
+    ) or ConstructorRegistry._is_primitive_type(
+        field.type, field.markers, nondefault_only=True
+    )
 
     if (
         not force_primitive

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -39,7 +39,6 @@ from ._typing import TypeForm
 from .conf import _confstruct, _markers
 from .constructors._primitive_spec import (
     PrimitiveConstructorSpec,
-    PrimitiveTypeInfo,
     UnsupportedTypeAnnotationError,
 )
 

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -89,16 +89,6 @@ class ParserSpecification:
         markers = markers | set(_resolver.unwrap_annotated(f, _markers._Marker)[1])
         consolidate_subcommand_args = _markers.ConsolidateSubcommandArgs in markers
 
-        # Resolve the type of `f`, generate a field list.
-        with _fields.FieldDefinition.marker_context(tuple(markers)):
-            out = _fields.field_list_from_type_or_callable(
-                f=f,
-                default_instance=default_instance,
-                support_single_arg_types=support_single_arg_types,
-            )
-            assert not isinstance(out, UnsupportedStructTypeMessage)
-            f, field_list = out
-
         # Cycle detection.
         #
         # 'parent' here refers to in the nesting hierarchy, not the superclass.
@@ -111,6 +101,16 @@ class ParserSpecification:
         # callables throughout the code. This is mostly for legacy reasons, could be
         # cleaned up.
         parent_classes = parent_classes | {cast(Type, f)}
+
+        # Resolve the type of `f`, generate a field list.
+        with _fields.FieldDefinition.marker_context(tuple(markers)):
+            out = _fields.field_list_from_type_or_callable(
+                f=f,
+                default_instance=default_instance,
+                support_single_arg_types=support_single_arg_types,
+            )
+            assert not isinstance(out, UnsupportedStructTypeMessage)
+            f, field_list = out
 
         has_required_args = False
         args = []

--- a/src/tyro/constructors/_struct_spec.py
+++ b/src/tyro/constructors/_struct_spec.py
@@ -5,7 +5,7 @@ import dataclasses
 import enum
 import sys
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Sequence
 
 from typing_extensions import (
     Annotated,
@@ -15,10 +15,6 @@ from typing_extensions import (
     get_args,
     get_origin,
     is_typeddict,
-)
-from tyro.constructors._primitive_spec import (
-    PrimitiveConstructorSpec,
-    PrimitiveTypeInfo,
 )
 
 from .. import _docstrings, _resolver

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -1,8 +1,7 @@
 import dataclasses
-from typing import Any, Generic, Mapping, NewType, Optional, Tuple, TypeVar, Union
+from typing import Any, Generic, NewType, Optional, Tuple, TypeVar, Union
 
 import pytest
-from frozendict import frozendict  # type: ignore
 from helptext_utils import get_helptext_with_checks
 from typing_extensions import Annotated, Final, Literal
 
@@ -1049,20 +1048,20 @@ def test_subparser_in_nested() -> None:
     ) == Parent(Nested1(Nested2(B(7))))
 
 
-def test_frozen_dict() -> None:
-    def main(
-        x: Mapping[str, float] = frozendict(  # type: ignore
-            {
-                "num_epochs": 20,
-                "batch_size": 64,
-            }
-        ),
-    ):
-        return x
-
-    assert hash(tyro.cli(main, args="--x.num-epochs 10".split(" "))) == hash(
-        frozendict({"num_epochs": 10, "batch_size": 64})  # type: ignore
-    )
+# def test_frozen_dict() -> None:
+#     def main(
+#         x: Mapping[str, float] = frozendict(  # type: ignore
+#             {
+#                 "num_epochs": 20,
+#                 "batch_size": 64,
+#             }
+#         ),
+#     ):
+#         return x
+#
+#     assert hash(tyro.cli(main, args="--x.num-epochs 10".split(" "))) == hash(
+#         frozendict({"num_epochs": 10, "batch_size": 64})  # type: ignore
+#     )
 
 
 def test_nested_in_subparser() -> None:

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -5,7 +5,6 @@ from typing import (
     Final,
     Generic,
     Literal,
-    Mapping,
     NewType,
     Optional,
     Tuple,
@@ -13,7 +12,6 @@ from typing import (
 )
 
 import pytest
-from frozendict import frozendict  # type: ignore
 from helptext_utils import get_helptext_with_checks
 
 import tyro
@@ -1059,20 +1057,20 @@ def test_subparser_in_nested() -> None:
     ) == Parent(Nested1(Nested2(B(7))))
 
 
-def test_frozen_dict() -> None:
-    def main(
-        x: Mapping[str, float] = frozendict(  # type: ignore
-            {
-                "num_epochs": 20,
-                "batch_size": 64,
-            }
-        ),
-    ):
-        return x
-
-    assert hash(tyro.cli(main, args="--x.num-epochs 10".split(" "))) == hash(
-        frozendict({"num_epochs": 10, "batch_size": 64})  # type: ignore
-    )
+# def test_frozen_dict() -> None:
+#     def main(
+#         x: Mapping[str, float] = frozendict(  # type: ignore
+#             {
+#                 "num_epochs": 20,
+#                 "batch_size": 64,
+#             }
+#         ),
+#     ):
+#         return x
+#
+#     assert hash(tyro.cli(main, args="--x.num-epochs 10".split(" "))) == hash(
+#         frozendict({"num_epochs": 10, "batch_size": 64})  # type: ignore
+#     )
 
 
 def test_nested_in_subparser() -> None:


### PR DESCRIPTION
- The `instantiate=` function passed into `StructConstructorSpec` is now correctly used.
- Multiple constructor registries can now be active simultaneously.
- Simpler logic for determining whether a type is a primitive or a struct.