### PR TITLE
Consistent behavior for implicit and explicit selection of optional subcommands

### DIFF
--- a/examples/06_custom_constructors/04_struct_registry.py
+++ b/examples/06_custom_constructors/04_struct_registry.py
@@ -43,7 +43,6 @@ def _(
     if isinstance(type_info.default, Bounds):
         # If the default value is a `Bounds` instance, we don't need to generate a constructor.
         default = (type_info.default.bounds[0], type_info.default.bounds[1])
-        is_default_overridden = True
     else:
         # Otherwise, the default value is missing. We'll mark the child defaults as missing as well.
         assert type_info.default in (
@@ -51,7 +50,6 @@ def _(
             tyro.constructors.MISSING_NONPROP,
         )
         default = (tyro.MISSING, tyro.MISSING)
-        is_default_overridden = False
 
     # If the rule applies, we return the constructor spec.
     return tyro.constructors.StructConstructorSpec(
@@ -62,14 +60,12 @@ def _(
                 name="lower",
                 type=int,
                 default=default[0],
-                is_default_overridden=is_default_overridden,
                 helptext="Lower bound." "",
             ),
             tyro.constructors.StructFieldSpec(
                 name="upper",
                 type=int,
                 default=default[1],
-                is_default_overridden=is_default_overridden,
                 helptext="Upper bound." "",
             ),
         ),

--- a/src/tyro/__init__.py
+++ b/src/tyro/__init__.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 
 
 from . import conf as conf

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -35,10 +35,6 @@ class FieldDefinition:
     """Full type, including runtime annotations."""
     type_stripped: TypeForm[Any] | Callable
     default: Any
-    # We need to record whether defaults are from default instances to
-    # determine if they should override the default in
-    # tyro.conf.subcommand(default=...).
-    is_default_from_default_instance: bool
     helptext: Optional[str]
     markers: Set[Any]
     custom_constructor: bool
@@ -66,7 +62,6 @@ class FieldDefinition:
             name=field_spec.name,
             typ=field_spec.type,
             default=field_spec.default,
-            is_default_from_default_instance=field_spec.is_default_overridden,
             helptext=field_spec.helptext,
             call_argname_override=field_spec._call_argname,
         )
@@ -76,7 +71,6 @@ class FieldDefinition:
         name: str,
         typ: Union[TypeForm[Any], Callable],
         default: Any,
-        is_default_from_default_instance: bool,
         helptext: Optional[str],
         call_argname_override: Optional[Any] = None,
     ):
@@ -133,7 +127,6 @@ class FieldDefinition:
             type=typ,
             type_stripped=type_stripped,
             default=default,
-            is_default_from_default_instance=is_default_from_default_instance,
             helptext=helptext,
             markers=set(markers),
             custom_constructor=argconf.constructor_factory is not None,
@@ -243,7 +236,6 @@ def field_list_from_type_or_callable(
                                 name="value",
                                 typ=f,
                                 default=default_instance,
-                                is_default_from_default_instance=True,
                                 helptext="",
                             )
                         ],
@@ -371,7 +363,6 @@ def _field_list_from_function(
                     if default_instance in MISSING_AND_MISSING_NONPROP
                     else Annotated[(typ, _markers._OPTIONAL_GROUP)],  # type: ignore
                     default=default if default is not param.empty else MISSING_NONPROP,
-                    is_default_from_default_instance=False,
                     helptext=helptext,
                 )
             )

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -553,8 +553,6 @@ class SubparsersSpecification:
 
             # If names match, borrow subcommand default from field default.
             if default_name == subcommand_name and (
-                # field.is_default_from_default_instance
-                # or subcommand_config.default in _singleton.MISSING_AND_MISSING_NONPROP
                 field.default not in _singleton.MISSING_AND_MISSING_NONPROP
             ):
                 subcommand_config = dataclasses.replace(

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -553,8 +553,9 @@ class SubparsersSpecification:
 
             # If names match, borrow subcommand default from field default.
             if default_name == subcommand_name and (
-                field.is_default_from_default_instance
-                or subcommand_config.default in _singleton.MISSING_AND_MISSING_NONPROP
+                # field.is_default_from_default_instance
+                # or subcommand_config.default in _singleton.MISSING_AND_MISSING_NONPROP
+                field.default not in _singleton.MISSING_AND_MISSING_NONPROP
             ):
                 subcommand_config = dataclasses.replace(
                     subcommand_config, default=field.default

--- a/src/tyro/conf/_confstruct.py
+++ b/src/tyro/conf/_confstruct.py
@@ -61,7 +61,7 @@ def subcommand(
     .. code-block:: python
 
         tyro.cli(
-            Union[NestedTypeA, NestedTypeB]
+            Union[StructTypeA, StructTypeB]
         )
 
     This will create two subcommands: `nested-type-a` and `nested-type-b`.
@@ -75,18 +75,36 @@ def subcommand(
         tyro.cli(
             Union[
                 Annotated[
-                    NestedTypeA, subcommand("a", ...)
+                    StructTypeA, subcommand("a", ...)
                 ],
                 Annotated[
-                    NestedTypeB, subcommand("b", ...)
+                    StructTypeB, subcommand("b", ...)
                 ],
             ]
         )
 
+    If we have a default value both in the annotation and attached to the field
+    itself (eg, RHS of `=` within function or dataclass signature), the field
+    default will take precedence.
+
+    .. code-block:: python
+
+        # For the first subcommand, StructType(1) will be used as the default.
+        # The second subcommand, whose type is inconsistent with the field
+        # default, will be unaffected.
+        x: Union[
+            Annotated[
+                StructTypeA, subcommand(default=StructTypeA(0)
+            ],
+            Annotated[
+                StructTypeB, subcommand(default=StructTypeB(0)
+            ],
+        ] = StructTypeA(1)
+
     Arguments:
         name: The name of the subcommand in the CLI.
         default: A default value for the subcommand, for struct-like types. (eg
-             dataclasses)
+             dataclasses).
         description: Description of this option to use in the helptext. Defaults to
             docstring.
         prefix_name: Whether to prefix the name of the subcommand based on where it

--- a/src/tyro/constructors/_struct_spec.py
+++ b/src/tyro/constructors/_struct_spec.py
@@ -62,8 +62,8 @@ class StructFieldSpec:
     _call_argname: Any = None
     """Private: the name of the argument to pass to the callable. This is used
     for dictionary types."""
-    is_default_overriden: None = None
-    """*Deprecated.*"""
+    is_default_overridden: None = None
+    """Deprecated. No longer used."""
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/test_base_configs_nested_exclude_py313.py
+++ b/tests/test_base_configs_nested_exclude_py313.py
@@ -117,7 +117,8 @@ class BaseConfig:
     experiment_config: AnnotatedExperimentParserUnion
 
     # The experiment configuration.
-    data_config: AnnotatedDataParserUnion = DataConfig()
+    # The default should get matched to small-data.
+    data_config: AnnotatedDataParserUnion = DataConfig(test=0)
 
 
 def test_base_configs_nested() -> None:
@@ -158,7 +159,7 @@ def test_base_configs_nested() -> None:
             seed=0,
             activation=nn.ReLU,
         ),
-        DataConfig(2221),
+        DataConfig(0),
     )
     assert tyro.cli(
         main,

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -8,10 +8,10 @@ import sys
 from typing import Any, Dict, Generic, List, Tuple, Type, TypeVar, Union
 
 import pytest
-import tyro
+from helptext_utils import get_helptext_with_checks
 from typing_extensions import Annotated, TypedDict
 
-from helptext_utils import get_helptext_with_checks
+import tyro
 
 
 def test_suppress_subcommand() -> None:

--- a/tests/test_py311_generated/test_base_configs_nested_exclude_py313_generated.py
+++ b/tests/test_py311_generated/test_base_configs_nested_exclude_py313_generated.py
@@ -116,7 +116,8 @@ class BaseConfig:
     experiment_config: AnnotatedExperimentParserUnion
 
     # The experiment configuration.
-    data_config: AnnotatedDataParserUnion = DataConfig()
+    # The default should get matched to small-data.
+    data_config: AnnotatedDataParserUnion = DataConfig(test=0)
 
 
 def test_base_configs_nested() -> None:
@@ -157,7 +158,7 @@ def test_base_configs_nested() -> None:
             seed=0,
             activation=nn.ReLU,
         ),
-        DataConfig(2221),
+        DataConfig(0),
     )
     assert tyro.cli(
         main,

--- a/tests/test_py311_generated/test_nested_generated.py
+++ b/tests/test_py311_generated/test_nested_generated.py
@@ -9,6 +9,7 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
+    Union,
 )
 
 import pytest
@@ -1342,3 +1343,49 @@ def test_union_with_tuple_autoexpand() -> None:
     assert tyro.cli(
         main, args="config:config --config.name world --config.age 27".split(" ")
     ) == Config(name="world", age=27)
+
+
+def test_subcommand_default_with_conf_annotation() -> None:
+    """Adapted from @mirceamironenco.
+
+    https://github.com/brentyi/tyro/issues/221#issuecomment-2572850582
+    """
+
+    @dataclasses.dataclass(frozen=True)
+    class OptimizerConfig:
+        lr: float = 1e-1
+
+    @dataclasses.dataclass(frozen=True)
+    class AdamConfig(OptimizerConfig):
+        adam_foo: float = 1.0
+
+    @dataclasses.dataclass(frozen=True)
+    class SGDConfig(OptimizerConfig):
+        sgd_foo: float = 1.0
+
+    def _constructor() -> Any:
+        cfgs = [
+            Annotated[SGDConfig, tyro.conf.subcommand(name="sgd")],
+            Annotated[AdamConfig, tyro.conf.subcommand(name="adam")],
+        ]
+        return Union.__getitem__(tuple(cfgs))  # type: ignore
+
+    @dataclasses.dataclass(frozen=True)
+    class Config1:
+        optimizer: Annotated[
+            OptimizerConfig, tyro.conf.arg(constructor_factory=_constructor)
+        ] = AdamConfig()
+        foo: int = 1
+        bar: str = "abc"
+
+    assert "(default: optimizer:adam)" in get_helptext_with_checks(Config1)
+
+    @dataclasses.dataclass(frozen=True)
+    class Config2:
+        optimizer: Annotated[
+            OptimizerConfig, tyro.conf.arg(constructor_factory=_constructor)
+        ] = SGDConfig()
+        foo: int = 1
+        bar: str = "abc"
+
+    assert "(default: optimizer:sgd)" in get_helptext_with_checks(Config2)


### PR DESCRIPTION
Default values specified in field declarations now always take precedence over default values specified in annotations. Updated tests + docs to reflect this.

cc #221