### PR TITLE
Support methods bound to generic classes

### DIFF
--- a/docs/source/whats_supported.rst
+++ b/docs/source/whats_supported.rst
@@ -30,15 +30,29 @@ What's not supported
 
 There are some limitations. We currently *do not* support:
 
-- Variable-length sequences over nested structures, unless a default is
+- **Self-referential types.** For example, ``type RecursiveList[T] = T | list[RecursiveList[T]]``.
+- **Variable-length sequences over nested structures**, unless a default is
   provided. For types like ``list[Dataclass]``, we require a default value to
   infer length from. The length of the corresponding field cannot be changed
   from the CLI interface.
-- Nesting variable-length sequences in other sequences. ``tuple[int, ...]`` and
+- **Nesting variable-length sequences in other sequences.** ``tuple[int, ...]`` and
   ``tuple[tuple[int, int, int], ...]`` are supported, as the variable-length
   sequence is the outermost type. However, ``tuple[tuple[int, ...], ...]`` is
   ambiguous to parse and not supported.
-- Self-referential types, like ``type RecursiveList[T] = T | list[RecursiveList[T]]``.
+- **Generic types in class methods.** For example:
 
-In each of these cases, a :ref:`custom constructor
+  .. code-block:: python
+
+      class MyClass[T: int | str]:
+        @classmethod
+        def my_method(cls, arg: T) -> T:
+          return arg
+
+      # The `int` type parameter will be ignored.
+      tyro.cli(MyClass[int].my_method)
+
+  This is because ``MyClass[int].my_method`` cannot be distinguished from
+  ``MyClass.my_method`` at runtime.
+
+For some of these cases, a :ref:`custom constructor
 <example-category-custom_constructors>` can be defined as a workaround.

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -304,7 +304,7 @@ def _rule_apply_primitive_specs(
             )
             if field_name != "":
                 raise UnsupportedTypeAnnotationError(
-                    f"Unsupported type annotation for field with name `{field_name}`, which is annotated as `{arg.field.type}`. "
+                    f"Unsupported type annotation for field with name `{field_name}`, which is resolved to `{arg.field.type}`. "
                     f"{error.args[0]} "
                     "To suppress this error, assign the field either a default value or a different type."
                 )

--- a/tests/test_generics_and_serialization.py
+++ b/tests/test_generics_and_serialization.py
@@ -5,11 +5,11 @@ import io
 from typing import Generic, List, NewType, Tuple, Type, TypeVar, Union
 
 import pytest
-import tyro
 import yaml
+from helptext_utils import get_helptext_with_checks
 from typing_extensions import Annotated
 
-from helptext_utils import get_helptext_with_checks
+import tyro
 
 T = TypeVar("T")
 

--- a/tests/test_generics_and_serialization.py
+++ b/tests/test_generics_and_serialization.py
@@ -5,11 +5,11 @@ import io
 from typing import Generic, List, NewType, Tuple, Type, TypeVar, Union
 
 import pytest
-import tyro
 import yaml
+from helptext_utils import get_helptext_with_checks
 from typing_extensions import Annotated
 
-from helptext_utils import get_helptext_with_checks
+import tyro
 
 T = TypeVar("T")
 
@@ -534,7 +534,9 @@ def test_deeply_inherited_init() -> None:
 
 
 def test_simple_bound_method() -> None:
-    class Config[T]:
+    T = TypeVar("T")
+
+    class Config(Generic[T]):
         def __init__(self, a: T) -> None: ...
         def method(self, a: T) -> T:
             return a
@@ -557,8 +559,6 @@ def test_inherited_bound_method() -> None:
     class AModel(Generic[TContainsAConfig]):
         def __init__(self, config: TContainsAConfig):
             self.config = config
-
-        config: TContainsAConfig
 
     TContainsAModel = TypeVar("TContainsAModel", bound=AModel)
 

--- a/tests/test_generics_and_serialization.py
+++ b/tests/test_generics_and_serialization.py
@@ -5,11 +5,11 @@ import io
 from typing import Generic, List, NewType, Tuple, Type, TypeVar, Union
 
 import pytest
+import tyro
 import yaml
-from helptext_utils import get_helptext_with_checks
 from typing_extensions import Annotated
 
-import tyro
+from helptext_utils import get_helptext_with_checks
 
 T = TypeVar("T")
 
@@ -543,3 +543,43 @@ def test_simple_bound_method() -> None:
     assert tyro.cli(Config[int](3).method, args="--a 5".split(" ")) == 5
     with pytest.raises(tyro.constructors.UnsupportedTypeAnnotationError):
         tyro.cli(Config(3).method, args="--a 5".split(" "))
+
+
+def test_inherited_bound_method() -> None:
+    """From @deeptoaster: https://github.com/brentyi/tyro/issues/233"""
+
+    @dataclasses.dataclass
+    class AConfig:
+        a: int
+
+    TContainsAConfig = TypeVar("TContainsAConfig", bound=AConfig)
+
+    class AModel(Generic[TContainsAConfig]):
+        def __init__(self, config: TContainsAConfig):
+            self.config = config
+
+        config: TContainsAConfig
+
+    TContainsAModel = TypeVar("TContainsAModel", bound=AModel)
+
+    @dataclasses.dataclass
+    class ABConfig(AConfig):
+        b: int
+
+    class ABModel(AModel[ABConfig]):
+        pass
+
+    class AHelper(Generic[TContainsAModel]):
+        def spam(self, model: TContainsAModel) -> TContainsAModel:
+            self.model = model
+            return model
+
+        model: TContainsAModel
+
+    class ABHelper(AHelper[ABModel]):
+        def print_model(self) -> None:
+            print(self.model.config)
+
+    assert tyro.cli(
+        ABHelper().spam, args="--model.config.a 5 --model.config.b 7".split(" ")
+    ).config == ABConfig(5, 7)

--- a/tests/test_generics_and_serialization.py
+++ b/tests/test_generics_and_serialization.py
@@ -574,8 +574,6 @@ def test_inherited_bound_method() -> None:
             self.model = model
             return model
 
-        model: TContainsAModel
-
     class ABHelper(AHelper[ABModel]):
         def print_model(self) -> None:
             print(self.model.config)

--- a/tests/test_py311_generated/test_generics_and_serialization_generated.py
+++ b/tests/test_py311_generated/test_generics_and_serialization_generated.py
@@ -532,7 +532,9 @@ def test_deeply_inherited_init() -> None:
 
 
 def test_simple_bound_method() -> None:
-    class Config[T]:
+    T = TypeVar("T")
+
+    class Config(Generic[T]):
         def __init__(self, a: T) -> None: ...
         def method(self, a: T) -> T:
             return a
@@ -556,8 +558,6 @@ def test_inherited_bound_method() -> None:
         def __init__(self, config: TContainsAConfig):
             self.config = config
 
-        config: TContainsAConfig
-
     TContainsAModel = TypeVar("TContainsAModel", bound=AModel)
 
     @dataclasses.dataclass
@@ -571,8 +571,6 @@ def test_inherited_bound_method() -> None:
         def spam(self, model: TContainsAModel) -> TContainsAModel:
             self.model = model
             return model
-
-        model: TContainsAModel
 
     class ABHelper(AHelper[ABModel]):
         def print_model(self) -> None:


### PR DESCRIPTION
This pattern is now supported:
```python
import tyro

class Config[T: str | int]:
    def method(self, x: T) -> T:
        return x

tyro.cli(Config[int]().method)
```

We also handle the case where methods are inherited; this fixes #233.