### PR TITLE
Improve error messages when tyro.conf.arg() options are set

### DIFF
--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -124,7 +124,7 @@ def recursive_arg_search(
             ):
                 continue
 
-            option_strings = (arg.lowered.name_or_flag,)
+            option_strings = arg.lowered.name_or_flags
 
             # Handle actions, eg BooleanOptionalAction will map ("--flag",) to
             # ("--flag", "--no-flag").
@@ -154,7 +154,9 @@ def recursive_arg_search(
 
             # An unrecognized argument.
             nonlocal same_exists
-            if not same_exists and arg.lowered.name_or_flag in unrecognized_arguments:
+            if not same_exists and any(
+                map(lambda x: x in unrecognized_arguments, arg.lowered.name_or_flags)
+            ):
                 same_exists = True
 
         if parser_spec.subparsers is not None:
@@ -775,6 +777,8 @@ class TyroArgumentParser(argparse.ArgumentParser, argparse_sys.ArgumentParser): 
 
             info_from_required_arg: Dict[str, Optional[_ArgumentInfo]] = {}
             for arg in message.partition(":")[2].strip().split(", "):
+                if "/" in arg:
+                    arg = arg.split("/")[0]
                 info_from_required_arg[arg] = None
 
             arguments, has_subcommands, same_exists = recursive_arg_search(

--- a/src/tyro/_calling.py
+++ b/src/tyro/_calling.py
@@ -118,7 +118,7 @@ def callable_with_args(
                 parsed_value = value_from_prefixed_field_name.get(prefixed_field_name)
                 if parsed_value not in _fields.MISSING_AND_MISSING_NONPROP:
                     raise InstantiationError(
-                        f"{arg.lowered.name_or_flag} was passed in, but"
+                        f"{'/'.join(arg.lowered.name_or_flags)} was passed in, but"
                         " is a fixed argument that cannot be parsed",
                         arg,
                     )
@@ -218,7 +218,7 @@ def callable_with_args(
                 found = False
                 for arg in arg_from_prefixed_field_name.values():
                     if arg.field.call_argname == k:
-                        missing_args.append(arg.lowered.name_or_flag)
+                        missing_args.append("/".join(arg.lowered.name_or_flags))
                         found = True
                         break
                 assert found, "This is likely a bug in tyro."

--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -483,7 +483,7 @@ def _cli_impl(
                 Panel(
                     Group(
                         "[bright_red][bold]Error parsing"
-                        f" {e.arg.lowered.name_or_flag if isinstance(e.arg, _arguments.ArgumentDefinition) else e.arg}[/bold]:[/bright_red] {e.message}",
+                        f" {'/'.join(e.arg.lowered.name_or_flags) if isinstance(e.arg, _arguments.ArgumentDefinition) else e.arg}[/bold]:[/bright_red] {e.message}",
                         *cast(  # Cast to appease mypy...
                             list,
                             (
@@ -495,7 +495,7 @@ def _cli_impl(
                                     "Argument helptext:",
                                     Padding(
                                         Group(
-                                            f"{e.arg.lowered.name_or_flag} [bold]{e.arg.lowered.metavar}[/bold]",
+                                            f"{'/'.join(e.arg.lowered.name_or_flags)} [bold]{e.arg.lowered.metavar}[/bold]",
                                             e.arg.lowered.help,
                                         ),
                                         pad=(0, 0, 0, 4),

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -251,7 +251,7 @@ class ParserSpecification:
             return (group_name + " options").strip()
 
         def group_name_from_arg(arg: _arguments.ArgumentDefinition) -> str:
-            prefix = arg.lowered.name_or_flag
+            prefix = arg.lowered.name_or_flags[0]
             if prefix.startswith("--"):
                 prefix = prefix[2:]
             if "." in prefix:

--- a/src/tyro/conf/_confstruct.py
+++ b/src/tyro/conf/_confstruct.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable, Sequence, TypeVar, overload
+from typing import Any, Callable, TypeVar, overload
 
 from .._singleton import MISSING_NONPROP
 
@@ -130,7 +130,7 @@ def arg(
     metavar: str | None = None,
     help: str | None = None,
     help_behavior_hint: str | Callable[[str], str] | None = None,
-    aliases: Sequence[str] | None = None,
+    aliases: tuple[str, ...] | list[str] | None = None,
     prefix_name: bool | None = None,
     constructor: None = None,
     constructor_factory: Callable[[], type | Callable] | None = None,
@@ -144,7 +144,7 @@ def arg(
     metavar: str | None = None,
     help: str | None = None,
     help_behavior_hint: str | Callable[[str], str] | None = None,
-    aliases: Sequence[str] | None = None,
+    aliases: tuple[str, ...] | list[str] | None = None,
     prefix_name: bool | None = None,
     constructor: type | Callable | None = None,
     constructor_factory: None = None,
@@ -157,7 +157,7 @@ def arg(
     metavar: str | None = None,
     help: str | None = None,
     help_behavior_hint: str | Callable[[str], str] | None = None,
-    aliases: Sequence[str] | None = None,
+    aliases: tuple[str, ...] | list[str] | None = None,
     prefix_name: bool | None = None,
     constructor: type | Callable | None = None,
     constructor_factory: Callable[[], type | Callable] | None = None,

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -551,14 +551,18 @@ def test_set_narrowing() -> None:
     def main(x: set = {0, 1, 2, "hello"}) -> Any:
         return x
 
-    assert tyro.cli(main, args="--x hi there 5".split(" ")) == {"hi", "there", 5}
+    out = tyro.cli(main, args="--x hi there 5".split(" "))
+    # Nondeterministic depending on set iteration order, `int | str` or `str | int`.
+    assert out in ({"hi", "there", 5}, {"hi", "there", "5"})
 
 
 def test_set_narrowing_any() -> None:
     def main(x: Set[Any] = {0, 1, 2, "hello"}) -> Any:
         return x
 
-    assert tyro.cli(main, args="--x hi there 5".split(" ")) == {"hi", "there", 5}
+    out = tyro.cli(main, args="--x hi there 5".split(" "))
+    # Nondeterministic depending on set iteration order, `int | str` or `str | int`.
+    assert out in ({"hi", "there", 5}, {"hi", "there", "5"})
 
 
 def test_set_narrowing_empty() -> None:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1382,7 +1382,7 @@ def test_alias() -> None:
         tyro.cli(Config, args="--x.struct.b 5".split(" "))
     error = target.getvalue()
     assert "We're missing arguments" in error
-    assert "'--x.struct.a'" in error
+    assert "'--x.struct.a/--all/-d'" in error
     assert "'--x.struct.b'" not in error
 
     assert "--x.struct.a INT, --all INT, -d INT" in get_helptext_with_checks(Config)

--- a/tests/test_py311_generated/test_collections_generated.py
+++ b/tests/test_py311_generated/test_collections_generated.py
@@ -550,14 +550,18 @@ def test_set_narrowing() -> None:
     def main(x: set = {0, 1, 2, "hello"}) -> Any:
         return x
 
-    assert tyro.cli(main, args="--x hi there 5".split(" ")) == {"hi", "there", 5}
+    out = tyro.cli(main, args="--x hi there 5".split(" "))
+    # Nondeterministic depending on set iteration order, `int | str` or `str | int`.
+    assert out in ({"hi", "there", 5}, {"hi", "there", "5"})
 
 
 def test_set_narrowing_any() -> None:
     def main(x: Set[Any] = {0, 1, 2, "hello"}) -> Any:
         return x
 
-    assert tyro.cli(main, args="--x hi there 5".split(" ")) == {"hi", "there", 5}
+    out = tyro.cli(main, args="--x hi there 5".split(" "))
+    # Nondeterministic depending on set iteration order, `int | str` or `str | int`.
+    assert out in ({"hi", "there", 5}, {"hi", "there", "5"})
 
 
 def test_set_narrowing_empty() -> None:

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1379,7 +1379,7 @@ def test_alias() -> None:
         tyro.cli(Config, args="--x.struct.b 5".split(" "))
     error = target.getvalue()
     assert "We're missing arguments" in error
-    assert "'--x.struct.a'" in error
+    assert "'--x.struct.a/--all/-d'" in error
     assert "'--x.struct.b'" not in error
 
     assert "--x.struct.a INT, --all INT, -d INT" in get_helptext_with_checks(Config)

--- a/tests/test_py311_generated/test_errors_generated.py
+++ b/tests/test_py311_generated/test_errors_generated.py
@@ -1,7 +1,7 @@
 import contextlib
 import dataclasses
 import io
-from typing import Dict, List, Literal, Tuple, TypeVar
+from typing import Annotated, Dict, List, Literal, Tuple, TypeVar
 
 import pytest
 
@@ -660,3 +660,23 @@ def test_invalid_subcommand_default() -> None:
 
     with pytest.warns(UserWarning):
         assert tyro.cli(A | B, default=C(3), args="b --b 5".split(" ")) == B(5)  # type: ignore
+
+
+def test_alias_error() -> None:
+    """https://github.com/brentyi/tyro/issues/218"""
+
+    @dataclasses.dataclass
+    class Train:
+        # residual block
+        residual: Annotated[
+            Literal["residual", "ResidualBlock", "double", "DoubleConv"],
+            tyro.conf.arg(metavar="{residual,double}"),
+        ]
+
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stderr(target):
+        tyro.cli(Train, args=[])
+
+    error = target.getvalue()
+    assert "{residual,double}" in error
+    assert "DoubleConv" not in error


### PR DESCRIPTION
- Show overridden metavars in error messages when available (fixes #218)
- Show aliases in error messages