### PR TITLE
Correct MRO traversal for inherited fields

### DIFF
--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -337,9 +337,9 @@ def _field_list_from_function(
                             _resolver.TypeParamResolver.concretize_type_params(base_cls)
                         )
 
-                assert (
-                    False
-                ), "We couldn't find the base class. This seems like a bug in tyro."
+                assert False, (
+                    "We couldn't find the base class. This seems like a bug in tyro."
+                )
 
             hints = get_hints_for_signature_func(orig_cls)
 

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -11,7 +11,7 @@ import sys
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import docstring_parser
-from typing_extensions import Annotated, get_args, get_origin
+from typing_extensions import Annotated, get_args, get_origin, get_original_bases
 
 from . import _docstrings, _resolver, _strings, _unsafe_cache
 from ._singleton import MISSING_AND_MISSING_NONPROP, MISSING_NONPROP
@@ -327,11 +327,7 @@ def _field_list_from_function(
                         return _resolver.get_type_hints_resolve_type_params(
                             f, include_extras=True
                         )
-                    for base_cls in (
-                        cls.__orig_bases__
-                        if hasattr(cls, "__orig_bases__")
-                        else cls.__bases__
-                    ):
+                    for base_cls in get_original_bases(cls):
                         if not issubclass(
                             _resolver.unwrap_origin_strip_extras(base_cls),
                             base_cls_with_signature,
@@ -341,9 +337,9 @@ def _field_list_from_function(
                             _resolver.TypeParamResolver.concretize_type_params(base_cls)
                         )
 
-                assert False, (
-                    "We couldn't find the base class. This seems like a bug in tyro."
-                )
+                assert (
+                    False
+                ), "We couldn't find the base class. This seems like a bug in tyro."
 
             hints = get_hints_for_signature_func(orig_cls)
 

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -36,6 +36,7 @@ from typing_extensions import (
     TypeAliasType,
     get_args,
     get_origin,
+    get_original_bases,
     get_type_hints,
 )
 
@@ -634,11 +635,7 @@ def get_type_hints_resolve_type_params(
                         return get_type_hints_resolve_type_params(
                             unbound_func, include_extras=include_extras
                         )
-                    for base_cls in (
-                        cls.__orig_bases__
-                        if hasattr(cls, "__orig_bases__")
-                        else cls.__bases__
-                    ):
+                    for base_cls in get_original_bases(cls):
                         if not issubclass(
                             unwrap_origin_strip_extras(base_cls),
                             unbound_func_context_cls,
@@ -648,9 +645,7 @@ def get_type_hints_resolve_type_params(
                             TypeParamResolver.concretize_type_params(base_cls)
                         )
 
-                assert False, (
-                    "Could not find base class containing method definition. This is likely a bug in tyro."
-                )
+                assert False, "Could not find base class containing method definition. This is likely a bug in tyro."
 
             out = get_hints_for_bound_method(cls)
             return out
@@ -663,32 +658,55 @@ def get_type_hints_resolve_type_params(
                 ).items()
             }
 
-    typevar_context = TypeParamResolver.get_assignment_context(obj)
-    obj = typevar_context.origin_type
-    with typevar_context:
-        # Only include type hints that are explicitly defined in this class.
-        # The follow loop will handle superclasses.
-        out = {
-            x: TypeParamResolver.concretize_type_params(t)
-            for x, t in _get_type_hints_backported_syntax(
-                obj, include_extras=include_extras
-            ).items()
-            if x in obj.__annotations__
-        }
+    # Get type parameter contexts for all superclasses.
+    context_from_origin_type: dict[Any, TypeParamAssignmentContext] = {}
 
-    # We need to recurse into base classes in order to correctly resolve superclass parameters.
-    for base in obj.__orig_bases__ if hasattr(obj, "__orig_bases__") else obj.__bases__:  # type: ignore
-        base_typevar_context = TypeParamResolver.get_assignment_context(base)
-        if get_origin(base_typevar_context.origin_type) is Generic:
+    def recurse_superclass_context(obj: Any) -> None:
+        if get_origin(obj) is Generic or obj is object:
+            return
+        context = TypeParamResolver.get_assignment_context(obj)
+        if context.origin_type in context_from_origin_type:
+            # Already visited. This should be compatible with diamond
+            # inheritance patterns like:
+            #
+            #   object
+            #      |
+            #      A
+            #     / \
+            #    B   C
+            #     \ /
+            #      D
+            #
+            # A will be visited twice. For consistency with the mro, only the
+            # earlier visit will be used. This is relevant when `A` is a
+            # parameterized type (A[T]).
+            return
+        context_from_origin_type[context.origin_type] = context
+
+        try:
+            bases = get_original_bases(context.origin_type)
+        except TypeError:
+            # For example, `TypedDict`.
+            return
+        for base in bases:  # type: ignore
+            recurse_superclass_context(base)
+
+    recurse_superclass_context(obj)
+
+    # Next, we'll resolve type parameters for each class in the mro. We go in
+    # reverse order to ensure that earlier classes take precedence.
+    out = {}
+    for origin_type in reversed(obj.mro()):
+        if origin_type not in context_from_origin_type:
             continue
-        with base_typevar_context:
-            base_hints = get_type_hints_resolve_type_params(
-                base_typevar_context.origin_type, include_extras=include_extras
-            )
+        with context_from_origin_type[origin_type]:
             out.update(
                 {
-                    x: TypeParamResolver.concretize_type_params(t)
-                    for x, t in base_hints.items()
+                    k: TypeParamResolver.concretize_type_params(v)
+                    for k, v in _get_type_hints_backported_syntax(
+                        origin_type, include_extras=include_extras
+                    ).items()
+                    if k in origin_type.__dict__.get("__annotations__", {})
                 }
             )
 

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -645,7 +645,9 @@ def get_type_hints_resolve_type_params(
                             TypeParamResolver.concretize_type_params(base_cls)
                         )
 
-                assert False, "Could not find base class containing method definition. This is likely a bug in tyro."
+                assert False, (
+                    "Could not find base class containing method definition. This is likely a bug in tyro."
+                )
 
             out = get_hints_for_bound_method(cls)
             return out

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -7,11 +7,11 @@ from typing import Generic, TypeVar, cast
 
 import attr
 import pytest
+from attrs import define, field
+from helptext_utils import get_helptext_with_checks
+
 import tyro
 import tyro._strings
-from attrs import define, field
-
-from helptext_utils import get_helptext_with_checks
 
 
 def test_attrs_basic() -> None:

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -1041,16 +1041,12 @@ def test_diamond_inheritance() -> None:
         pass
 
     helptext = get_helptext_with_checks(D)
-    # Despite C coming earlier in the MRO than A....
-    # assert "5" not in helptext
-    # assert "10" in helptext
-
-    # ...the field is inherited from A.
-    # This appears to be a Python bug.
+    # Despite C coming earlier in the MRO than A, the field is inherited from
+    # A. This appears to be a Python bug.
     # https://github.com/python/cpython/issues/108611
     assert "5" in helptext
     assert "10" not in helptext
 
-    # The type, however, currently comes from `A`. This matches the behavior of
-    # pyright and mypy but not of dataclasses.fields().
+    # The type, however, currently comes from C. This matches the MRO and the
+    # behavior of pyright and mypy but not of dataclasses.fields().
     assert "INT|STR" not in helptext

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -1001,6 +1001,28 @@ def test_runtime_checkable_edge_case() -> None:
     )
 
 
+def test_linear_inheritance() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class A:
+        field: Union[str, int] = 5
+
+    @dataclasses.dataclass(frozen=True)
+    class B(A):
+        field: int = 10
+
+    @dataclasses.dataclass(frozen=True)
+    class C(B):
+        pass
+
+    helptext = get_helptext_with_checks(C)
+    assert "5" not in helptext
+    assert "10" in helptext
+    assert "INT" in helptext
+    assert tyro.cli(C, args=[]) == C(10)
+    assert tyro.cli(C, args=["--field", "3"]) == C(3)
+    assert tyro.cli(A, args=["--field", "3"]) == A("3")
+
+
 def test_diamond_inheritance() -> None:
     @dataclasses.dataclass(frozen=True)
     class A:

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -20,6 +20,7 @@ from typing import (
 )
 
 import pytest
+from helptext_utils import get_helptext_with_checks
 from typing_extensions import (
     Annotated,
     Final,
@@ -998,3 +999,36 @@ def test_runtime_checkable_edge_case() -> None:
         ).subconfig
         == SubConfigB()
     )
+
+
+def test_diamond_inheritance() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class A:
+        field: int | str = 5
+
+    @dataclasses.dataclass(frozen=True)
+    class B(A):
+        pass
+
+    @dataclasses.dataclass(frozen=True)
+    class C(A):
+        field: int = 10
+
+    @dataclasses.dataclass(frozen=True)
+    class D(B, C):
+        pass
+
+    helptext = get_helptext_with_checks(D)
+    # Despite C coming earlier in the MRO than A....
+    # assert "5" not in helptext
+    # assert "10" in helptext
+
+    # ...the field is inherited from A.
+    # This appears to be a Python bug.
+    # https://github.com/python/cpython/issues/108611
+    assert "5" in helptext
+    assert "10" not in helptext
+
+    # The type, however, currently comes from `A`. This matches the behavior of
+    # pyright and mypy but not of dataclasses.fields().
+    assert "INT|STR" not in helptext

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -1004,7 +1004,7 @@ def test_runtime_checkable_edge_case() -> None:
 def test_diamond_inheritance() -> None:
     @dataclasses.dataclass(frozen=True)
     class A:
-        field: int | str = 5
+        field: Union[int, str] = 5
 
     @dataclasses.dataclass(frozen=True)
     class B(A):

--- a/tests/test_new_style_annotations_min_py312.py
+++ b/tests/test_new_style_annotations_min_py312.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Literal, NewType
 
 import pytest
-from helptext_utils import get_helptext_with_checks
-from pydantic import BaseModel
-
 import tyro
+from pydantic import BaseModel
 from tyro.conf._markers import OmitArgPrefixes
 from tyro.constructors import UnsupportedTypeAnnotationError
+
+from helptext_utils import get_helptext_with_checks
 
 
 def test_simple_generic() -> None:
@@ -402,3 +402,24 @@ def test_deeply_inherited_init() -> None:
     assert "--model.config.a" in get_helptext_with_checks(c)
     assert "--model.config.b" in get_helptext_with_checks(c)
     assert "--model.config.c" in get_helptext_with_checks(c)
+
+
+def test_bad_orig_bases() -> None:
+    @dataclass(frozen=True)
+    class A[T]:
+        a: T
+
+    @dataclass(frozen=True)
+    class B(A[int | str | bool]):
+        x: int
+
+    @dataclass(frozen=True)
+    class C(A[int | str | bool]):
+        a: str
+
+    @dataclass(frozen=True)
+    class D(B, C): ...  # , C): ...
+
+    assert "--a" in get_helptext_with_checks(D)
+    assert "STR" in get_helptext_with_checks(D)
+    assert "INT|STR" not in get_helptext_with_checks(D)

--- a/tests/test_new_style_annotations_min_py312.py
+++ b/tests/test_new_style_annotations_min_py312.py
@@ -5,12 +5,12 @@ from dataclasses import dataclass
 from typing import Annotated, Any, Literal, NewType
 
 import pytest
-import tyro
+from helptext_utils import get_helptext_with_checks
 from pydantic import BaseModel
+
+import tyro
 from tyro.conf._markers import OmitArgPrefixes
 from tyro.constructors import UnsupportedTypeAnnotationError
-
-from helptext_utils import get_helptext_with_checks
 
 
 def test_simple_generic() -> None:

--- a/tests/test_py311_generated/test_attrs_generated.py
+++ b/tests/test_py311_generated/test_attrs_generated.py
@@ -151,3 +151,27 @@ def test_attrs_inheritance_with_same_typevar() -> None:
 
     assert tyro.cli(B[str], args=["--x", "1", "--y", "2"]) == B(x=1, y="2")
     assert tyro.cli(B[int], args=["--x", "1", "--y", "2"]) == B(x=1, y=2)
+
+
+def test_diamond_inheritance() -> None:
+    @define(frozen=True)
+    class A:
+        field: int | str = 5
+
+    @define(frozen=True)
+    class B(A):
+        pass
+
+    @define(frozen=True)
+    class C(A):
+        field: int = 10
+
+    @define(frozen=True)
+    class D(B, C):
+        pass
+
+    # C should come earlier int the MRO than A.
+    helptext = get_helptext_with_checks(D)
+    assert "5" not in helptext
+    assert "10" in helptext
+    assert "INT|STR" not in helptext

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -1038,16 +1038,12 @@ def test_diamond_inheritance() -> None:
         pass
 
     helptext = get_helptext_with_checks(D)
-    # Despite C coming earlier in the MRO than A....
-    # assert "5" not in helptext
-    # assert "10" in helptext
-
-    # ...the field is inherited from A.
-    # This appears to be a Python bug.
+    # Despite C coming earlier in the MRO than A, the field is inherited from
+    # A. This appears to be a Python bug.
     # https://github.com/python/cpython/issues/108611
     assert "5" in helptext
     assert "10" not in helptext
 
-    # The type, however, currently comes from `A`. This matches the behavior of
-    # pyright and mypy but not of dataclasses.fields().
+    # The type, however, currently comes from C. This matches the MRO and the
+    # behavior of pyright and mypy but not of dataclasses.fields().
     assert "INT|STR" not in helptext

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -25,6 +25,7 @@ from typing import (
 )
 
 import pytest
+from helptext_utils import get_helptext_with_checks
 
 import tyro
 
@@ -995,3 +996,36 @@ def test_runtime_checkable_edge_case() -> None:
         ).subconfig
         == SubConfigB()
     )
+
+
+def test_diamond_inheritance() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class A:
+        field: int | str = 5
+
+    @dataclasses.dataclass(frozen=True)
+    class B(A):
+        pass
+
+    @dataclasses.dataclass(frozen=True)
+    class C(A):
+        field: int = 10
+
+    @dataclasses.dataclass(frozen=True)
+    class D(B, C):
+        pass
+
+    helptext = get_helptext_with_checks(D)
+    # Despite C coming earlier in the MRO than A....
+    # assert "5" not in helptext
+    # assert "10" in helptext
+
+    # ...the field is inherited from A.
+    # This appears to be a Python bug.
+    # https://github.com/python/cpython/issues/108611
+    assert "5" in helptext
+    assert "10" not in helptext
+
+    # The type, however, currently comes from `A`. This matches the behavior of
+    # pyright and mypy but not of dataclasses.fields().
+    assert "INT|STR" not in helptext

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -998,6 +998,28 @@ def test_runtime_checkable_edge_case() -> None:
     )
 
 
+def test_linear_inheritance() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class A:
+        field: str | int = 5
+
+    @dataclasses.dataclass(frozen=True)
+    class B(A):
+        field: int = 10
+
+    @dataclasses.dataclass(frozen=True)
+    class C(B):
+        pass
+
+    helptext = get_helptext_with_checks(C)
+    assert "5" not in helptext
+    assert "10" in helptext
+    assert "INT" in helptext
+    assert tyro.cli(C, args=[]) == C(10)
+    assert tyro.cli(C, args=["--field", "3"]) == C(3)
+    assert tyro.cli(A, args=["--field", "3"]) == A("3")
+
+
 def test_diamond_inheritance() -> None:
     @dataclasses.dataclass(frozen=True)
     class A:

--- a/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
@@ -402,3 +402,24 @@ def test_deeply_inherited_init() -> None:
     assert "--model.config.a" in get_helptext_with_checks(c)
     assert "--model.config.b" in get_helptext_with_checks(c)
     assert "--model.config.c" in get_helptext_with_checks(c)
+
+
+def test_bad_orig_bases() -> None:
+    @dataclass(frozen=True)
+    class A[T]:
+        a: T
+
+    @dataclass(frozen=True)
+    class B(A[int | str | bool]):
+        x: int
+
+    @dataclass(frozen=True)
+    class C(A[int | str | bool]):
+        a: str
+
+    @dataclass(frozen=True)
+    class D(B, C): ...  # , C): ...
+
+    assert "--a" in get_helptext_with_checks(D)
+    assert "STR" in get_helptext_with_checks(D)
+    assert "INT|STR" not in get_helptext_with_checks(D)


### PR DESCRIPTION
Our logic for retrieving type hints + resolving type parameters was following a depth-first order instead of C3 linearization.

This causes problems for overriding fields in specific "diamond" inheritance patterns. I added some to the tests.

I also noted some inconsistent behavior. In this example we end up with the type annotation from `A` but the default value from `C`:
```python
    @dataclasses.dataclass(frozen=True)
    class A:
        field: int | str = 5

    @dataclasses.dataclass(frozen=True)
    class B(A):
        pass

    @dataclasses.dataclass(frozen=True)
    class C(A):
        field: int = 10

    @dataclasses.dataclass(frozen=True)
    class D(B, C):
        pass

    helptext = get_helptext_with_checks(D)
    # Despite C coming earlier in the MRO than A,
    # the default is inherited from A.
    assert "5" in helptext
    assert "10" not in helptext

    # The type, however, currently comes from `C`. This matches the behavior of
    # pyright and mypy but not of dataclasses.fields().
    assert "INT|STR" not in helptext
```

This is really unfortunate, but the root cause looks like a Python bug (https://github.com/python/cpython/issues/108611), so for now I'm leaving it as-is.