### PR TITLE
Fix `tyro.conf.UseAppendAction` + abstract `Sequence` annotations

### DIFF
--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -302,8 +302,10 @@ class TyroArgumentParser(argparse.ArgumentParser, argparse_sys.ArgumentParser): 
             except (AttributeError, OSError):  # pragma: no cover
                 pass
 
-    @override
-    def _parse_known_args(self, arg_strings, namespace):  # pragma: no cover, type: ignore
+    # @override
+    def _parse_known_args(  # type: ignore
+        self, arg_strings, namespace
+    ):  # pragma: no cover
         """We override _parse_known_args() to improve error messages in the presence of
         subcommands. Difference is marked with <new>...</new> below."""
 

--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -303,7 +303,7 @@ class TyroArgumentParser(argparse.ArgumentParser, argparse_sys.ArgumentParser): 
                 pass
 
     @override
-    def _parse_known_args(self, arg_strings, namespace):  # pragma: no cover
+    def _parse_known_args(self, arg_strings, namespace):  # pragma: no cover, type: ignore
         """We override _parse_known_args() to improve error messages in the presence of
         subcommands. Difference is marked with <new>...</new> below."""
 

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -3,6 +3,7 @@ argparse's `add_argument()`."""
 
 from __future__ import annotations
 
+import collections.abc
 import dataclasses
 import json
 import shlex
@@ -372,7 +373,7 @@ def _rule_apply_primitive_specs(
                     out.append(part)
 
             # Return output with correct type.
-            if isinstance(out, dict):
+            if container_type in (dict, Sequence, collections.abc.Sequence):
                 return out
             else:
                 return container_type(out)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,5 +1,4 @@
 import argparse
-import collections.abc
 import contextlib
 import dataclasses
 import io
@@ -908,20 +907,6 @@ def test_append_sequence() -> None:
     @dataclasses.dataclass
     class A:
         x: tyro.conf.UseAppendAction[Sequence[int]]
-
-    assert tyro.cli(A, args=[]) == A(x=[])
-    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
-    assert tyro.cli(A, args=[]) == A(x=[])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x", "1", "2", "3"])
-
-
-def test_append_abc_sequence() -> None:
-    @dataclasses.dataclass
-    class A:
-        x: tyro.conf.UseAppendAction[collections.abc.Sequence[int]]
 
     assert tyro.cli(A, args=[]) == A(x=[])
     assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,11 +1,12 @@
 import argparse
+import collections.abc
 import contextlib
 import dataclasses
 import io
 import json as json_
 import shlex
 import sys
-from typing import Any, Dict, Generic, List, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Sequence, Tuple, Type, TypeVar, Union
 
 import pytest
 from helptext_utils import get_helptext_with_checks
@@ -893,6 +894,34 @@ def test_append_lists() -> None:
     @dataclasses.dataclass
     class A:
         x: tyro.conf.UseAppendAction[List[int]]
+
+    assert tyro.cli(A, args=[]) == A(x=[])
+    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
+    assert tyro.cli(A, args=[]) == A(x=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
+
+
+def test_append_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[Sequence[int]]
+
+    assert tyro.cli(A, args=[]) == A(x=[])
+    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
+    assert tyro.cli(A, args=[]) == A(x=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
+
+
+def test_append_abc_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[collections.abc.Sequence[int]]
 
     assert tyro.cli(A, args=[]) == A(x=[])
     assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])

--- a/tests/test_new_style_annotations_min_py39.py
+++ b/tests/test_new_style_annotations_min_py39.py
@@ -1,3 +1,4 @@
+import collections.abc
 import dataclasses
 from typing import Any, Literal, Optional, Type, Union
 
@@ -68,6 +69,20 @@ def test_super_nested() -> None:
 def test_tuple_direct() -> None:
     assert tyro.cli(tuple[int, ...], args="1 2".split(" ")) == (1, 2)  # type: ignore
     assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore
+
+
+def test_append_abc_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[collections.abc.Sequence[int]]
+
+    assert tyro.cli(A, args=[]) == A(x=[])
+    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
+    assert tyro.cli(A, args=[]) == A(x=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
 
 
 try:

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1,4 +1,5 @@
 import argparse
+import collections.abc
 import contextlib
 import dataclasses
 import io
@@ -11,6 +12,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    Sequence,
     Tuple,
     Type,
     TypedDict,
@@ -901,6 +903,34 @@ def test_append_lists() -> None:
     @dataclasses.dataclass
     class A:
         x: tyro.conf.UseAppendAction[List[int]]
+
+    assert tyro.cli(A, args=[]) == A(x=[])
+    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
+    assert tyro.cli(A, args=[]) == A(x=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
+
+
+def test_append_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[Sequence[int]]
+
+    assert tyro.cli(A, args=[]) == A(x=[])
+    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
+    assert tyro.cli(A, args=[]) == A(x=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
+
+
+def test_append_abc_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[collections.abc.Sequence[int]]
 
     assert tyro.cli(A, args=[]) == A(x=[])
     assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1,5 +1,4 @@
 import argparse
-import collections.abc
 import contextlib
 import dataclasses
 import io
@@ -917,20 +916,6 @@ def test_append_sequence() -> None:
     @dataclasses.dataclass
     class A:
         x: tyro.conf.UseAppendAction[Sequence[int]]
-
-    assert tyro.cli(A, args=[]) == A(x=[])
-    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
-    assert tyro.cli(A, args=[]) == A(x=[])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x"])
-    with pytest.raises(SystemExit):
-        tyro.cli(A, args=["--x", "1", "2", "3"])
-
-
-def test_append_abc_sequence() -> None:
-    @dataclasses.dataclass
-    class A:
-        x: tyro.conf.UseAppendAction[collections.abc.Sequence[int]]
 
     assert tyro.cli(A, args=[]) == A(x=[])
     assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])

--- a/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
@@ -1,3 +1,4 @@
+import collections.abc
 import dataclasses
 from typing import Any, Literal, Optional, Type
 
@@ -68,6 +69,20 @@ def test_super_nested() -> None:
 def test_tuple_direct() -> None:
     assert tyro.cli(tuple[int, ...], args="1 2".split(" ")) == (1, 2)  # type: ignore
     assert tyro.cli(tuple[int, int], args="1 2".split(" ")) == (1, 2)  # type: ignore
+
+
+def test_append_abc_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.UseAppendAction[collections.abc.Sequence[int]]
+
+    assert tyro.cli(A, args=[]) == A(x=[])
+    assert tyro.cli(A, args="--x 1 --x 2 --x 3".split(" ")) == A(x=[1, 2, 3])
+    assert tyro.cli(A, args=[]) == A(x=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "1", "2", "3"])
 
 
 try:


### PR DESCRIPTION
"Append" actions were broken for abstract sequences (`typing.Sequence`, `collections.abc.Sequence`) in the 0.9.0 refactor.

Fixes #244