### PR TITLE
Add flag to omit prefixes while keeping groups

### DIFF
--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -541,11 +541,14 @@ def _rule_set_name_or_flag_and_dest(
     elif (
         arg.field.argconf.prefix_name is False
         or _markers.OmitArgPrefixes in arg.field.markers
+        or _markers.OmitArgPrefixesKeepGrouping in arg.field.markers
     ):
         # Strip prefixes when the argument is suppressed.
         # Still need to call make_field_name() because it converts underscores
         # to hyphens, etc.
         name_or_flag = _strings.make_field_name([arg.field.extern_name])
+        if _markers.OmitArgPrefixesKeepGrouping in arg.field.markers:
+            arg.field.group = arg.extern_prefix
     elif (
         _markers.OmitSubcommandPrefixes in arg.field.markers
         and arg.subcommand_prefix != ""

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -46,6 +46,8 @@ class FieldDefinition:
     # doesn't match the keyword expected by our callable.
     call_argname: Any
 
+    group: str = ""
+
     @staticmethod
     @contextlib.contextmanager
     def marker_context(markers: Tuple[_markers.Marker, ...]):

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -248,6 +248,8 @@ class ParserSpecification:
             return (group_name + " options").strip()
 
         def group_name_from_arg(arg: _arguments.ArgumentDefinition) -> str:
+            if arg.field.group:
+                return arg.field.group
             prefix = arg.lowered.name_or_flags[0]
             if prefix.startswith("--"):
                 prefix = prefix[2:]

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -20,6 +20,7 @@ from ._markers import Fixed as Fixed
 from ._markers import FlagConversionOff as FlagConversionOff
 from ._markers import HelptextFromCommentsOff as HelptextFromCommentsOff
 from ._markers import OmitArgPrefixes as OmitArgPrefixes
+from ._markers import OmitArgPrefixesKeepGrouping as OmitArgPrefixesKeepGrouping
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes
 from ._markers import Positional as Positional
 from ._markers import PositionalRequiredArgs as PositionalRequiredArgs

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -124,6 +124,19 @@ By default, ``--cmd.arg`` may be generated as a flag. If prefixes are omitted, w
 instead simply have ``--arg``.
 """
 
+OmitArgPrefixesKeepGrouping = Annotated[T, None]
+"""Make flags used for keyword arguments shorter by omitting prefixes.
+
+If we have a structure with the field:
+
+.. code-block:: python
+
+    cmd: NestedType
+
+By default, ``--cmd.arg`` may be generated as a flag. If prefixes are omitted, we would
+instead simply have ``--arg``. But the groups would still be printed.
+"""
+
 UseAppendAction = Annotated[T, None]
 """Use "append" actions for variable-length arguments.
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1112,9 +1112,34 @@ def test_omit_arg_prefixes() -> None:
         args="--model.num-slots 3".split(" "),
     ) == TrainConfig(ModelConfig(num_slots=3))
 
+    annot = tyro.conf.OmitArgPrefixes[TrainConfig]
     assert tyro.cli(
-        tyro.conf.OmitArgPrefixes[TrainConfig], args="--num-slots 3".split(" ")
+        annot, args="--num-slots 3".split(" ")
     ) == TrainConfig(ModelConfig(num_slots=3))
+
+    help_text = get_helptext_with_checks(annot)
+    assert "model options" not in help_text
+    assert "--num-slots" in help_text
+
+
+def test_omit_arg_prefixes_keep_grouping() -> None:
+    # Works the same way as test_omit_arg_prefixes but the help text keeps groups
+    @dataclasses.dataclass
+    class ModelConfig:
+        num_slots: int
+
+    @dataclasses.dataclass
+    class TrainConfig:
+        model: ModelConfig
+
+    annot = tyro.conf.OmitArgPrefixesKeepGrouping[TrainConfig]
+    assert tyro.cli(
+        annot, args="--num-slots 3".split(" ")
+    ) == TrainConfig(ModelConfig(num_slots=3))
+
+    help_text = get_helptext_with_checks(annot)
+    assert "model options" in help_text
+    assert "--num-slots" in help_text
 
 
 def test_custom_constructor_0() -> None:


### PR DESCRIPTION
And this is my second wish. My big project uses many argparsers. For backward compatiblity, I do not want to impose the usrs to change all the flags to its subparser variants `--model.x` instead of `--x`. But I really need to keep the help text divided into groups.

This marker adds the functionality, help text displaying groups, while omitting the args prefixes. How it should be done so that you can accept the feature please?