### PR TITLE
Implement warning for duplicate subcommands

### DIFF
--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -494,6 +494,13 @@ class SubparsersSpecification:
                 ),
                 type(None) if option_unwrapped is none_proxy else cast(type, option),
             )
+            if subcommand_name in subcommand_type_from_name:
+                # Raise a warning that the subcommand already exists
+                warnings.warn(
+                    f"Subcommand '{subcommand_name}' already exists for type "
+                    f"{subcommand_type_from_name[subcommand_name].__name__} and will be replaced by "
+                    f"{option_unwrapped.__name__ if option_unwrapped is not none_proxy else 'None'}."
+                )
             if len(found_subcommand_configs) != 0:
                 # Explicitly annotated default.
                 assert len(found_subcommand_configs) == 1, (

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -496,10 +496,17 @@ class SubparsersSpecification:
             )
             if subcommand_name in subcommand_type_from_name:
                 # Raise a warning that the subcommand already exists
+                original_type = subcommand_type_from_name[subcommand_name]
+                new_type = type(None) if option_unwrapped is none_proxy else option_unwrapped
+                original_type_full_name = f"{original_type.__module__}.{original_type.__name__}"
+                new_type_full_name = f"{new_type.__module__}.{new_type.__name__}" if new_type is not None else "None"
+                
                 warnings.warn(
-                    f"Subcommand '{subcommand_name}' already exists for type "
-                    f"{subcommand_type_from_name[subcommand_name].__name__} and will be replaced by "
-                    f"{option_unwrapped.__name__ if option_unwrapped is not none_proxy else 'None'}."
+                    f"Duplicate subcommand name detected: '{subcommand_name}' is already used for "
+                    f"{original_type_full_name} but will be overwritten by {new_type_full_name}. "
+                    f"Only the last type ({new_type_full_name}) will be accessible via this subcommand. "
+                    f"Consider using distinct class names or use tyro.conf.subcommand() to specify "
+                    f"explicit subcommand names."
                 )
             if len(found_subcommand_configs) != 0:
                 # Explicitly annotated default.

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -497,10 +497,18 @@ class SubparsersSpecification:
             if subcommand_name in subcommand_type_from_name:
                 # Raise a warning that the subcommand already exists
                 original_type = subcommand_type_from_name[subcommand_name]
-                new_type = type(None) if option_unwrapped is none_proxy else option_unwrapped
-                original_type_full_name = f"{original_type.__module__}.{original_type.__name__}"
-                new_type_full_name = f"{new_type.__module__}.{new_type.__name__}" if new_type is not None else "None"
-                
+                new_type = (
+                    type(None) if option_unwrapped is none_proxy else option_unwrapped
+                )
+                original_type_full_name = (
+                    f"{original_type.__module__}.{original_type.__name__}"
+                )
+                new_type_full_name = (
+                    f"{new_type.__module__}.{new_type.__name__}"
+                    if new_type is not None
+                    else "None"
+                )
+
                 warnings.warn(
                     f"Duplicate subcommand name detected: '{subcommand_name}' is already used for "
                     f"{original_type_full_name} but will be overwritten by {new_type_full_name}. "

--- a/src/tyro/constructors/_struct_spec_ml_collections.py
+++ b/src/tyro/constructors/_struct_spec_ml_collections.py
@@ -4,11 +4,11 @@ import copy
 import sys
 from typing import Any
 
-import tyro
 from typing_extensions import Annotated
 
 from .._resolver import narrow_collection_types
 from .._singleton import EXCLUDE_FROM_CALL
+from ..conf import _confstruct
 from ._struct_spec import StructConstructorSpec, StructFieldSpec, StructTypeInfo
 
 _NotRootConfigDict = None  # type: ignore
@@ -81,7 +81,7 @@ def ml_collections_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
             val_type = narrow_collection_types(type(v), v)
             val_type = Annotated[
                 val_type,
-                tyro.conf.arg(
+                _confstruct.arg(
                     help=f"Reference default: {v}.",
                     help_behavior_hint="(assigns reference)",
                 ),

--- a/tests/test_duplicate_subcommand_warning.py
+++ b/tests/test_duplicate_subcommand_warning.py
@@ -33,6 +33,6 @@ def test_duplicate_subcommand_warning():
         try:
             # We need to catch SystemExit since tyro.cli() will exit
             # when called with --help or with no arguments for required options
-            tyro.cli(ConfigType, args=["nested"])
+            tyro.cli(ConfigType, args=["nested"])  # type: ignore
         except SystemExit:
             pass  # We're just testing for the warning, not the actual execution

--- a/tests/test_duplicate_subcommand_warning.py
+++ b/tests/test_duplicate_subcommand_warning.py
@@ -26,7 +26,7 @@ def test_duplicate_subcommand_warning():
     ConfigType = Union[Config.Nested, ConfigAgain.Nested]
     
     # This should raise a warning about duplicate subcommands
-    with pytest.warns(UserWarning, match=r"Subcommand 'nested' already exists for type Nested and will be replaced by Nested"):
+    with pytest.warns(UserWarning, match=r"Duplicate subcommand name detected:.*'nested'.*will be overwritten.*Consider using distinct class names"):
         try:
             # We need to catch SystemExit since tyro.cli() will exit
             # when called with --help or with no arguments for required options

--- a/tests/test_duplicate_subcommand_warning.py
+++ b/tests/test_duplicate_subcommand_warning.py
@@ -9,7 +9,7 @@ import tyro
 
 def test_duplicate_subcommand_warning():
     """Test that a warning is raised when a subcommand is duplicated.
-    
+
     Adapted from an example by @foges in https://github.com/brentyi/tyro/issues/273
     """
 
@@ -17,16 +17,19 @@ def test_duplicate_subcommand_warning():
     class Config:
         class Nested(BaseModel):
             name: Literal["foo"] = "foo"
-    
+
     class ConfigAgain:
         class Nested(BaseModel):
             value: Literal["bar"] = "bar"
 
     # This will create duplicate 'nested' subcommands
     ConfigType = Union[Config.Nested, ConfigAgain.Nested]
-    
+
     # This should raise a warning about duplicate subcommands
-    with pytest.warns(UserWarning, match=r"Duplicate subcommand name detected:.*'nested'.*will be overwritten.*Consider using distinct class names"):
+    with pytest.warns(
+        UserWarning,
+        match=r"Duplicate subcommand name detected:.*'nested'.*will be overwritten.*Consider using distinct class names",
+    ):
         try:
             # We need to catch SystemExit since tyro.cli() will exit
             # when called with --help or with no arguments for required options

--- a/tests/test_duplicate_subcommand_warning.py
+++ b/tests/test_duplicate_subcommand_warning.py
@@ -1,0 +1,29 @@
+import dataclasses
+from typing import Union
+
+import pytest
+from pydantic import BaseModel
+from typing_extensions import Literal
+
+import tyro
+
+
+def test_duplicate_subcommand_warning():
+    """Test that a warning is raised when a subcommand is duplicated.
+    
+    Adapted from an example by @foges in https://github.com/brentyi/tyro/issues/273
+    """
+
+    class foo:
+        class Config(BaseModel):
+            name: Literal["foo"] = "foo"
+
+    class bar:
+        class Config(BaseModel):
+            name: Literal["bar"] = "bar"
+
+    ConfigType = Union[foo.Config, bar.Config]  # Python 3.7 compatible syntax
+
+    # This should raise a warning about duplicate subcommands
+    with pytest.warns(UserWarning, match=r".*subcommand.*already exists.*"):
+        tyro.cli(ConfigType, args=["--help"])

--- a/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
+++ b/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
@@ -32,6 +32,6 @@ def test_duplicate_subcommand_warning():
         try:
             # We need to catch SystemExit since tyro.cli() will exit
             # when called with --help or with no arguments for required options
-            tyro.cli(ConfigType, args=["nested"])
+            tyro.cli(ConfigType, args=["nested"])  # type: ignore
         except SystemExit:
             pass  # We're just testing for the warning, not the actual execution

--- a/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
+++ b/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
@@ -1,4 +1,3 @@
-
 from typing import Literal
 
 import pytest
@@ -28,7 +27,7 @@ def test_duplicate_subcommand_warning():
     # This should raise a warning about duplicate subcommands
     with pytest.warns(
         UserWarning,
-        match=r"Subcommand 'nested' already exists for type Nested and will be replaced by Nested",
+        match=r"Duplicate subcommand name detected:.*'nested'.*will be overwritten.*Consider using distinct class names",
     ):
         try:
             # We need to catch SystemExit since tyro.cli() will exit

--- a/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
+++ b/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
@@ -1,15 +1,15 @@
-from typing import Union
+
+from typing import Literal
 
 import pytest
 from pydantic import BaseModel
-from typing_extensions import Literal
 
 import tyro
 
 
 def test_duplicate_subcommand_warning():
     """Test that a warning is raised when a subcommand is duplicated.
-    
+
     Adapted from an example by @foges in https://github.com/brentyi/tyro/issues/273
     """
 
@@ -17,16 +17,19 @@ def test_duplicate_subcommand_warning():
     class Config:
         class Nested(BaseModel):
             name: Literal["foo"] = "foo"
-    
+
     class ConfigAgain:
         class Nested(BaseModel):
             value: Literal["bar"] = "bar"
 
     # This will create duplicate 'nested' subcommands
-    ConfigType = Union[Config.Nested, ConfigAgain.Nested]
-    
+    ConfigType = Config.Nested | ConfigAgain.Nested
+
     # This should raise a warning about duplicate subcommands
-    with pytest.warns(UserWarning, match=r"Subcommand 'nested' already exists for type Nested and will be replaced by Nested"):
+    with pytest.warns(
+        UserWarning,
+        match=r"Subcommand 'nested' already exists for type Nested and will be replaced by Nested",
+    ):
         try:
             # We need to catch SystemExit since tyro.cli() will exit
             # when called with --help or with no arguments for required options


### PR DESCRIPTION
## Summary
- Added a warning when a subcommand with the same name already exists
- This is related to confusing behavior in #273
- Added tests to verify the warning is raised correctly

## Test plan
- Added a test case that triggers the duplicate subcommand warning
- Generated corresponding Python 3.11 test variant
- Verified that the warning is displayed when running the `union_warning.py` example directly

🤖 Generated with [Claude Code](https://claude.ai/code)