### PR TITLE
Development: Push neural net packages and NumPy into a separate optional dependency group to reduce wait on cold setup.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install uv
-          uv pip install --system -e ".[dev]"
+          uv pip install --system -e ".[dev-nn]"
       - name: Generate coverage report
         run: |
           pytest --cov=tyro --cov-report=xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Building documentation
         run: |
           pip install uv
-          uv pip install --system -e ".[dev]"
+          uv pip install --system -e ".[dev-nn]"
           uv pip install --system -r docs/requirements.txt
           sphinx-build docs/source docs/build -b dirhtml
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install uv
-          uv pip install --system -e ".[dev]"
+          uv pip install --system -e ".[dev-nn]"
       - name: Test with mypy
         run: |
           mypy --install-types --non-interactive .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install uv
-          uv pip install --system -e ".[dev]"
+          uv pip install --system -e ".[dev-nn]"
           uv pip install --system build twine
       - name: Strip unsupported tags in README
         run: |

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install uv
-          uv pip install --system -e ".[dev]"
+          uv pip install --system -e ".[dev-nn]"
       - name: Run pyright
         run: |
           pyright .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install uv
-          uv pip install --system ".[dev]"
+          uv pip install --system ".[dev-nn]"
       - name: Test with pytest
         run: |
           pytest

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install uv
-          uv pip install --system -e ".[dev]"
+          uv pip install --system -e ".[dev-nn]"
       - name: Ruff check
         run: |
           ruff check --output-format github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Tyro Development Guide
 
 ## Build & Test Commands
-- Install dev dependencies: `pip install -e ".[dev]"`
+- Install dev dependencies: `pip install -e ".[dev-nn]"`
 - Run all tests: `pytest -n auto` (parallel execution)
 - Run all tests: `pytest` (sequential execution)
 - Run specific test: `pytest tests/test_file.py -v` or `pytest tests/test_file.py::test_name -v`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,16 +47,19 @@ dev = [
     "pytest-xdist>=3.5.0",
     "omegaconf>=2.2.2",
     "attrs>=21.4.0",
-    "torch>=1.10.0;python_version<='3.12'",
     "pyright>=1.1.349,!=1.1.379",
     "ruff>=0.1.13",
     "mypy>=1.4.1",
-    "numpy>=1.20.0",
-    "flax>=0.6.9;python_version<='3.12'",
     "pydantic>=2.5.2,!=2.10.0",
     "coverage[toml]>=6.5.0",
     "eval_type_backport>=0.1.3",
     "ml_collections>=0.1.0",
+]
+dev-nn = [
+    "tyro[dev]",
+    "flax>=0.6.9;python_version<='3.12'",
+    "numpy>=1.20.0",
+    "torch>=1.10.0;python_version<='3.12'",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,19 @@ if not sys.version_info >= (3, 11):
 
 if sys.version_info >= (3, 13):
     collect_ignore_glob.append("*_exclude_py313*.py")
+
+try:
+    import flax  # noqa: I001,F401 # type: ignore
+except ImportError:
+    collect_ignore_glob.append("*_flax*.py")
+
+try:
+    import numpy  # noqa: I001,F401 # type: ignore
+except ImportError:
+    collect_ignore_glob.append("*_custom_constructors*.py")
+
+try:
+    import torch  # noqa: I001,F401 # type: ignore
+except ImportError:
+    collect_ignore_glob.append("*_torch*.py")
+    collect_ignore_glob.append("*_base_configs_nested*.py")

--- a/tests/test_new_style_annotations_min_py39.py
+++ b/tests/test_new_style_annotations_min_py39.py
@@ -109,7 +109,6 @@ try:
         assert tyro.cli(main, args=[]) == LinearLRConfig()
         assert "_target" not in get_helptext_with_checks(LinearLRConfig)
 except ImportError:
-    # We can't install PyTorch in Python 3.13.
-    import sys
-
-    assert sys.version_info >= (3, 13)
+    # PyTorch may be unavailable due to Python version
+    # or optional dependencies.
+    pass

--- a/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py39_generated.py
@@ -109,7 +109,6 @@ try:
         assert tyro.cli(main, args=[]) == LinearLRConfig()
         assert "_target" not in get_helptext_with_checks(LinearLRConfig)
 except ImportError:
-    # We can't install PyTorch in Python 3.13.
-    import sys
-
-    assert sys.version_info >= (3, 13)
+    # PyTorch may be unavailable due to Python version
+    # or optional dependencies.
+    pass


### PR DESCRIPTION
Closes #278 .

Passes Ruff checks in all environments.
Passes Pyright analysis in `dev-nn` environments < Python 3.13.
Test suite passes in all environments.

Sizes:
```text
$ du -hs venv-3.10/lib/python3.10/site-packages
139M    venv-3.10/lib/python3.10/site-packages
$ du -hs venv-3.13/lib/python3.13/site-packages
137M    venv-3.13/lib/python3.13/site-packages
$ du -hs venv-nn-3.10/lib/python3.10/site-packages
6.0G    venv-nn-3.10/lib/python3.10/site-packages
$ du -hs venv-nn-3.13/lib/python3.13/site-packages
204M    venv-nn-3.13/lib/python3.13/site-packages
```

A bit messier than I had hoped. Imports being used in module-level class definitions prevented use of `pytest.mark.skipif` as I had hoped. And using it where it could be used (in conjunction with `try .. except ImportError`) made Pyright upset since static analysis obviously could not understand the semantics of `skipif`.

Wasn't feeling motivated to work on any of my projects this evening, which is why I did this, even though the effort-reward ratio is rather questionable. Obviously not a high priority for review.