### PR TITLE
(experimental) Propagate helptext into subcommands

### DIFF
--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -398,7 +398,7 @@ def _cli_impl(
         parser._parsing_known_args = return_unknown_args
         parser._console_outputs = console_outputs
         parser._args = args
-        parser_spec.apply(parser, force_required_subparsers=False)
+        parser_spec.apply(parser, force_required_subparsers=False, parent=None)
 
         # Print help message when no arguments are passed in. (but arguments are
         # expected)

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -127,16 +127,14 @@ class ParserSpecification:
             # Helptext for this field; used as description for grouping
             # arguments and not needed for fields that are handled via
             # ArgumentDefinition.
+            #
+            # This should happen for both subparsers and nested parsers.
             class_field_name = _strings.make_field_name(
                 [intern_prefix, field.intern_name]
             )
             if field.helptext is not None:
                 helptext_from_intern_prefixed_field_name[class_field_name] = (
                     field.helptext
-                )
-            else:
-                helptext_from_intern_prefixed_field_name[class_field_name] = (
-                    _docstrings.get_callable_description(f)
                 )
 
             if isinstance(field_out, SubparsersSpecification):
@@ -147,6 +145,13 @@ class ParserSpecification:
                 # Handle nested parsers.
                 nested_parser = field_out
                 child_from_prefix[field_out.intern_prefix] = nested_parser
+
+                # If there's no helptext from the field, we can grab it from
+                # the callable (docstring) itself.
+                if field.helptext is None:
+                    helptext_from_intern_prefixed_field_name[class_field_name] = (
+                        _docstrings.get_callable_description(nested_parser.f)
+                    )
 
                 if nested_parser.has_required_args:
                     has_required_args = True


### PR DESCRIPTION
discussed in #221 

```python
from dataclasses import dataclass
import tyro

@dataclass(frozen=True)
class AdamConfig:
    adam_foo: float = 1.0

@dataclass(frozen=True)
class SGDConfig:
    sgd_foo: float = 1.0

@dataclass(frozen=True)
class Config:
    optimizer: AdamConfig | SGDConfig = AdamConfig()
    """Optimizer configuration."""

tyro.cli(Config)
```

root helptext (unchanged):
```
usage: ex.py [-h] [{optimizer:adam-config,optimizer:sgd-config}]

╭─ options ─────────────────────────────────────────────────╮
│ -h, --help        show this help message and exit         │
╰───────────────────────────────────────────────────────────╯
╭─ optional subcommands ────────────────────────────────────╮
│ Optimizer configuration. (default: optimizer:adam-config) │
│ ───────────────────────────────────────────────────────── │
│ [{optimizer:adam-config,optimizer:sgd-config}]            │
│     optimizer:adam-config                                 │
│     optimizer:sgd-config                                  │
╰───────────────────────────────────────────────────────────╯
```

subcommand helptext ("Optimizer configuration" is new):
```
usage: ex.py optimizer:adam-config [-h] [--optimizer.adam-foo FLOAT]

╭─ options ─────────────────────────────────────────╮
│ -h, --help        show this help message and exit │
╰───────────────────────────────────────────────────╯
╭─ optimizer options ───────────────────────────────╮
│ Optimizer configuration.                          │
│ ────────────────────────────────                  │
│ --optimizer.adam-foo FLOAT                        │
│                   (default: 1.0)                  │
╰───────────────────────────────────────────────────╯
```