### PR TITLE
Workaround for `__type_params__` bug in Python 3.12.0

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.12.0", "3.13"]
 
     steps:
       - uses: actions/checkout@v2

--- a/tests/test_new_style_annotations_min_py39.py
+++ b/tests/test_new_style_annotations_min_py39.py
@@ -2,9 +2,9 @@ import dataclasses
 from typing import Any, Literal, Optional, Type, Union
 
 import pytest
-import tyro
-
 from helptext_utils import get_helptext_with_checks
+
+import tyro
 
 
 def test_list() -> None:

--- a/tests/test_new_style_annotations_min_py39.py
+++ b/tests/test_new_style_annotations_min_py39.py
@@ -2,9 +2,9 @@ import dataclasses
 from typing import Any, Literal, Optional, Type, Union
 
 import pytest
-from helptext_utils import get_helptext_with_checks
-
 import tyro
+
+from helptext_utils import get_helptext_with_checks
 
 
 def test_list() -> None:
@@ -70,24 +70,31 @@ def test_tuple_direct() -> None:
     assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore
 
 
-def test_type_with_init_false() -> None:
-    """https://github.com/brentyi/tyro/issues/235"""
+try:
     from torch.optim.lr_scheduler import LinearLR, LRScheduler
 
-    @dataclasses.dataclass(frozen=True)
-    class LinearLRConfig:
-        _target: type[LRScheduler] = dataclasses.field(
-            init=False, default_factory=lambda: LinearLR
-        )
-        _target2: Type[LRScheduler] = dataclasses.field(
-            init=False, default_factory=lambda: LinearLR
-        )
-        start_factor: float = 1.0 / 3
-        end_factor: float = 1.0
-        total_iters: Optional[int] = None
+    def test_type_with_init_false() -> None:
+        """https://github.com/brentyi/tyro/issues/235"""
 
-    def main(config: LinearLRConfig) -> LinearLRConfig:
-        return config
+        @dataclasses.dataclass(frozen=True)
+        class LinearLRConfig:
+            _target: type[LRScheduler] = dataclasses.field(
+                init=False, default_factory=lambda: LinearLR
+            )
+            _target2: Type[LRScheduler] = dataclasses.field(
+                init=False, default_factory=lambda: LinearLR
+            )
+            start_factor: float = 1.0 / 3
+            end_factor: float = 1.0
+            total_iters: Optional[int] = None
 
-    assert tyro.cli(main, args=[]) == LinearLRConfig()
-    assert "_target" not in get_helptext_with_checks(LinearLRConfig)
+        def main(config: LinearLRConfig) -> LinearLRConfig:
+            return config
+
+        assert tyro.cli(main, args=[]) == LinearLRConfig()
+        assert "_target" not in get_helptext_with_checks(LinearLRConfig)
+except ImportError:
+    # We can't install PyTorch in Python 3.13.
+    import sys
+
+    assert sys.version_info >= (3, 13)

--- a/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, Optional, Type
 
 import pytest
 from helptext_utils import get_helptext_with_checks
+from torch.optim.lr_scheduler import LinearLR, LRScheduler
 
 import tyro
 
@@ -72,7 +73,6 @@ def test_tuple_direct() -> None:
 
 def test_type_with_init_false() -> None:
     """https://github.com/brentyi/tyro/issues/235"""
-    from torch.optim.lr_scheduler import LinearLR, LRScheduler
 
     @dataclasses.dataclass(frozen=True)
     class LinearLRConfig:

--- a/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
@@ -1,7 +1,8 @@
 import dataclasses
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Type
 
 import pytest
+from helptext_utils import get_helptext_with_checks
 
 import tyro
 
@@ -67,3 +68,26 @@ def test_super_nested() -> None:
 def test_tuple_direct() -> None:
     assert tyro.cli(tuple[int, ...], args="1 2".split(" ")) == (1, 2)  # type: ignore
     assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore
+
+
+def test_type_with_init_false() -> None:
+    """https://github.com/brentyi/tyro/issues/235"""
+    from torch.optim.lr_scheduler import LinearLR, LRScheduler
+
+    @dataclasses.dataclass(frozen=True)
+    class LinearLRConfig:
+        _target: type[LRScheduler] = dataclasses.field(
+            init=False, default_factory=lambda: LinearLR
+        )
+        _target2: Type[LRScheduler] = dataclasses.field(
+            init=False, default_factory=lambda: LinearLR
+        )
+        start_factor: float = 1.0 / 3
+        end_factor: float = 1.0
+        total_iters: Optional[int] = None
+
+    def main(config: LinearLRConfig) -> LinearLRConfig:
+        return config
+
+    assert tyro.cli(main, args=[]) == LinearLRConfig()
+    assert "_target" not in get_helptext_with_checks(LinearLRConfig)


### PR DESCRIPTION
cc #235