### PR TITLE
Fix subcommand Callable type annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Tyro Development Guide
+
+## Build & Test Commands
+- Install dev dependencies: `pip install -e ".[dev]"`
+- Run all tests: `pytest`
+- Run specific test: `pytest tests/test_file.py -v` or `pytest tests/test_file.py::test_name -v`
+- Prefer pyright for type checking: `pyright .`
+- Run linting: `ruff check`
+- Fix linting issues: `ruff check --fix` (some fixes require `--unsafe-fixes` option)
+- Format code: `ruff format` (check changes first with `ruff format --diff`)
+
+## Style Guidelines
+- Use type annotations for all functions and variables
+- Follow PEP 8 conventions 
+- Use descriptive variable/function names in snake_case
+- Classes should use CamelCase
+- Prefer dataclasses for configuration objects
+- Use docstrings for public functions/classes
+- Import ordering: stdlib > third-party > local modules
+- Pass exceptions up where appropriate (don't suppress silently)
+- Prefer composition over inheritance
+
+## Architecture
+Tyro focuses on generating CLI interfaces from type-annotated Python. The codebase supports Python 3.7-3.13 with conditional imports and version-specific features.

--- a/src/tyro/conf/_confstruct.py
+++ b/src/tyro/conf/_confstruct.py
@@ -14,7 +14,7 @@ class _SubcommandConfig:
     default: Any
     description: str | None
     prefix_name: bool
-    constructor_factory: Callable[[], type | Callable] | None
+    constructor_factory: Callable[[], type | Callable[..., Any]] | None
 
     def __hash__(self) -> int:
         return object.__hash__(self)
@@ -28,7 +28,7 @@ def subcommand(
     description: str | None = None,
     prefix_name: bool = True,
     constructor: None = None,
-    constructor_factory: Callable[[], type | Callable] | None = None,
+    constructor_factory: Callable[[], type | Callable[..., Any]] | None = None,
 ) -> Any: ...
 
 
@@ -39,7 +39,7 @@ def subcommand(
     default: Any = MISSING_NONPROP,
     description: str | None = None,
     prefix_name: bool = True,
-    constructor: type | Callable | None = None,
+    constructor: type | Callable[..., Any] | None = None,
     constructor_factory: None = None,
 ) -> Any: ...
 
@@ -50,8 +50,8 @@ def subcommand(
     default: Any = MISSING_NONPROP,
     description: str | None = None,
     prefix_name: bool = True,
-    constructor: type | Callable | None = None,
-    constructor_factory: Callable[[], type | Callable] | None = None,
+    constructor: type | Callable[..., Any] | None = None,
+    constructor_factory: Callable[[], type | Callable[..., Any]] | None = None,
 ) -> Any:
     """Returns a metadata object for configuring subcommands with
     :py:data:`typing.Annotated`. Useful for aesthetics.


### PR DESCRIPTION
## Summary
- Update Callable type annotations in subcommand related code to use Callable[..., Any]
- Fixes pyright type checking errors when using subcommand function with stricter settings
- Similar to PR #249 which fixed other Callable annotations
- Fixes #262

## Test plan
- Verified with local pyright that it fixes the type checking error
- No runtime behavior changes, only type annotation improvements

🤖 Generated with Claude Code