### PR TITLE
Consistency improvements for `tyro.MISSING`

### DIFF
--- a/src/tyro/_singleton.py
+++ b/src/tyro/_singleton.py
@@ -1,3 +1,4 @@
+import unittest.mock
 from typing import Any
 
 
@@ -16,11 +17,16 @@ class Singleton:
         pass
 
 
-class PropagatingMissingType(Singleton):
+# We'll inherit from unittest.mock.Mock for MISSING types to help with
+# typeguard error suppression.
+# https://typeguard.readthedocs.io/en/latest/features.html#support-for-mock-objects
+
+
+class PropagatingMissingType(Singleton, unittest.mock.Mock):
     pass
 
 
-class NonpropagatingMissingType(Singleton):
+class NonpropagatingMissingType(Singleton, unittest.mock.Mock):
     pass
 
 

--- a/src/tyro/constructors/_struct_spec.py
+++ b/src/tyro/constructors/_struct_spec.py
@@ -649,10 +649,7 @@ def _get_dataclass_field_default(
             return getattr(parent_default_instance, field.name)
 
     # Try grabbing default from dataclass field.
-    if (
-        field.default not in MISSING_AND_MISSING_NONPROP
-        and field.default is not dataclasses.MISSING
-    ):
+    if field.default is not dataclasses.MISSING:
         default = field.default
         # dataclasses.is_dataclass() will also return true for dataclass
         # _types_, not just instances.

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -3,7 +3,7 @@
 import contextlib
 import dataclasses
 import io
-from typing import Tuple
+from typing import Tuple, Union
 
 import pytest
 
@@ -80,3 +80,124 @@ def test_missing_nested_default() -> None:
         args=["--child.a", "5", "--child.b", "7", "--child.c", "3"],
         default=Parent(child=tyro.MISSING),
     ) == Parent(Child(5, 7, 3))
+
+
+def test_missing_in_dataclass_def() -> None:
+    @dataclasses.dataclass
+    class Child:
+        a: int = 5
+        b: int = 3
+        c: int = 7
+
+    @dataclasses.dataclass
+    class Parent:
+        child: Child = tyro.MISSING
+
+    assert tyro.cli(
+        Parent, args=["--child.a", "5", "--child.b", "7", "--child.c", "3"]
+    ) == Parent(Child(5, 7, 3))
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Parent, args=[], default=tyro.MISSING)
+
+    # tyro.MISSING in dataclass definition should propagate to child fields, which makes all arguments required.
+    with pytest.raises(SystemExit):
+        tyro.cli(Parent, args=[])
+    with pytest.raises(SystemExit):
+        tyro.cli(Parent, args=["--child.a", "5"])
+
+
+def test_missing_in_tuple() -> None:
+    @dataclasses.dataclass
+    class Child:
+        a: int = 5
+        b: int = 3
+        c: int = 7
+
+    @dataclasses.dataclass
+    class Parent:
+        child: Tuple[Child, Child] = tyro.MISSING
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Parent, args=[])
+
+    assert tyro.cli(
+        Parent,
+        args=[
+            "--child.0.a",
+            "5",
+            "--child.0.b",
+            "7",
+            "--child.0.c",
+            "3",
+            "--child.1.a",
+            "5",
+            "--child.1.b",
+            "7",
+            "--child.1.c",
+            "3",
+        ],
+    ) == Parent((Child(5, 7, 3), Child(5, 7, 3)))
+
+
+def test_missing_in_tuple_pair() -> None:
+    @dataclasses.dataclass
+    class Child:
+        a: int = 5
+        b: int = 3
+        c: int = 7
+
+    @dataclasses.dataclass
+    class Parent:
+        child: Tuple[Child, Child] = (tyro.MISSING, tyro.MISSING)
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Parent, args=[])
+
+    assert tyro.cli(
+        Parent,
+        args=[
+            "--child.0.a",
+            "5",
+            "--child.0.b",
+            "7",
+            "--child.0.c",
+            "3",
+            "--child.1.a",
+            "5",
+            "--child.1.b",
+            "7",
+            "--child.1.c",
+            "3",
+        ],
+    ) == Parent((Child(5, 7, 3), Child(5, 7, 3)))
+
+
+def test_missing_in_tuple_pair_subcommands() -> None:
+    @dataclasses.dataclass
+    class Child1:
+        a: int = 5
+
+    @dataclasses.dataclass
+    class Child2:
+        b: int = 3
+
+    @dataclasses.dataclass
+    class Parent:
+        children: Tuple[Union[Child1, Child2], Union[Child1, Child2]] = (
+            tyro.MISSING,
+            Child2(2),
+        )
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Parent, args=[])
+
+    assert tyro.cli(
+        Parent,
+        args=["children.0:child1", "--children.0.a", "5"],
+    ) == Parent((Child1(5), Child2(2)))
+
+    assert tyro.cli(
+        Parent,
+        args=["children.0:child2", "--children.0.b", "5"],
+    ) == Parent((Child2(5), Child2(2)))


### PR DESCRIPTION
- More consistent behavior when `tyro.MISSING` is placed in dataclass definitions
    - Missing semantics were not correctly propagating to children
- More consistent behavior when `tyro.MISSING` is used inside of struct types
    - For example: `field: tuple[DataclassA, DataclassB] = (tyro.MISSING, tyro.MISSING)`
    - This was previously throwing an error