### PR TITLE
Restore helptext behavior for erased argument names + tests

### DIFF
--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -264,7 +264,19 @@ class ParserSpecification:
             if arg.is_suppressed():
                 continue
 
-            group_name = arg.extern_prefix
+            group_name = (
+                arg.extern_prefix
+                if arg.field.argconf.name != ""
+                # If the field name is "erased", we'll place the argument in
+                # the parent's group.
+                #
+                # This is to avoid "issue 1" in:
+                # https://github.com/brentyi/tyro/issues/183
+                #
+                # Setting `tyro.conf.arg(name="")` should generally be
+                # discouraged, so this will rarely matter.
+                else arg.extern_prefix.rpartition(".")[0]
+            )
             if group_name not in group_from_group_name:
                 description = (
                     parent.helptext_from_intern_prefixed_field_name.get(

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1117,7 +1117,7 @@ def test_omit_arg_prefixes() -> None:
         ModelConfig(num_slots=3)
     )
 
-    # groups are still printed in the help text
+    # Groups are still printed in the helptext.
     help_text = get_helptext_with_checks(annot)
     assert "model options" in help_text
     assert "--num-slots" in help_text

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -959,3 +959,20 @@ def test_typeddict_exclude() -> None:
 
     help = get_helptext_with_checks(Special)
     assert "unset by default" in help, help
+
+
+def test_conf_erased_argname() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class Verbose:
+        is_verbose: bool = True
+
+    @dataclasses.dataclass(frozen=True)
+    class Args:
+        verbose: Annotated[Verbose, tyro.conf.arg(name="")]
+
+    def main(args: Args) -> None:
+        print(args)
+
+    helptext = get_helptext_with_checks(main)
+    assert "args options" in helptext
+    assert "args.verbose options" not in helptext

--- a/tests/test_py311_generated/test_boolean_optional_generated.py
+++ b/tests/test_py311_generated/test_boolean_optional_generated.py
@@ -1,5 +1,6 @@
 import dataclasses
 
+import pytest
 from helptext_utils import get_helptext_with_checks
 
 import tyro
@@ -83,3 +84,52 @@ def test_flag_default_true_helptext() -> None:
     assert "(default: True)" in get_helptext_with_checks(A)
     assert "(default: False)" not in get_helptext_with_checks(A)
     assert "(default: None)" not in get_helptext_with_checks(A)
+
+
+def test_flag_no_pairs() -> None:
+    """Test for tyro.conf.FlagPairOff."""
+
+    @dataclasses.dataclass
+    class A:
+        x: tyro.conf.FlagCreatePairsOff[bool]
+        y: tyro.conf.FlagCreatePairsOff[bool] = False
+        z: tyro.conf.FlagCreatePairsOff[bool] = True
+
+    assert tyro.cli(
+        A,
+        args=["--x", "True"],
+    ) == A(True)
+    assert tyro.cli(
+        A,
+        args=["--x", "True", "--y"],
+    ) == A(True, True)
+    assert tyro.cli(
+        A,
+        args=["--x", "True", "--y", "--no-z"],
+    ) == A(True, True, False)
+
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            A,
+            args=["--x", "True", "--y", "True"],
+        )
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            A,
+            args=["--x", "True", "--no-y"],
+        )
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            A,
+            args=["--x", "True", "--z"],
+        )
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            A,
+            args=["--x"],
+        )
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            A,
+            args=["--no-x"],
+        )

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1121,9 +1121,15 @@ def test_omit_arg_prefixes() -> None:
         args="--model.num-slots 3".split(" "),
     ) == TrainConfig(ModelConfig(num_slots=3))
 
-    assert tyro.cli(
-        tyro.conf.OmitArgPrefixes[TrainConfig], args="--num-slots 3".split(" ")
-    ) == TrainConfig(ModelConfig(num_slots=3))
+    annot = tyro.conf.OmitArgPrefixes[TrainConfig]
+    assert tyro.cli(annot, args="--num-slots 3".split(" ")) == TrainConfig(
+        ModelConfig(num_slots=3)
+    )
+
+    # Groups are still printed in the helptext.
+    help_text = get_helptext_with_checks(annot)
+    assert "model options" in help_text
+    assert "--num-slots" in help_text
 
 
 def test_custom_constructor_0() -> None:

--- a/tests/test_py311_generated/test_helptext_generated.py
+++ b/tests/test_py311_generated/test_helptext_generated.py
@@ -960,3 +960,20 @@ def test_typeddict_exclude() -> None:
 
     help = get_helptext_with_checks(Special)
     assert "unset by default" in help, help
+
+
+def test_conf_erased_argname() -> None:
+    @dataclasses.dataclass(frozen=True)
+    class Verbose:
+        is_verbose: bool = True
+
+    @dataclasses.dataclass(frozen=True)
+    class Args:
+        verbose: Annotated[Verbose, tyro.conf.arg(name="")]
+
+    def main(args: Args) -> None:
+        print(args)
+
+    helptext = get_helptext_with_checks(main)
+    assert "args options" in helptext
+    assert "args.verbose options" not in helptext


### PR DESCRIPTION
#252 reverted the helptext grouping behavior discussed in #183 for when `tyro.conf.arg(name="")` is used. I restored this. The groupings that motivated #252 should be unaffected.