### PR TITLE
Fix custom constructor edge case for variable-length positional arguments

### DIFF
--- a/src/tyro/_calling.py
+++ b/src/tyro/_calling.py
@@ -97,6 +97,7 @@ def callable_with_args(
             consumed_keywords.add(name_maybe_prefixed)
             if not arg.lowered.is_fixed():
                 value, value_found = get_value_from_arg(name_maybe_prefixed, arg)
+                should_cast = False
 
                 if value in _fields.MISSING_AND_MISSING_NONPROP:
                     value = arg.field.default
@@ -114,14 +115,18 @@ def callable_with_args(
                         and arg.lowered.nargs in ("?", "*")
                     ):
                         value = []
+                        should_cast = True
                 elif value_found:
                     # Value was found from the CLI, so we need to cast it with instance_from_str.
+                    should_cast = True
                     any_arguments_provided = True
                     if arg.lowered.nargs == "?":
                         # Special case for optional positional arguments: this is the
                         # only time that arguments don't come back as a list.
                         value = [value]
 
+                # Attempt to cast the value to the correct type.
+                if should_cast:
                     try:
                         assert arg.lowered.instance_from_str is not None
                         value = arg.lowered.instance_from_str(value)

--- a/tests/test_custom_constructors.py
+++ b/tests/test_custom_constructors.py
@@ -105,14 +105,14 @@ def test_custom_constructor_numpy() -> None:
     )
 
 
-def make_list_of_strings_with_minimum_length(args: list[str]) -> list[str]:
+def make_list_of_strings_with_minimum_length(args: List[str]) -> List[str]:
     if len(args) == 0:
         raise ValueError("Expected at least one string")
     return args
 
 
 ListOfStringsWithMinimumLength = Annotated[
-    list[str],
+    List[str],
     tyro.constructors.PrimitiveConstructorSpec(
         nargs="*",
         metavar="STR [STR ...]",
@@ -128,6 +128,7 @@ def test_min_length_custom_constructor() -> None:
     def main(
         field1: ListOfStringsWithMinimumLength, field2: int = 3
     ) -> ListOfStringsWithMinimumLength:
+        del field2
         return field1
 
     with pytest.raises(SystemExit):

--- a/tests/test_py311_generated/test_custom_constructors_generated.py
+++ b/tests/test_py311_generated/test_custom_constructors_generated.py
@@ -104,14 +104,14 @@ def test_custom_constructor_numpy() -> None:
     )
 
 
-def make_list_of_strings_with_minimum_length(args: list[str]) -> list[str]:
+def make_list_of_strings_with_minimum_length(args: List[str]) -> List[str]:
     if len(args) == 0:
         raise ValueError("Expected at least one string")
     return args
 
 
 ListOfStringsWithMinimumLength = Annotated[
-    list[str],
+    List[str],
     tyro.constructors.PrimitiveConstructorSpec(
         nargs="*",
         metavar="STR [STR ...]",
@@ -127,6 +127,7 @@ def test_min_length_custom_constructor() -> None:
     def main(
         field1: ListOfStringsWithMinimumLength, field2: int = 3
     ) -> ListOfStringsWithMinimumLength:
+        del field2
         return field1
 
     with pytest.raises(SystemExit):

--- a/tests/test_py311_generated/test_custom_constructors_generated.py
+++ b/tests/test_py311_generated/test_custom_constructors_generated.py
@@ -4,6 +4,7 @@ import json
 from typing import Annotated, Any, Dict, List, Literal, get_args
 
 import numpy as np
+import pytest
 
 import tyro
 
@@ -101,3 +102,35 @@ def test_custom_constructor_numpy() -> None:
         ).dtype
         == np.float32
     )
+
+
+def make_list_of_strings_with_minimum_length(args: list[str]) -> list[str]:
+    if len(args) == 0:
+        raise ValueError("Expected at least one string")
+    return args
+
+
+ListOfStringsWithMinimumLength = Annotated[
+    list[str],
+    tyro.constructors.PrimitiveConstructorSpec(
+        nargs="*",
+        metavar="STR [STR ...]",
+        is_instance=lambda x: isinstance(x, list)
+        and all(isinstance(i, str) for i in x),
+        instance_from_str=make_list_of_strings_with_minimum_length,
+        str_from_instance=lambda args: args,
+    ),
+]
+
+
+def test_min_length_custom_constructor() -> None:
+    def main(
+        field1: ListOfStringsWithMinimumLength, field2: int = 3
+    ) -> ListOfStringsWithMinimumLength:
+        return field1
+
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--field1"])
+    assert tyro.cli(main, args=["--field1", "a", "b"]) == ["a", "b"]


### PR DESCRIPTION
Custom constructors were not being called correctly when:
- A variable-length argument was defined
- The argument was set to positional
- A length-0 input was passed in

cc #257