### PR TITLE
Fix truncation of long Literal options in helptext display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 ## Build & Test Commands
 - Install dev dependencies: `pip install -e ".[dev]"`
-- Run all tests: `pytest`
+- Run all tests: `pytest -n auto` (parallel execution)
+- Run all tests: `pytest` (sequential execution)
 - Run specific test: `pytest tests/test_file.py -v` or `pytest tests/test_file.py::test_name -v`
 - Prefer pyright for type checking: `pyright .`
 - Run linting: `ruff check`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - Run all tests: `pytest -n auto` (parallel execution)
 - Run all tests: `pytest` (sequential execution)
 - Run specific test: `pytest tests/test_file.py -v` or `pytest tests/test_file.py::test_name -v`
+- When modifying tests, regenerate the Py311 test variants: `python tests/test_py311_generated/_generate.py`
 - Prefer pyright for type checking: `pyright .`
 - Run linting: `ruff check`
 - Fix linting issues: `ruff check --fix` (some fixes require `--unsafe-fixes` option)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "PyYAML>=6.0",
     "pytest>=7.1.2",
     "pytest-cov>=3.0.0",
+    "pytest-xdist>=3.5.0",
     "omegaconf>=2.2.2",
     "attrs>=21.4.0",
     "torch>=1.10.0;python_version<='3.12'",

--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -906,6 +906,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                         style=(
                             THEME.metavar_fixed if out == "{fixed}" else THEME.metavar
                         ),
+                        overflow="fold",
                     ),
                     soft_wrap=True,
                 )
@@ -992,7 +993,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                     elif isinstance(item_content, str):
                         if item_content.strip() == "":
                             continue
-                        top_parts.append(Text.from_ansi(item_content))
+                        top_parts.append(Text.from_ansi(item_content, overflow="fold"))
 
                     # Add panels. (argument groups, subcommands, etc)
                     else:
@@ -1088,9 +1089,9 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
             if action.help is not None:
                 assert isinstance(action.help, str)
                 helptext = (
-                    Text.from_ansi(action.help.replace("%%", "%"))
+                    Text.from_ansi(action.help.replace("%%", "%"), overflow="fold")
                     if _strings.strip_ansi_sequences(action.help) != action.help
-                    else Text.from_markup(action.help.replace("%%", "%"))
+                    else Text.from_markup(action.help.replace("%%", "%"), overflow="fold")
                 )
             else:
                 helptext = Text("")
@@ -1108,6 +1109,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                     Text.from_ansi(
                         invocation,
                         style=THEME.invocation,
+                        overflow="fold",
                     ),
                     helptext,
                 )
@@ -1119,6 +1121,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                     Text.from_ansi(
                         invocation + "\n",
                         style=THEME.invocation,
+                        overflow="fold",
                     )
                 )
                 if action.help:
@@ -1170,6 +1173,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                         description_part = Text.from_ansi(
                             item_content.strip() + "\n",
                             style=THEME.description,
+                            overflow="fold",
                         )
 
             if len(item_parts) == 0:
@@ -1211,7 +1215,7 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                 # expand to fill the full width of the console. This only impacts
                 # single-column layouts.
                 self.formatter._tyro_rule = Text.from_ansi(
-                    "─" * max_width, style=THEME.border, overflow="crop"
+                    "─" * max_width, style=THEME.border, overflow="fold"
                 )
             elif len(self.formatter._tyro_rule._text[0]) < max_width:
                 self.formatter._tyro_rule._text = ["─" * max_width]

--- a/src/tyro/_argparse_formatter.py
+++ b/src/tyro/_argparse_formatter.py
@@ -1091,7 +1091,9 @@ class TyroArgparseHelpFormatter(argparse.RawDescriptionHelpFormatter):
                 helptext = (
                     Text.from_ansi(action.help.replace("%%", "%"), overflow="fold")
                     if _strings.strip_ansi_sequences(action.help) != action.help
-                    else Text.from_markup(action.help.replace("%%", "%"), overflow="fold")
+                    else Text.from_markup(
+                        action.help.replace("%%", "%"), overflow="fold"
+                    )
                 )
             else:
                 helptext = Text("")

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -980,7 +980,7 @@ def test_conf_erased_argname() -> None:
 
 def test_long_literal_options() -> None:
     """Test that long literal options don't get truncated in helptext."""
-    
+
     def main(
         x: Literal[
             "one",
@@ -1008,14 +1008,31 @@ def test_long_literal_options() -> None:
         print(x)
 
     helptext = get_helptext_with_checks(main)
-    
+
     # Check that the helptext contains all options without truncation
     for option in [
-        "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
-        "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
-        "eighteen", "nineteen", "twenty"
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+        "eleven",
+        "twelve",
+        "thirteen",
+        "fourteen",
+        "fifteen",
+        "sixteen",
+        "seventeen",
+        "eighteen",
+        "nineteen",
+        "twenty",
     ]:
         assert option in helptext
-    
+
     # Check that there's no ellipsis character in the helptext
     assert "…" not in helptext

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -976,3 +976,46 @@ def test_conf_erased_argname() -> None:
     helptext = get_helptext_with_checks(main)
     assert "args options" in helptext
     assert "args.verbose options" not in helptext
+
+
+def test_long_literal_options() -> None:
+    """Test that long literal options don't get truncated in helptext."""
+    
+    def main(
+        x: Literal[
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen",
+            "seventeen",
+            "eighteen",
+            "nineteen",
+            "twenty",
+        ],
+    ) -> None:
+        print(x)
+
+    helptext = get_helptext_with_checks(main)
+    
+    # Check that the helptext contains all options without truncation
+    for option in [
+        "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+        "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
+        "eighteen", "nineteen", "twenty"
+    ]:
+        assert option in helptext
+    
+    # Check that there's no ellipsis character in the helptext
+    assert "…" not in helptext

--- a/tests/test_py311_generated/test_helptext_generated.py
+++ b/tests/test_py311_generated/test_helptext_generated.py
@@ -977,3 +977,63 @@ def test_conf_erased_argname() -> None:
     helptext = get_helptext_with_checks(main)
     assert "args options" in helptext
     assert "args.verbose options" not in helptext
+
+
+def test_long_literal_options() -> None:
+    """Test that long literal options don't get truncated in helptext."""
+
+    def main(
+        x: Literal[
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen",
+            "seventeen",
+            "eighteen",
+            "nineteen",
+            "twenty",
+        ],
+    ) -> None:
+        print(x)
+
+    helptext = get_helptext_with_checks(main)
+
+    # Check that the helptext contains all options without truncation
+    for option in [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+        "eleven",
+        "twelve",
+        "thirteen",
+        "fourteen",
+        "fifteen",
+        "sixteen",
+        "seventeen",
+        "eighteen",
+        "nineteen",
+        "twenty",
+    ]:
+        assert option in helptext
+
+    # Check that there's no ellipsis character in the helptext
+    assert "…" not in helptext


### PR DESCRIPTION
## Summary
- Fixed an issue where long Literal type options were being truncated with an ellipsis character in helptext
- Added overflow=\"fold\" parameter to Text.from_ansi() calls in argparse_formatter.py to ensure proper line wrapping
- Added test to verify the fix
- Added pytest-xdist as a dev dependency for parallel test execution
- Updated CLAUDE.md with test generation instructions

## Test plan
- Run the test_long_literal_options test
- Run the long_literal.py example script with --help
- Verify that all options are displayed with proper line wrapping instead of truncation

🤖 Generated with [Claude Code](https://claude.ai/code)