### PR TITLE
Fix subcommand edge cases associated with generics, `tyro.conf.Suppress`, `tyro.conf.AvoidSubcomands`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 <br />
 
 <strong><code>tyro.cli()</code></strong> is a tool for generating CLI
-interfaces in Python.
+interfaces from type-annotated Python.
 
 We can define configurable scripts using functions:
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,7 +2,7 @@
 
 |ruff| |nbsp| |mypy| |nbsp| |pyright| |nbsp| |coverage| |nbsp| |versions|
 
-:func:`tyro.cli()` is a tool for generating CLI interfaces in Python.
+:func:`tyro.cli()` is a tool for generating CLI interfaces from type-annotated Python.
 
 We can define configurable scripts using functions:
 

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -17,7 +17,7 @@ from ._singleton import MISSING_AND_MISSING_NONPROP, MISSING_NONPROP
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
 from .constructors._primitive_spec import UnsupportedTypeAnnotationError
-from .constructors._registry import ConstructorRegistry
+from .constructors._registry import ConstructorRegistry, check_default_instances
 from .constructors._struct_spec import (
     StructFieldSpec,
     StructTypeInfo,
@@ -92,7 +92,10 @@ class FieldDefinition:
             # called for functions.
             typ = _resolver.type_from_typevar_constraints(typ)
             typ = _resolver.narrow_collection_types(typ, default)
-            typ = _resolver.narrow_union_type(typ, default)
+
+            # Be forgiving about default instances.
+            if not check_default_instances():
+                typ = _resolver.expand_union_types(typ, default)
 
         # Try to extract argconf overrides from type.
         _, argconfs = _resolver.unwrap_annotated(typ, _confstruct._ArgConfig)

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -457,8 +457,8 @@ class TypeParamAssignmentContext:
 
 
 @_unsafe_cache.unsafe_cache(maxsize=1024)
-def narrow_union_type(typ: TypeOrCallable, default_instance: Any) -> TypeOrCallable:
-    """Narrow union types.
+def expand_union_types(typ: TypeOrCallable, default_instance: Any) -> TypeOrCallable:
+    """Expand union types if necessary.
 
     This is a shim for failing more gracefully when we we're given a Union type that
     doesn't match the default value.

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1573,8 +1573,10 @@ def test_suppressed_subcommand() -> None:
 
 
 def test_avoid_subcommands_with_generics() -> None:
+    T = TypeVar("T")
+
     @dataclasses.dataclass(frozen=True)
-    class Person[T]:
+    class Person(Generic[T]):
         field: T | bool
 
     @dataclasses.dataclass

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1579,7 +1579,9 @@ def test_avoid_subcommands_with_generics() -> None:
 
     @dataclasses.dataclass
     class Train:
-        person: Person[str] | Person[int] = Person("hello")
+        person: Person[int] | Person[bool] | Person[str] | Person[float] = Person(
+            "hello"
+        )
 
     assert tyro.cli(Train, config=(tyro.conf.AvoidSubcommands,), args=[]) == Train(
         person=Person("hello")

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -5,7 +5,7 @@ import io
 import json as json_
 import shlex
 import sys
-from typing import Any, Dict, Generic, List, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Tuple, Type, TypedDict, TypeVar, Union
 
 import pytest
 from helptext_utils import get_helptext_with_checks
@@ -1558,3 +1558,41 @@ def test_nested_suppress() -> None:
         b_conf: Bconfig = dataclasses.field(default_factory=Bconfig)
 
     assert tyro.cli(Aconfig, config=(tyro.conf.Suppress,), args=[]) == Aconfig()
+
+
+def test_suppressed_subcommand() -> None:
+    class Person(TypedDict):
+        name: str
+        age: int
+
+    @dataclasses.dataclass
+    class Train:
+        person: tyro.conf.Suppress[Person | None] = None
+
+    assert tyro.cli(Train, args=[]) == Train(None)
+
+
+def test_avoid_subcommands_with_generics() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class Person[T]:
+        field: T | bool
+
+    @dataclasses.dataclass
+    class Train:
+        person: Person[str] | Person[int] = Person("hello")
+
+    assert tyro.cli(Train, config=(tyro.conf.AvoidSubcommands,), args=[]) == Train(
+        person=Person("hello")
+    )
+
+    # No subcommand should be created.
+    assert "STR|{True,False}" in get_helptext_with_checks(
+        tyro.conf.AvoidSubcommands[Train]
+    )
+    assert "person:person-str" not in get_helptext_with_checks(
+        tyro.conf.AvoidSubcommands[Train]
+    )
+
+    # Subcommand should be created.
+    assert "STR|{True,False}" not in get_helptext_with_checks(Train)
+    assert "person:person-str" in get_helptext_with_checks(Train)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -5,11 +5,11 @@ import io
 import json as json_
 import shlex
 import sys
-from typing import Any, Dict, Generic, List, Tuple, Type, TypedDict, TypeVar, Union
+from typing import Any, Dict, Generic, List, Tuple, Type, TypeVar, Union
 
 import pytest
 from helptext_utils import get_helptext_with_checks
-from typing_extensions import Annotated
+from typing_extensions import Annotated, TypedDict
 
 import tyro
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1567,7 +1567,7 @@ def test_suppressed_subcommand() -> None:
 
     @dataclasses.dataclass
     class Train:
-        person: tyro.conf.Suppress[Person | None] = None
+        person: tyro.conf.Suppress[Union[Person, None]] = None
 
     assert tyro.cli(Train, args=[]) == Train(None)
 
@@ -1577,11 +1577,11 @@ def test_avoid_subcommands_with_generics() -> None:
 
     @dataclasses.dataclass(frozen=True)
     class Person(Generic[T]):
-        field: T | bool
+        field: Union[T, bool]
 
     @dataclasses.dataclass
     class Train:
-        person: Person[int] | Person[bool] | Person[str] | Person[float] = Person(
+        person: Union[Person[int], Person[bool], Person[str], Person[float]] = Person(
             "hello"
         )
 

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -5,7 +5,17 @@ import io
 import json as json_
 import shlex
 import sys
-from typing import Annotated, Any, Dict, Generic, List, Tuple, Type, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Tuple,
+    Type,
+    TypedDict,
+    TypeVar,
+)
 
 import pytest
 from helptext_utils import get_helptext_with_checks
@@ -1553,3 +1563,41 @@ def test_nested_suppress() -> None:
         b_conf: Bconfig = dataclasses.field(default_factory=Bconfig)
 
     assert tyro.cli(Aconfig, config=(tyro.conf.Suppress,), args=[]) == Aconfig()
+
+
+def test_suppressed_subcommand() -> None:
+    class Person(TypedDict):
+        name: str
+        age: int
+
+    @dataclasses.dataclass
+    class Train:
+        person: tyro.conf.Suppress[Person | None] = None
+
+    assert tyro.cli(Train, args=[]) == Train(None)
+
+
+def test_avoid_subcommands_with_generics() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class Person[T]:
+        field: T | bool
+
+    @dataclasses.dataclass
+    class Train:
+        person: Person[str] | Person[int] = Person("hello")
+
+    assert tyro.cli(Train, config=(tyro.conf.AvoidSubcommands,), args=[]) == Train(
+        person=Person("hello")
+    )
+
+    # No subcommand should be created.
+    assert "STR|{True,False}" in get_helptext_with_checks(
+        tyro.conf.AvoidSubcommands[Train]
+    )
+    assert "person:person-str" not in get_helptext_with_checks(
+        tyro.conf.AvoidSubcommands[Train]
+    )
+
+    # Subcommand should be created.
+    assert "STR|{True,False}" not in get_helptext_with_checks(Train)
+    assert "person:person-str" in get_helptext_with_checks(Train)

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1584,7 +1584,9 @@ def test_avoid_subcommands_with_generics() -> None:
 
     @dataclasses.dataclass
     class Train:
-        person: Person[str] | Person[int] = Person("hello")
+        person: Person[int] | Person[bool] | Person[str] | Person[float] = Person(
+            "hello"
+        )
 
     assert tyro.cli(Train, config=(tyro.conf.AvoidSubcommands,), args=[]) == Train(
         person=Person("hello")

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1578,8 +1578,10 @@ def test_suppressed_subcommand() -> None:
 
 
 def test_avoid_subcommands_with_generics() -> None:
+    T = TypeVar("T")
+
     @dataclasses.dataclass(frozen=True)
-    class Person[T]:
+    class Person(Generic[T]):
         field: T | bool
 
     @dataclasses.dataclass


### PR DESCRIPTION
Now fixed:
- [x] `tyro.conf.AvoidSubcommands` could unnecessarily narrow types when generic types were placed in unions.
- [x] `x: tyro.conf.Suppress[StructA | None] = None` was throwing an error if a default was missing from `StructA`.

Example of one bug we had:
```python
from dataclasses import dataclass
import tyro

@dataclass(frozen=True)
class Container[T]:
    value: T | bool

def main(
    container: Container[int] | Container[str] = Container("default string"),
) -> None:
    print(container.value)

if __name__ == "__main__":
    tyro.cli(main, config=(tyro.conf.AvoidSubcommands,))
```

The help that we expect and now get is:
```
usage: test.py [-h] [--container.value STR|{True,False}]

╭─ options ─────────────────────────────────────────╮
│ -h, --help        show this help message and exit │
╰───────────────────────────────────────────────────╯
╭─ container options ───────────────────────────────╮
│ --container.value STR|{True,False}                │
│                   (default: 'default string')     │
╰───────────────────────────────────────────────────╯
```

Compared to previously:
```
/Users/brentyi/miniconda3/envs/py312/lib/python3.12/site-packages/tyro/_resolver.py:480: UserWarning: <class 'str'> does not match any type in Union: [<class 'int'>, <class 'bool'>]
  warnings.warn(
usage: test.py [-h] [--container.value {fixed}]

╭─ options ─────────────────────────────────────────╮
│ -h, --help        show this help message and exit │
╰───────────────────────────────────────────────────╯
╭─ container options ───────────────────────────────╮
│ --container.value {fixed}                         │
│                   (fixed to: default string)      │
╰───────────────────────────────────────────────────╯
```