### PR TITLE
Add registry parameter to tyro.cli()

### DIFF
--- a/docs/source/examples/custom_constructors.rst
+++ b/docs/source/examples/custom_constructors.rst
@@ -240,9 +240,8 @@ define a rule that applies to all types that match ``dict[str, Any]``.
         print(f"{dict2=}")
 
     if __name__ == "__main__":
-        # To activate a custom registry, we should use it as a context manager.
-        with custom_registry:
-            tyro.cli(main)
+        # Pass the registry directly to tyro.cli().
+        tyro.cli(main, registry=custom_registry)
 
 
 
@@ -363,9 +362,8 @@ structs.
         print(f"{bounds_with_default=}")
 
     if __name__ == "__main__":
-        # To activate a custom registry, we should use it as a context manager.
-        with custom_registry:
-            tyro.cli(main)
+        # Pass the registry directly to tyro.cli().
+        tyro.cli(main, registry=custom_registry)
 
 
 

--- a/examples/06_custom_constructors/03_primitive_registry.py
+++ b/examples/06_custom_constructors/03_primitive_registry.py
@@ -48,6 +48,5 @@ def main(
 
 
 if __name__ == "__main__":
-    # To activate a custom registry, we should use it as a context manager.
-    with custom_registry:
-        tyro.cli(main)
+    # Pass the registry directly to tyro.cli()
+    tyro.cli(main, registry=custom_registry)

--- a/examples/06_custom_constructors/03_primitive_registry.py
+++ b/examples/06_custom_constructors/03_primitive_registry.py
@@ -48,5 +48,5 @@ def main(
 
 
 if __name__ == "__main__":
-    # Pass the registry directly to tyro.cli()
+    # Pass the registry directly to tyro.cli().
     tyro.cli(main, registry=custom_registry)

--- a/examples/06_custom_constructors/04_struct_registry.py
+++ b/examples/06_custom_constructors/04_struct_registry.py
@@ -82,6 +82,5 @@ def main(
 
 
 if __name__ == "__main__":
-    # To activate a custom registry, we should use it as a context manager.
-    with custom_registry:
-        tyro.cli(main)
+    # Pass the registry directly to tyro.cli()
+    tyro.cli(main, registry=custom_registry)

--- a/examples/06_custom_constructors/04_struct_registry.py
+++ b/examples/06_custom_constructors/04_struct_registry.py
@@ -82,5 +82,5 @@ def main(
 
 
 if __name__ == "__main__":
-    # Pass the registry directly to tyro.cli()
+    # Pass the registry directly to tyro.cli().
     tyro.cli(main, registry=custom_registry)

--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -435,7 +435,6 @@ def _cli_impl(
         _arguments.USE_RICH = True
 
     # Map a callable to the relevant CLI arguments + subparsers.
-    # Use the context manager approach for registry if provided
     if registry is not None:
         with registry:
             parser_spec = _parsers.ParserSpecification.from_callable_or_type(

--- a/src/tyro/constructors/_registry.py
+++ b/src/tyro/constructors/_registry.py
@@ -88,7 +88,15 @@ class ConstructorRegistry:
     command-line arguments.
 
 
-    To activate a registry, use it as a context manager. For example:
+    To activate a registry, pass it directly to :func:`tyro.cli`:
+
+    .. code-block: python
+
+        registry = ConstructorRegistry()
+        tyro.cli(..., registry=registry)
+
+    For backward compatibility, you can also use the context manager pattern, though
+    the direct parameter approach is recommended:
 
     .. code-block: python
 


### PR DESCRIPTION
## Summary
- Add `registry` parameter to `tyro.cli()` and `get_parser()` functions to provide a cleaner, more explicit way to specify constructor registries
- Keep backward compatibility with the context manager pattern while promoting the new approach
- Update examples and documentation to demonstrate the new usage pattern

## Test plan
- Verified by running the examples locally
- Both patterns (direct argument and context manager) work properly

🤖 Generated with [Claude Code](https://claude.ai/code)