### PR TITLE
Fix subcommand matcher when `tyro.conf.subcommand` is used

### DIFF
--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -1027,7 +1027,6 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                     )
                 else:
                     column_width = None
-
                 column_lines = [0 for i in range(column_count)]
                 column_parts_grouped = [[] for i in range(column_count)]
                 for p, l in zip(column_parts, column_parts_lines):

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -2,10 +2,10 @@ import dataclasses
 from typing import Any, Generic, NewType, Optional, Tuple, TypeVar, Union
 
 import pytest
-from helptext_utils import get_helptext_with_checks
+import tyro
 from typing_extensions import Annotated, Final, Literal
 
-import tyro
+from helptext_utils import get_helptext_with_checks
 
 
 def test_nested() -> None:
@@ -1353,7 +1353,7 @@ def test_subcommand_default_with_conf_annotation() -> None:
     class SGDConfig(OptimizerConfig):
         sgd_foo: float = 1.0
 
-    def _constructor() -> type[OptimizerConfig]:
+    def _constructor() -> Any:
         cfgs = [
             Annotated[SGDConfig, tyro.conf.subcommand(name="sgd")],
             Annotated[AdamConfig, tyro.conf.subcommand(name="adam")],

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -1358,7 +1358,7 @@ def test_subcommand_default_with_conf_annotation() -> None:
             Annotated[SGDConfig, tyro.conf.subcommand(name="sgd")],
             Annotated[AdamConfig, tyro.conf.subcommand(name="adam")],
         ]
-        return Union[*cfgs]  # type: ignore
+        return Union.__getitem__(tuple(cfgs))  # type: ignore
 
     @dataclasses.dataclass(frozen=True)
     class Config1:

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -2,10 +2,10 @@ import dataclasses
 from typing import Any, Generic, NewType, Optional, Tuple, TypeVar, Union
 
 import pytest
-import tyro
+from helptext_utils import get_helptext_with_checks
 from typing_extensions import Annotated, Final, Literal
 
-from helptext_utils import get_helptext_with_checks
+import tyro
 
 
 def test_nested() -> None:


### PR DESCRIPTION
@mirceamironenco this fixes the second bug you pointed out in #221, which is caused by a bug introduced in `0.9.1`. I also added your example to the tests to prevent regressions; I really appreciate the succinct reproduction instructions!