### PR TITLE
Treat unannotated arguments as `Any`

### DIFF
--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -474,7 +474,7 @@ def _rule_generate_helptext(
         elif lowered.instance_from_str is None:
             # Intentionally not quoted via shlex, since this can't actually be passed
             # in via the commandline.
-            behavior_hint = f"(fixed to: {default_label})"
+            behavior_hint = f"(fixed to: {str(default)})"
         elif lowered.action == "count":
             # Repeatable argument.
             behavior_hint = "(repeatable)"

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -287,10 +287,6 @@ def _field_list_from_function(
     # Check for abstract classes.
     if inspect.isabstract(f):
         return UnsupportedStructTypeMessage("Abstract classes cannot be instantiated!")
-    if f.__name__ == "<lambda>":
-        return UnsupportedStructTypeMessage(
-            "Lambda functions cannot be type-annotated!"
-        )
 
     # If `f` is class, we want to inspect its __init__ method for the
     # signature. But the docstrings may still be in the class signature itself.
@@ -357,6 +353,12 @@ def _field_list_from_function(
                 )
 
             hints = get_hints_for_signature_func(orig_cls)
+
+    # Early return for lambda functions.
+    if f.__name__ == "<lambda>" and len(params) > 0:
+        return UnsupportedStructTypeMessage(
+            "Lambda functions cannot be type-annotated!"
+        )
 
     # Get type annotations, docstrings.
     docstring = inspect.getdoc(f)

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -17,7 +17,6 @@ from . import _docstrings, _resolver, _strings, _unsafe_cache
 from ._singleton import MISSING_AND_MISSING_NONPROP, MISSING_NONPROP
 from ._typing import TypeForm
 from .conf import _confstruct, _markers
-from .constructors._primitive_spec import UnsupportedTypeAnnotationError
 from .constructors._registry import ConstructorRegistry, check_default_instances
 from .constructors._struct_spec import (
     StructFieldSpec,
@@ -371,6 +370,22 @@ def _field_list_from_function(
         except TypeError:
             return UnsupportedStructTypeMessage(f"Could not get hints for {f}!")
 
+    # Expect non-empty type hints from classes.
+    #
+    # Generally we can be more forgiving with functions, for example
+    #
+    #     def main(x = 3) -> None: ...
+    #
+    # we can parse as if `x` was annotated with int. But if we have:
+    #
+    #     def main(x: SomeScaryType = SomeScaryDefault) -> None: ...
+    #
+    # we'll be more conservative in converting `--x` to a {fixed} argument.
+    # The latter case requires returning an UnsupportedStructTypeMessage to avoid
+    # unpacking the arguments of SomeScaryType.
+    if (len(hints) == 0 or len(params) == 0) and inspect.isclass(f_before_init_unwrap):
+        return UnsupportedStructTypeMessage(f"Empty hints for {f}!")
+
     field_list = []
     for param in params:
         # Get default value.
@@ -378,28 +393,14 @@ def _field_list_from_function(
 
         # Get helptext from docstring.
         helptext = docstring_from_arg_name.get(param.name)
-
-        # TODO: re-add.
         if helptext is None and inspect.isclass(f_before_init_unwrap):
             helptext = _docstrings.get_field_docstring(
                 f_before_init_unwrap, param.name, markers
             )
 
-        if param.name not in hints:
-            out = UnsupportedStructTypeMessage(
-                f"Expected fully type-annotated callable, but {f} with arguments"
-                f" {tuple(map(lambda p: p.name, params))} has no annotation for"
-                f" '{param.name}'."
-            )
-            if param.kind is param.KEYWORD_ONLY:
-                # If keyword only: this can't possibly be an instantiator function
-                # either, so we escalate to an error.
-                raise UnsupportedTypeAnnotationError(out.message)
-            return out
-
         # Set markers for positional + variadic arguments.
         func_markers: Tuple[Any, ...] = ()
-        typ: Any = hints[param.name]
+        typ: Any = hints.get(param.name, Any)
         if param.kind is inspect.Parameter.POSITIONAL_ONLY:
             func_markers = (_markers.Positional, _markers._PositionalCall)
         elif param.kind is inspect.Parameter.VAR_POSITIONAL:

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -287,6 +287,10 @@ def _field_list_from_function(
     # Check for abstract classes.
     if inspect.isabstract(f):
         return UnsupportedStructTypeMessage("Abstract classes cannot be instantiated!")
+    if f.__name__ == "<lambda>":
+        return UnsupportedStructTypeMessage(
+            "Lambda functions cannot be type-annotated!"
+        )
 
     # If `f` is class, we want to inspect its __init__ method for the
     # signature. But the docstrings may still be in the class signature itself.

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -355,7 +355,7 @@ def _field_list_from_function(
             hints = get_hints_for_signature_func(orig_cls)
 
     # Early return for lambda functions.
-    if f.__name__ == "<lambda>" and len(params) > 0:
+    if getattr(f, "__name__", None) == "<lambda>" and len(params) > 0:
         return UnsupportedStructTypeMessage(
             "Lambda functions cannot be type-annotated!"
         )

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -1050,3 +1050,18 @@ def test_diamond_inheritance() -> None:
     # The type, however, currently comes from C. This matches the MRO and the
     # behavior of pyright and mypy but not of dataclasses.fields().
     assert "INT|STR" not in helptext
+
+
+def test_partial_annotation() -> None:
+    class A:
+        def __init__(self, b=[], c: float = 1):
+            super(A, self).__init__()
+            del b
+            del c
+
+    def main(opt: A = A()):
+        del opt
+
+    assert "--opt.b" in get_helptext_with_checks(main)
+    assert "{fixed}" in get_helptext_with_checks(main)
+    assert "--opt.c" in get_helptext_with_checks(main)

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -1047,3 +1047,18 @@ def test_diamond_inheritance() -> None:
     # The type, however, currently comes from C. This matches the MRO and the
     # behavior of pyright and mypy but not of dataclasses.fields().
     assert "INT|STR" not in helptext
+
+
+def test_partial_annotation() -> None:
+    class A:
+        def __init__(self, b=[], c: float = 1):
+            super(A, self).__init__()
+            del b
+            del c
+
+    def main(opt: A = A()):
+        del opt
+
+    assert "--opt.b" in get_helptext_with_checks(main)
+    assert "{fixed}" in get_helptext_with_checks(main)
+    assert "--opt.c" in get_helptext_with_checks(main)

--- a/tests/test_py311_generated/test_torch_exclude_py313_generated.py
+++ b/tests/test_py311_generated/test_torch_exclude_py313_generated.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, Callable, Tuple
 
 import torch
@@ -27,6 +28,7 @@ def test_torch_device_2() -> None:
 
 
 def test_unparsable() -> None:
+    @dataclass
     class Struct:
         a: int = 5
         b: str = "7"

--- a/tests/test_torch_exclude_py313.py
+++ b/tests/test_torch_exclude_py313.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, Callable, Tuple
 
 import torch
@@ -27,6 +28,7 @@ def test_torch_device_2() -> None:
 
 
 def test_unparsable() -> None:
+    @dataclass
     class Struct:
         a: int = 5
         b: str = "7"


### PR DESCRIPTION
Adjusts behavior for unannotated arguments. For example, this is now supported:


```python
import tyro

def main(x=3, y="hello", z=(1, 2, 3)):
    print(x, y, z)

tyro.cli(main)
```

It becomes:
```
usage: pr285.py [-h] [--x INT] [--y STR] [--z [INT [INT ...]]]

╭─ options ───────────────────────────────────────────────╮
│ -h, --help              show this help message and exit │
│ --x INT                 (default: 3)                    │
│ --y STR                 (default: hello)                │
│ --z [INT [INT ...]]     (default: 1 2 3)                │
╰─────────────────────────────────────────────────────────╯
```


Also fixes #282