### PR TITLE
Add flag to turn off boolean negation

### DIFF
--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -311,9 +311,7 @@ def _rule_apply_primitive_specs(
             )
             if field_name != "":
                 raise UnsupportedTypeAnnotationError(
-                    f"Unsupported type annotation for field with name `{
-                        field_name
-                    }`, which is resolved to `{arg.field.type}`. "
+                    f"Unsupported type annotation for field with name `{field_name}`, which is resolved to `{arg.field.type}`. "
                     f"{error.args[0]} "
                     "To suppress this error, assign the field either a default value or a different type."
                 )

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -146,7 +146,7 @@ class ArgumentDefinition:
         action = kwargs.get("action", None)
         if action not in {"append", "count"}:
             kwargs["default"] = _singleton.MISSING_NONPROP
-        elif action in {BooleanOptionalAction, "store_true", "count"}:
+        elif action in {BooleanOptionalAction, "store_true", "store_false", "count"}:
             pass
         else:
             kwargs["default"] = []

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -47,24 +47,7 @@ else:
 _T = TypeVar("_T")
 
 
-class BooleanOptionalActionBase(argparse.Action):
-    # Typically only supported in Python 3.10, but we backport some functionality in
-    # _argparse_formatters.py
-    def format_usage(self):
-        return " | ".join(self.option_strings)
-
-
-class BooleanNoConverionAction(BooleanOptionalActionBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, nargs=0, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        if option_string in self.option_strings:
-            assert option_string is not None
-            setattr(namespace, self.dest, True)
-
-
-class BooleanOptionalAction(BooleanOptionalActionBase):
+class BooleanOptionalAction(argparse.Action):
     """Adapted from https://github.com/python/cpython/pull/27672"""
 
     def __init__(
@@ -113,6 +96,9 @@ class BooleanOptionalAction(BooleanOptionalActionBase):
             assert option_string is not None
             setattr(namespace, self.dest, option_string not in self._no_strings)
 
+    def format_usage(self):
+        return " | ".join(self.option_strings)
+
 
 @dataclasses.dataclass(frozen=True)
 class ArgumentDefinition:
@@ -160,7 +146,7 @@ class ArgumentDefinition:
         action = kwargs.get("action", None)
         if action not in {"append", "count"}:
             kwargs["default"] = _singleton.MISSING_NONPROP
-        elif action in {BooleanOptionalActionBase, "count"}:
+        elif action in {BooleanOptionalAction, "store_true", "count"}:
             pass
         else:
             kwargs["default"] = []
@@ -268,7 +254,13 @@ def _rule_handle_boolean_flags(
         return
     elif arg.field.default in (True, False):
         # Default `False` => --flag passed in flips to `True`.
-        lowered.action = BooleanNoConverionAction if _markers.FlagNegationOff in arg.field.markers else BooleanOptionalAction
+        if _markers.FlagPairOff in arg.field.markers:
+            # If default is True, --flag will flip to `False`.
+            # If default is False, --no-flag will flip to `True`.
+            lowered.action = "store_false" if arg.field.default else "store_true"
+        else:
+            # Create both --flag and --no-flag.
+            lowered.action = BooleanOptionalAction
         lowered.instance_from_str = (
             lambda x: x
         )  # argparse will directly give us a bool!
@@ -318,7 +310,8 @@ def _rule_apply_primitive_specs(
             if field_name != "":
                 raise UnsupportedTypeAnnotationError(
                     f"Unsupported type annotation for field with name `{
-                        field_name}`, which is resolved to `{arg.field.type}`. "
+                        field_name
+                    }`, which is resolved to `{arg.field.type}`. "
                     f"{error.args[0]} "
                     "To suppress this error, assign the field either a default value or a different type."
                 )
@@ -545,12 +538,14 @@ def _rule_set_name_or_flag_and_dest(
     arg: ArgumentDefinition,
     lowered: LoweredArgumentDefinition,
 ) -> None:
+    extern_name = arg.field.extern_name
+    if lowered.action == "store_false":
+        extern_name = "no_" + extern_name
+
     if lowered.help is argparse.SUPPRESS:
         # Use standard name for suppressed arguments.
         # Relevant: https://github.com/brentyi/tyro/issues/170
-        name_or_flag = _strings.make_field_name(
-            [arg.extern_prefix, arg.field.extern_name]
-        )
+        name_or_flag = _strings.make_field_name([arg.extern_prefix, extern_name])
     elif (
         arg.field.argconf.prefix_name is False
         or _markers.OmitArgPrefixes in arg.field.markers
@@ -558,7 +553,7 @@ def _rule_set_name_or_flag_and_dest(
         # Strip prefixes when the argument is suppressed.
         # Still need to call make_field_name() because it converts underscores
         # to hyphens, etc.
-        name_or_flag = _strings.make_field_name([arg.field.extern_name])
+        name_or_flag = _strings.make_field_name([extern_name])
     elif (
         _markers.OmitSubcommandPrefixes in arg.field.markers
         and arg.subcommand_prefix != ""
@@ -567,17 +562,13 @@ def _rule_set_name_or_flag_and_dest(
         # prefixes.`extern_prefix` can start with the prefix corresponding to
         # the parent subcommand, but end with other prefixes correspondeding to
         # nested structures within the subcommand.
-        name_or_flag = _strings.make_field_name(
-            [arg.extern_prefix, arg.field.extern_name]
-        )
+        name_or_flag = _strings.make_field_name([arg.extern_prefix, extern_name])
         strip_prefix = arg.subcommand_prefix + "."
         assert name_or_flag.startswith(strip_prefix), name_or_flag
-        name_or_flag = name_or_flag[len(strip_prefix):]
+        name_or_flag = name_or_flag[len(strip_prefix) :]
     else:
         # Standard prefixed name.
-        name_or_flag = _strings.make_field_name(
-            [arg.extern_prefix, arg.field.extern_name]
-        )
+        name_or_flag = _strings.make_field_name([arg.extern_prefix, extern_name])
 
     # Prefix keyword arguments with --.
     if not arg.field.is_positional():

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -96,6 +96,8 @@ class BooleanOptionalAction(argparse.Action):
             assert option_string is not None
             setattr(namespace, self.dest, option_string not in self._no_strings)
 
+    # Typically only supported in Python 3.10, but we backport some functionality in
+    # _argparse_formatters.py
     def format_usage(self):
         return " | ".join(self.option_strings)
 
@@ -254,7 +256,7 @@ def _rule_handle_boolean_flags(
         return
     elif arg.field.default in (True, False):
         # Default `False` => --flag passed in flips to `True`.
-        if _markers.FlagPairOff in arg.field.markers:
+        if _markers.FlagCreatePairsOff in arg.field.markers:
             # If default is True, --flag will flip to `False`.
             # If default is False, --no-flag will flip to `True`.
             lowered.action = "store_false" if arg.field.default else "store_true"

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -18,6 +18,7 @@ from ._markers import ConsolidateSubcommandArgs as ConsolidateSubcommandArgs
 from ._markers import EnumChoicesFromValues as EnumChoicesFromValues
 from ._markers import Fixed as Fixed
 from ._markers import FlagConversionOff as FlagConversionOff
+from ._markers import FlagNegationOff as FlagNegationOff
 from ._markers import HelptextFromCommentsOff as HelptextFromCommentsOff
 from ._markers import OmitArgPrefixes as OmitArgPrefixes
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -18,7 +18,7 @@ from ._markers import ConsolidateSubcommandArgs as ConsolidateSubcommandArgs
 from ._markers import EnumChoicesFromValues as EnumChoicesFromValues
 from ._markers import Fixed as Fixed
 from ._markers import FlagConversionOff as FlagConversionOff
-from ._markers import FlagNegationOff as FlagNegationOff
+from ._markers import FlagPairOff as FlagPairOff
 from ._markers import HelptextFromCommentsOff as HelptextFromCommentsOff
 from ._markers import OmitArgPrefixes as OmitArgPrefixes
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -18,7 +18,7 @@ from ._markers import ConsolidateSubcommandArgs as ConsolidateSubcommandArgs
 from ._markers import EnumChoicesFromValues as EnumChoicesFromValues
 from ._markers import Fixed as Fixed
 from ._markers import FlagConversionOff as FlagConversionOff
-from ._markers import FlagPairOff as FlagPairOff
+from ._markers import FlagCreatePairsOff as FlagCreatePairsOff
 from ._markers import HelptextFromCommentsOff as HelptextFromCommentsOff
 from ._markers import OmitArgPrefixes as OmitArgPrefixes
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -55,7 +55,7 @@ with `bool` will expect an explicit True or False.
 Can be used directly on boolean annotations, ``FlagConversionOff[bool]``, or recursively
 applied to nested types."""
 
-FlagPairOff = Annotated[T, None]
+FlagCreatePairsOff = Annotated[T, None]
 """Turn off creation of ``{--flag,--no-flag}`` pairs. Instead, only one flag will be
 created. ``--flag`` if the field default is ``False``, and ``--no-flag`` if the field default is
 ``True``.

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -55,8 +55,13 @@ with `bool` will expect an explicit True or False.
 Can be used directly on boolean annotations, ``FlagConversionOff[bool]``, or recursively
 applied to nested types."""
 
-FlagNegationOff = Annotated[T, None]
-"""Turn off automatic --no-flag creation
+FlagPairOff = Annotated[T, None]
+"""Turn off creation of ``{--flag,--no-flag}`` pairs. Instead, only one flag will be
+created. ``--flag`` if the field default is ``False``, and ``--no-flag`` if the field default is
+``True``.
+
+The default 'pair' behavior is more robust to changes in the default value, but might
+feel cluttered. This option provides an alternative.
 
 Can be used directly on boolean annotations, ``FlagNegationOff[bool]``, or recursively
 applied to nested types."""

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -55,6 +55,12 @@ with `bool` will expect an explicit True or False.
 Can be used directly on boolean annotations, ``FlagConversionOff[bool]``, or recursively
 applied to nested types."""
 
+FlagNegationOff = Annotated[T, None]
+"""Turn off automatic --no-flag creation
+
+Can be used directly on boolean annotations, ``FlagNegationOff[bool]``, or recursively
+applied to nested types."""
+
 AvoidSubcommands = Annotated[T, None]
 """Avoid creating subcommands when a default is provided for unions over nested types.
 This simplifies CLI interfaces, but makes them less expressive.

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -16,8 +16,8 @@ from .. import _singleton
 T = TypeVar("T")
 
 Positional = Annotated[T, None]
-"""A type ``T`` can be annotated as ``Positional[T]`` if we want to parse it as a positional
-argument."""
+"""A type ``T`` can be annotated as ``Positional[T]`` if we want to parse it as a
+positional argument."""
 
 PositionalRequiredArgs = Annotated[T, None]
 """Make all arguments without defaults positional."""
@@ -42,8 +42,8 @@ from parsing it; a default value should be set instead. Fields that can't be
 parsed with defaults will also be marked as fixed automatically."""
 
 Suppress = Annotated[T, None]
-"""A type ``T`` can be annotated as ``Suppress[T]`` to prevent :func:`tyro.cli` from parsing it, and
-to prevent it from showing up in helptext."""
+"""A type ``T`` can be annotated as ``Suppress[T]`` to prevent :func:`tyro.cli` from
+parsing it, and to prevent it from showing up in helptext."""
 
 SuppressFixed = Annotated[T, None]
 """Hide fields that are either manually or automatically marked as fixed."""
@@ -56,9 +56,9 @@ Can be used directly on boolean annotations, ``FlagConversionOff[bool]``, or rec
 applied to nested types."""
 
 FlagCreatePairsOff = Annotated[T, None]
-"""Turn off creation of ``{--flag,--no-flag}`` pairs. Instead, only one flag will be
-created. ``--flag`` if the field default is ``False``, and ``--no-flag`` if the field default is
-``True``.
+"""Turn off creation of ``{--flag,--no-flag}`` pairs for boolean types. Instead, only
+one flag will be created. ``--flag`` if the field default is ``False``, and
+``--no-flag`` if the field default is ``True``.
 
 The default 'pair' behavior is more robust to changes in the default value, but might
 feel cluttered. This option provides an alternative.
@@ -77,8 +77,8 @@ ConsolidateSubcommandArgs = Annotated[T, None]
 """Consolidate arguments applied to subcommands. Makes CLI less sensitive to argument
 ordering, with some tradeoffs.
 
-By default, :mod:`tyro` will generate a traditional CLI interface where args are applied to
-the directly preceding subcommand. When we have two subcommands ``s1`` and ``s2``:
+By default, :mod:`tyro` will generate a traditional CLI interface where args are applied
+to the directly preceding subcommand. When we have two subcommands ``s1`` and ``s2``:
 
 
 .. code-block:: bash
@@ -100,8 +100,8 @@ This is more robust to reordering of options, ensuring that any new options can 
 be placed at the end of the command.
 
 The tradeoff is in required arguments. In the above example, if any ``--root.*`` options
-are required (no default is specified), all subcommands will need to be specified in order to
-provide the required argument.
+are required (no default is specified), all subcommands will need to be specified in
+order to provide the required argument.
 
 .. code-block:: bash
 
@@ -138,18 +138,19 @@ instead simply have ``--arg``.
 UseAppendAction = Annotated[T, None]
 """Use "append" actions for variable-length arguments.
 
-Given an annotation like ``x: list[int]``, this means that ``x = [0, 1, 2]`` can be set via
-the CLI syntax ``--x 0 --x 1 --x 2`` instead of the default of ``--x 0 1 2``.
+Given an annotation like ``x: list[int]``, this means that ``x = [0, 1, 2]`` can be set
+via the CLI syntax ``--x 0 --x 1 --x 2`` instead of the default of ``--x 0 1 2``.
 
-The resulting syntax may be more user-friendly; for :mod:`tyro`, it also enables support for
-otherwise ambiguous annotations like ``list[list[int]]``.
+The resulting syntax may be more user-friendly; for :mod:`tyro`, it also enables support
+for otherwise ambiguous annotations like ``list[list[int]]``.
 
 Can be applied to all variable-length sequences (``list[T]``, ``Sequence[T]``,
 ``tuple[T, ...]``, etc), including dictionaries without default values.
 """
 
 UseCounterAction = Annotated[T, None]
-"""Use "counter" actions for integer arguments. Should be used with integers, ``UseCounterAction[int]``."""
+"""Use "counter" actions for integer arguments. Should be used with integers,
+``UseCounterAction[int]``."""
 
 EnumChoicesFromValues = Annotated[T, None]
 """Populate choices from enum values rather than enum names.
@@ -170,9 +171,10 @@ Example:
             OutputFormats, tyro.conf.EnumChoicesFromValues
         ] = OutputFormats.PRETTY
 
-The above will result in ``json``, ``pretty``, ``rich``, and ``toml`` (all lowercase) as choices,
-since the auto values for `StrEnum` (Python 3.11+) are lowercase transformations of the
-names. Without this marker, the choices would be ``JSON``, ``PRETTY``, ``RICH``, and ``TOML``.
+The above will result in ``json``, ``pretty``, ``rich``, and ``toml`` (all lowercase) as
+choices, since the auto values for `StrEnum` (Python 3.11+) are lowercase
+transformations of the names. Without this marker, the choices would be ``JSON``,
+``PRETTY``, ``RICH``, and ``TOML``.
 
 Enum aliases are not relevant when this marker is present. The first entry matching the
 chosen value will be selected.
@@ -216,11 +218,11 @@ Marker = Any
 def configure(*markers: Marker) -> Callable[[CallableType], CallableType]:
     """Decorator for applying configuration options.
 
-    Consider using the ``config=`` argument of :func:`tyro.cli()` instead,
-    which takes the same config marker objects as inputs.
+    Consider using the ``config=`` argument of :func:`tyro.cli()` instead, which takes
+    the same config marker objects as inputs.
 
-    Configuration markers are implemented via :py:data:`typing.Annotated` and straightforward
-    to apply to types, for example:
+    Configuration markers are implemented via :py:data:`typing.Annotated` and
+    straightforward to apply to types, for example:
 
     .. code-block:: python
 

--- a/tests/test_boolean_optional.py
+++ b/tests/test_boolean_optional.py
@@ -83,3 +83,39 @@ def test_flag_default_true_helptext() -> None:
     assert "(default: True)" in get_helptext_with_checks(A)
     assert "(default: False)" not in get_helptext_with_checks(A)
     assert "(default: None)" not in get_helptext_with_checks(A)
+
+
+def test_flag_no_negation() -> None:
+    """Test for argparse.BooleanOptionalAction-style usage."""
+
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.FlagNegationOff[bool] = False
+
+    @dataclasses.dataclass
+    class B:
+        x: bool = True
+
+    # import pdb
+    # pdb.set_trace()
+    assert tyro.cli(
+        A,
+        args=["--x"],
+        default=A(True),
+    ) == A(True)
+
+    # no pair --no-x flag is generated
+    try:
+        tyro.cli(
+            A,
+            args=["--no-x"],
+            default=A(True),
+        )
+        assert False
+    except SystemExit:
+        pass
+
+    assert tyro.cli(
+        A,
+        args=[]
+    ) == A(False)

--- a/tests/test_boolean_optional.py
+++ b/tests/test_boolean_optional.py
@@ -91,9 +91,9 @@ def test_flag_no_pairs() -> None:
 
     @dataclasses.dataclass
     class A:
-        x: tyro.conf.FlagPairOff[bool]
-        y: tyro.conf.FlagPairOff[bool] = False
-        z: tyro.conf.FlagPairOff[bool] = True
+        x: tyro.conf.FlagCreatePairsOff[bool]
+        y: tyro.conf.FlagCreatePairsOff[bool] = False
+        z: tyro.conf.FlagCreatePairsOff[bool] = True
 
     assert tyro.cli(
         A,


### PR DESCRIPTION
Hi, I really appreciate your work. I am a happy user since months when I did a study, comparing over 25+ CLI parsing projects and tyro was the best.

I am trying to port a project with a lot of options to tyro. However, there are some things that look bad: I'd really like to turn off boolean negation. As I have many options with aliases, the flag namespace gets really polluted. As all of the flags are off by default, I really need only the positive flag.

Here, I propose an option to do this behaviour. I've added a test as well. How should I edit the code so that it is convenient for the tyro code base please?