### PR TITLE
Fix runtime error with NotRequired[bool] in TypedDict

### DIFF
--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -247,32 +247,26 @@ def _rule_handle_boolean_flags(
         return
 
     if (
-        arg.field.default in _singleton.MISSING_AND_MISSING_NONPROP
+        arg.field.default not in (True, False)
         or arg.field.is_positional()
         or _markers.FlagConversionOff in arg.field.markers
         or _markers.Fixed in arg.field.markers
+        or arg.field.default not in (True, False)
     ):
         # Treat bools as a normal parameter.
         return
-    elif arg.field.default in (True, False):
-        # Default `False` => --flag passed in flips to `True`.
-        if _markers.FlagCreatePairsOff in arg.field.markers:
-            # If default is True, --flag will flip to `False`.
-            # If default is False, --no-flag will flip to `True`.
-            lowered.action = "store_false" if arg.field.default else "store_true"
-        else:
-            # Create both --flag and --no-flag.
-            lowered.action = BooleanOptionalAction
-        lowered.instance_from_str = (
-            lambda x: x
-        )  # argparse will directly give us a bool!
-        lowered.default = arg.field.default
-        return
 
-    assert False, (
-        f"Expected a boolean as a default for {arg.field.intern_name}, but got"
-        f" {arg.field.default}."
-    )
+    # Default `False` => --flag passed in flips to `True`.
+    if _markers.FlagCreatePairsOff in arg.field.markers:
+        # If default is True, --flag will flip to `False`.
+        # If default is False, --no-flag will flip to `True`.
+        lowered.action = "store_false" if arg.field.default else "store_true"
+    else:
+        # Create both --flag and --no-flag.
+        lowered.action = BooleanOptionalAction
+    lowered.instance_from_str = lambda x: x  # argparse will directly give us a bool!
+    lowered.default = arg.field.default
+    return
 
 
 def _rule_apply_primitive_specs(

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -247,11 +247,10 @@ def _rule_handle_boolean_flags(
         return
 
     if (
-        arg.field.default not in (True, False)
+        arg.field.default in _singleton.MISSING_AND_MISSING_NONPROP
         or arg.field.is_positional()
         or _markers.FlagConversionOff in arg.field.markers
         or _markers.Fixed in arg.field.markers
-        or arg.field.default not in (True, False)
     ):
         # Treat bools as a normal parameter.
         return

--- a/tests/test_dict_namedtuple.py
+++ b/tests/test_dict_namedtuple.py
@@ -588,8 +588,8 @@ def test_not_required_bool() -> None:
     class NotRequiredBool(TypedDict):
         x: NotRequired[bool]
 
-    assert tyro.cli(NotRequiredBool, args="--x True".split(" ")) == {"x": True}
-    assert tyro.cli(NotRequiredBool, args="--x False".split(" ")) == {"x": False}
+    assert tyro.cli(NotRequiredBool, args="--x".split(" ")) == {"x": True}
+    assert tyro.cli(NotRequiredBool, args="--no-x".split(" ")) == {"x": False}
     assert tyro.cli(NotRequiredBool, args=[]) == {}
 
 

--- a/tests/test_dict_namedtuple.py
+++ b/tests/test_dict_namedtuple.py
@@ -584,6 +584,15 @@ def test_functional_typeddict():
     }
 
 
+def test_not_required_bool() -> None:
+    class NotRequiredBool(TypedDict):
+        x: NotRequired[bool]
+
+    assert tyro.cli(NotRequiredBool, args="--x True".split(" ")) == {"x": True}
+    assert tyro.cli(NotRequiredBool, args="--x False".split(" ")) == {"x": False}
+    assert tyro.cli(NotRequiredBool, args=[]) == {}
+
+
 def test_functional_typeddict_with_default():
     """Source: https://github.com/brentyi/tyro/issues/87"""
     NerfMLPHiddenLayers_0 = TypedDict(

--- a/tests/test_py311_generated/test_dict_namedtuple_generated.py
+++ b/tests/test_py311_generated/test_dict_namedtuple_generated.py
@@ -598,8 +598,8 @@ def test_not_required_bool() -> None:
     class NotRequiredBool(TypedDict):
         x: NotRequired[bool]
 
-    assert tyro.cli(NotRequiredBool, args="--x True".split(" ")) == {"x": True}
-    assert tyro.cli(NotRequiredBool, args="--x False".split(" ")) == {"x": False}
+    assert tyro.cli(NotRequiredBool, args="--x".split(" ")) == {"x": True}
+    assert tyro.cli(NotRequiredBool, args="--no-x".split(" ")) == {"x": False}
     assert tyro.cli(NotRequiredBool, args=[]) == {}
 
 

--- a/tests/test_py311_generated/test_dict_namedtuple_generated.py
+++ b/tests/test_py311_generated/test_dict_namedtuple_generated.py
@@ -594,6 +594,15 @@ def test_functional_typeddict():
     }
 
 
+def test_not_required_bool() -> None:
+    class NotRequiredBool(TypedDict):
+        x: NotRequired[bool]
+
+    assert tyro.cli(NotRequiredBool, args="--x True".split(" ")) == {"x": True}
+    assert tyro.cli(NotRequiredBool, args="--x False".split(" ")) == {"x": False}
+    assert tyro.cli(NotRequiredBool, args=[]) == {}
+
+
 def test_functional_typeddict_with_default():
     """Source: https://github.com/brentyi/tyro/issues/87"""
     NerfMLPHiddenLayers_0 = TypedDict(


### PR DESCRIPTION
## Summary
- Fixes a runtime error that occurred when using NotRequired[bool] in TypedDict
- Simplifies boolean flag handling logic in _rule_handle_boolean_flags
- Adds test cases to verify NotRequired[bool] functionality works correctly

## Test plan
- Added test_not_required_bool which verifies that TypedDict with NotRequired[bool] works as expected
- All tests pass including the new test case

🤖 Generated with [Claude Code](https://claude.ai/code)