### PR TITLE
Consider argument metavar in 'Perhaps you meant' error text

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -293,6 +293,28 @@ def test_similar_arguments_subcommands() -> None:
     assert error.count("--help") == 3
 
 
+def test_different_metavar_subcommands() -> None:
+    @dataclasses.dataclass
+    class ClassA:
+        arg: Literal["a"]
+
+    @dataclasses.dataclass
+    class ClassB:
+        arg: Literal["b"]
+
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stderr(target):
+        tyro.cli(Union[ClassA, ClassB], args="--ar".split(" "))  # type: ignore
+
+    error = target.getvalue()
+    assert "Unrecognized option" in error
+    assert "Perhaps you meant:" in error
+    assert error.count("--arg") == 2
+    assert error.count("--arg {a}") == 1
+    assert error.count("--arg {b}") == 1
+    assert error.count("--help") == 3
+
+
 def test_similar_arguments_subcommands_multiple() -> None:
     @dataclasses.dataclass
     class RewardConfig:

--- a/tests/test_py311_generated/test_errors_generated.py
+++ b/tests/test_py311_generated/test_errors_generated.py
@@ -292,6 +292,28 @@ def test_similar_arguments_subcommands() -> None:
     assert error.count("--help") == 3
 
 
+def test_different_metavar_subcommands() -> None:
+    @dataclasses.dataclass
+    class ClassA:
+        arg: Literal["a"]
+
+    @dataclasses.dataclass
+    class ClassB:
+        arg: Literal["b"]
+
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stderr(target):
+        tyro.cli(ClassA | ClassB, args="--ar".split(" "))  # type: ignore
+
+    error = target.getvalue()
+    assert "Unrecognized option" in error
+    assert "Perhaps you meant:" in error
+    assert error.count("--arg") == 2
+    assert error.count("--arg {a}") == 1
+    assert error.count("--arg {b}") == 1
+    assert error.count("--help") == 3
+
+
 def test_similar_arguments_subcommands_multiple() -> None:
     @dataclasses.dataclass
     class RewardConfig:


### PR DESCRIPTION
## Summary
- Include metavar in "Perhaps you meant" suggestions to differentiate between similarly named arguments that accept different values
- Refactor error handling to use a single `prev_arg_info` variable instead of separate variables
- Related to #273

## Test plan
- Added test case to verify that metavars are displayed in suggestions

🤖 Generated with [Claude Code](https://claude.ai/code)