### PR TITLE
Integration for `msgspec`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ __pycache__
 .coverage
 build/
 dist/
+
+**/.claude/settings.local.json

--- a/docs/source/examples/hierarchical_structures.rst
+++ b/docs/source/examples/hierarchical_structures.rst
@@ -794,3 +794,69 @@ ML Collections + Field References
                  'value_obs_key': 'state'},
      'wandb': {'mode': 'online', 'project': 'robot-sandbox'}}
     </pre>
+.. _example-10_msgspec:
+
+Msgspec Integration
+-------------------
+
+In addition to standard dataclasses, :func:`tyro.cli()` also supports
+`msgspec <https://jcristharif.com/msgspec/>`_ structs.
+
+
+.. code-block:: python
+    :linenos:
+
+    # 10_msgspec.py
+    import msgspec
+
+    import tyro
+
+    class Args(msgspec.Struct):
+        """Description.
+        This should show up in the helptext!"""
+
+        field1: str
+        """A string field."""
+
+        field2: int = 5
+        """A required integer field."""
+
+    if __name__ == "__main__":
+        args = tyro.cli(Args)
+        print(args)
+
+
+
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./10_msgspec.py --help</strong>
+    <span style="font-weight: bold">usage</span>: 10_msgspec.py [-h] --field1 <span style="font-weight: bold">STR</span> [--field2 <span style="font-weight: bold">INT</span>]
+    
+    Description. This should show up in the helptext!
+    
+    <span style="font-weight: lighter">╭─</span><span style="font-weight: lighter"> options </span><span style="font-weight: lighter">─────────────────────────────────────────────────</span><span style="font-weight: lighter">─╮</span>
+    <span style="font-weight: lighter">│</span> -h, --help          <span style="font-weight: lighter">show this help message and exit</span>        <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> --field1 <span style="font-weight: bold">STR</span>        <span style="font-weight: lighter">A string field.</span> <span style="font-weight: bold; color: #e60000">(required)</span>             <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> --field2 <span style="font-weight: bold">INT</span>        <span style="font-weight: lighter">A required integer field.</span> <span style="color: #008080">(default: 5)</span> <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">╰────────────────────────────────────────────────────────────╯</span>
+    </pre>
+
+
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./10_msgspec.py --field1 hello</strong>
+    Args(field1='hello', field2=5)
+    </pre>
+
+
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./10_msgspec.py --field1 hello --field2 5</strong>
+    Args(field1='hello', field2=5)
+    </pre>

--- a/docs/source/whats_supported.rst
+++ b/docs/source/whats_supported.rst
@@ -19,7 +19,7 @@ Inputs can be annotated with:
 Types can also be placed and nested in various structures, such as:
 
 - :func:`dataclasses.dataclass`.
-- ``attrs``, ``pydantic``, and ``flax.linen`` models.
+- ``attrs``, ``pydantic``, ``ml_collections``, ``msgspec``, and ``flax.linen`` models.
 - :py:class:`typing.NamedTuple`.
 - :py:class:`typing.TypedDict`, including with flags like ``total=`` and associated annotations like :py:data:`typing.Required`, :py:data:`typing.NotRequired`, and :py:data:`typing.ReadOnly`.
 

--- a/examples/02_hierarchical_structures/10_msgspec.py
+++ b/examples/02_hierarchical_structures/10_msgspec.py
@@ -1,0 +1,31 @@
+"""Msgspec Integration
+
+In addition to standard dataclasses, :func:`tyro.cli()` also supports
+`msgspec <https://jcristharif.com/msgspec/>`_ structs.
+
+Usage:
+
+    python ./10_msgspec.py --help
+    python ./10_msgspec.py --field1 hello
+    python ./10_msgspec.py --field1 hello --field2 5
+"""
+
+import msgspec
+
+import tyro
+
+
+class Args(msgspec.Struct):
+    """Description.
+    This should show up in the helptext!"""
+
+    field1: str
+    """A string field."""
+
+    field2: int = 5
+    """A required integer field."""
+
+
+if __name__ == "__main__":
+    args = tyro.cli(Args)
+    print(args) 

--- a/examples/02_hierarchical_structures/10_msgspec.py
+++ b/examples/02_hierarchical_structures/10_msgspec.py
@@ -28,4 +28,4 @@ class Args(msgspec.Struct):
 
 if __name__ == "__main__":
     args = tyro.cli(Args)
-    print(args) 
+    print(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "coverage[toml]>=6.5.0",
     "eval_type_backport>=0.1.3",
     "ml_collections>=0.1.0",
+    "msgspec>=0.18.6",
 ]
 dev-nn = [
     "tyro[dev]",

--- a/src/tyro/constructors/_struct_spec.py
+++ b/src/tyro/constructors/_struct_spec.py
@@ -160,13 +160,15 @@ def apply_default_struct_rules(registry: ConstructorRegistry) -> None:
     from ._struct_spec_attrs import attrs_rule
     from ._struct_spec_dataclass import dataclass_rule
     from ._struct_spec_ml_collections import ml_collections_rule
+    from ._struct_spec_msgspec import msgspec_rule
     from ._struct_spec_pydantic import pydantic_rule
 
     # Register imported rules.
     registry.struct_rule(attrs_rule)
     registry.struct_rule(dataclass_rule)
-    registry.struct_rule(pydantic_rule)
     registry.struct_rule(ml_collections_rule)
+    registry.struct_rule(msgspec_rule)
+    registry.struct_rule(pydantic_rule)
 
     @registry.struct_rule
     def typeddict_rule(info: StructTypeInfo) -> StructConstructorSpec | None:

--- a/src/tyro/constructors/_struct_spec_msgspec.py
+++ b/src/tyro/constructors/_struct_spec_msgspec.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+
+from typing_extensions import get_type_hints
+
+from .._docstrings import get_field_docstring
+from .._singleton import MISSING, MISSING_NONPROP
+from ._struct_spec import StructConstructorSpec, StructFieldSpec, StructTypeInfo
+
+
+def msgspec_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
+    if "msgspec" not in sys.modules.keys():  # pragma: no cover
+        return None
+
+    import msgspec
+
+    try:
+        if not issubclass(info.type, msgspec.Struct):
+            return None
+    except TypeError:  # issubclass failed
+        return None
+
+    # Handle msgspec struct objects.
+    field_list = []
+    struct_type = msgspec.inspect.type_info(info.type)
+    assert isinstance(struct_type, msgspec.inspect.StructType)
+
+    # We need to use the original type hints, because `field.type` returns
+    # a msgspec-specified type descriptor.
+    annotations = get_type_hints(info.type, include_extras=True)
+
+    for field in struct_type.fields:
+        if info.default not in (
+            MISSING,
+            MISSING_NONPROP,
+        ):
+            default = getattr(info.default, field.name)
+        elif field.default is not msgspec.NODEFAULT:
+            default = field.default
+        elif field.default_factory is not msgspec.NODEFAULT:
+            default = field.default_factory()
+        else:
+            default = MISSING_NONPROP
+
+        field_list.append(
+            StructFieldSpec(
+                name=field.name,
+                type=annotations[field.name],
+                default=default,
+                helptext=get_field_docstring(info.type, field.name, info.markers),
+            )
+        )
+
+    return StructConstructorSpec(instantiate=info.type, fields=tuple(field_list))

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1,8 +1,9 @@
+import enum
+from datetime import date, datetime, time
+from typing import List, Optional, Set
+
 import msgspec
 import pytest
-from typing import Optional, List, Set
-from datetime import datetime, date, time
-import enum
 
 import tyro
 
@@ -14,7 +15,9 @@ def test_basic_msgspec_struct():
         email: Optional[str] = None
 
     # Test with all fields
-    result = tyro.cli(User, args=["--name", "Alice", "--age", "30", "--email", "alice@example.com"])
+    result = tyro.cli(
+        User, args=["--name", "Alice", "--age", "30", "--email", "alice@example.com"]
+    )
     assert result.name == "Alice"
     assert result.age == 30
     assert result.email == "alice@example.com"
@@ -44,10 +47,7 @@ def test_msgspec_struct_with_collections():
 
 def test_msgspec_struct_with_default_factory():
     class Settings(msgspec.Struct):
-        def default_list() -> List[str]:
-            return ["default"]
-
-        values: List[str] = msgspec.field(default_factory=default_list)
+        values: List[str] = msgspec.field(default_factory=lambda: ["default"])
 
     # Test with default factory
     result = tyro.cli(Settings, args=[])
@@ -221,4 +221,6 @@ def test_msgspec_struct_with_enums():
 
     # Test invalid enum value
     with pytest.raises(SystemExit):
-        tyro.cli(Task, args=["--name", "Task", "--color", "YELLOW", "--priority", "HIGH"])
+        tyro.cli(
+            Task, args=["--name", "Task", "--color", "YELLOW", "--priority", "HIGH"]
+        )

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1,0 +1,224 @@
+import msgspec
+import pytest
+from typing import Optional, List, Set
+from datetime import datetime, date, time
+import enum
+
+import tyro
+
+
+def test_basic_msgspec_struct():
+    class User(msgspec.Struct):
+        name: str
+        age: int = 25
+        email: Optional[str] = None
+
+    # Test with all fields
+    result = tyro.cli(User, args=["--name", "Alice", "--age", "30", "--email", "alice@example.com"])
+    assert result.name == "Alice"
+    assert result.age == 30
+    assert result.email == "alice@example.com"
+
+    # Test with defaults
+    result = tyro.cli(User, args=["--name", "Bob"])
+    assert result.name == "Bob"
+    assert result.age == 25  # default value
+    assert result.email is None  # default value
+
+
+def test_msgspec_struct_with_collections():
+    class Config(msgspec.Struct):
+        tags: List[str] = []
+        flags: Set[int] = set()
+
+    # Test with empty collections
+    result = tyro.cli(Config, args=[])
+    assert result.tags == []
+    assert result.flags == set()
+
+    # Test with populated collections
+    result = tyro.cli(Config, args=["--tags", "tag1", "tag2", "--flags", "1", "2", "3"])
+    assert result.tags == ["tag1", "tag2"]
+    assert result.flags == {1, 2, 3}
+
+
+def test_msgspec_struct_with_default_factory():
+    class Settings(msgspec.Struct):
+        def default_list() -> List[str]:
+            return ["default"]
+
+        values: List[str] = msgspec.field(default_factory=default_list)
+
+    # Test with default factory
+    result = tyro.cli(Settings, args=[])
+    assert result.values == ["default"]
+
+    # Test with custom values
+    result = tyro.cli(Settings, args=["--values", "custom1", "custom2"])
+    assert result.values == ["custom1", "custom2"]
+
+
+def test_msgspec_struct_validation():
+    class Point(msgspec.Struct):
+        x: int
+        y: int
+
+    # Test valid input
+    result = tyro.cli(Point, args=["--x", "10", "--y", "20"])
+    assert result.x == 10
+    assert result.y == 20
+
+    # Test invalid input (missing required field)
+    with pytest.raises(SystemExit):
+        tyro.cli(Point, args=["--x", "10"])
+
+    # Test invalid input (wrong type)
+    with pytest.raises(SystemExit):
+        tyro.cli(Point, args=["--x", "10.5", "--y", "20"])
+
+
+def test_nested_msgspec_struct():
+    class Address(msgspec.Struct):
+        street: str
+        city: str
+        zip_code: str
+
+    class Person(msgspec.Struct):
+        name: str
+        address: Address
+
+    # Test nested struct
+    result = tyro.cli(
+        Person,
+        args=[
+            "--name",
+            "John",
+            "--address.street",
+            "123 Main St",
+            "--address.city",
+            "Boston",
+            "--address.zip_code",
+            "02108",
+        ],
+    )
+    assert result.name == "John"
+    assert result.address.street == "123 Main St"
+    assert result.address.city == "Boston"
+    assert result.address.zip_code == "02108"
+
+
+def test_msgspec_struct_inheritance():
+    class Animal(msgspec.Struct):
+        name: str
+        age: int = 0
+        species: str = "unknown"
+
+    class Dog(Animal):
+        breed: str = "mixed"
+        is_good_boy: bool = True
+
+    class WorkingDog(Dog):
+        job: str = "guard"
+        hours_per_day: int = 8
+
+    # Test base class
+    result = tyro.cli(Animal, args=["--name", "Generic"])
+    assert result.name == "Generic"
+    assert result.age == 0
+    assert result.species == "unknown"
+
+    # Test single inheritance
+    result = tyro.cli(Dog, args=["--name", "Rex", "--breed", "German Shepherd"])
+    assert result.name == "Rex"
+    assert result.age == 0  # inherited default
+    assert result.species == "unknown"  # inherited default
+    assert result.breed == "German Shepherd"
+    assert result.is_good_boy is True  # inherited default
+
+    # Test multiple inheritance
+    result = tyro.cli(
+        WorkingDog,
+        args=[
+            "--name",
+            "Max",
+            "--breed",
+            "Belgian Malinois",
+            "--job",
+            "police",
+            "--hours_per_day",
+            "10",
+        ],
+    )
+    assert result.name == "Max"
+    assert result.age == 0  # inherited from Animal
+    assert result.species == "unknown"  # inherited from Animal
+    assert result.breed == "Belgian Malinois"  # inherited from Dog
+    assert result.is_good_boy is True  # inherited from Dog
+    assert result.job == "police"
+    assert result.hours_per_day == 10
+
+
+def test_msgspec_struct_with_datetime_types():
+    class Event(msgspec.Struct):
+        name: str
+        start_time: datetime
+        event_date: date
+        check_in: time
+
+    # Test with all datetime types
+    result = tyro.cli(
+        Event,
+        args=[
+            "--name",
+            "Conference",
+            "--start-time",
+            "2024-03-20T09:00:00",
+            "--event-date",
+            "2024-03-20",
+            "--check-in",
+            "08:30:00",
+        ],
+    )
+    assert result.name == "Conference"
+    assert result.start_time == datetime(2024, 3, 20, 9, 0)
+    assert result.event_date == date(2024, 3, 20)
+    assert result.check_in == time(8, 30)
+
+
+def test_msgspec_struct_with_enums():
+    class Color(enum.Enum):
+        RED = enum.auto()
+        GREEN = enum.auto()
+        BLUE = enum.auto()
+
+    class Priority(enum.IntEnum):
+        LOW = enum.auto()
+        MEDIUM = enum.auto()
+        HIGH = enum.auto()
+
+    class Task(msgspec.Struct):
+        name: str
+        color: Color
+        priority: Priority
+        status: str = "pending"
+
+    # Test with enum types
+    result = tyro.cli(
+        Task,
+        args=[
+            "--name",
+            "Important Task",
+            "--color",
+            "RED",
+            "--priority",
+            "HIGH",
+        ],
+    )
+    assert result.name == "Important Task"
+    assert result.color == Color.RED
+    assert result.priority == Priority.HIGH
+    assert result.status == "pending"
+
+    # Test invalid enum value
+    with pytest.raises(SystemExit):
+        tyro.cli(Task, args=["--name", "Task", "--color", "YELLOW", "--priority", "HIGH"])

--- a/tests/test_msgspec.py
+++ b/tests/test_msgspec.py
@@ -1,11 +1,16 @@
 import enum
+import pathlib
 from datetime import date, datetime, time
-from typing import List, Optional, Set
+from typing import Generic, List, Optional, Set, Tuple, TypeVar, Union
 
 import msgspec
 import pytest
+from helptext_utils import get_helptext_with_checks
+from typing_extensions import Annotated
 
 import tyro
+import tyro._strings
+from tyro.conf import Positional, Suppress, arg
 
 
 def test_basic_msgspec_struct():
@@ -224,3 +229,272 @@ def test_msgspec_struct_with_enums():
         tyro.cli(
             Task, args=["--name", "Task", "--color", "YELLOW", "--priority", "HIGH"]
         )
+
+
+def test_msgspec_with_post_init_validation():
+    class Interval(msgspec.Struct):
+        start: int
+        end: int
+
+        def __post_init__(self):
+            if self.start > self.end:
+                raise ValueError("start must be less than or equal to end")
+
+    # Test with valid values
+    result = tyro.cli(Interval, args=["--start", "10", "--end", "20"])
+    assert result.start == 10
+    assert result.end == 20
+
+    # Test with invalid values
+    with pytest.raises(ValueError, match="start must be less than or equal to end"):
+        tyro.cli(Interval, args=["--start", "30", "--end", "20"])
+
+
+def test_msgspec_with_meta_validation():
+    class Constraints(msgspec.Struct):
+        name: Annotated[str, msgspec.Meta(min_length=3, max_length=50)]
+        age: Annotated[int, msgspec.Meta(gt=0, lt=120)]
+        score: Annotated[float, msgspec.Meta(ge=0.0, le=100.0)] = 0.0
+        tags: Annotated[List[str], msgspec.Meta(min_length=1)] = msgspec.field(
+            default_factory=lambda: ["default"]
+        )
+
+    # Test with valid values
+    result = tyro.cli(
+        Constraints,
+        args=[
+            "--name",
+            "Alice",
+            "--age",
+            "25",
+            "--score",
+            "95.5",
+            "--tags",
+            "tag1",
+            "tag2",
+        ],
+    )
+    assert result.name == "Alice"
+    assert result.age == 25
+    assert result.score == 95.5
+    assert result.tags == ["tag1", "tag2"]
+
+    # Post-init validation is not triggered during CLI parsing for Meta constraints
+    # It would only happen during deserialization
+    # Test with defaults
+    result = tyro.cli(Constraints, args=["--name", "Bob", "--age", "30"])
+    assert result.name == "Bob"
+    assert result.age == 30
+    assert result.score == 0.0
+    assert result.tags == ["default"]
+
+
+def test_msgspec_with_path_conversion():
+    class FileConfig(msgspec.Struct):
+        config_path: pathlib.Path
+        output_dir: pathlib.Path = pathlib.Path("./output")
+
+    # Test with path values
+    result = tyro.cli(FileConfig, args=["--config-path", "~/config.yaml"])
+    assert result.config_path == pathlib.Path("~/config.yaml")
+    assert result.output_dir == pathlib.Path("./output")
+
+    # Test with custom output dir
+    result = tyro.cli(
+        FileConfig,
+        args=["--config-path", "/etc/config.yaml", "--output-dir", "/var/log"],
+    )
+    assert result.config_path == pathlib.Path("/etc/config.yaml")
+    assert result.output_dir == pathlib.Path("/var/log")
+
+
+def test_msgspec_with_union_type():
+    class UnionConfig(msgspec.Struct):
+        value: Union[int, str] = "default"
+
+    # Test with default
+    result = tyro.cli(UnionConfig, args=[])
+    assert result.value == "default"
+
+    # Test with int
+    result = tyro.cli(UnionConfig, args=["--value", "42"])
+    assert result.value == 42
+
+    # Test with str
+    result = tyro.cli(UnionConfig, args=["--value", "hello"])
+    assert result.value == "hello"
+
+
+def test_msgspec_with_tuple_type():
+    class TupleConfig(msgspec.Struct):
+        coords: Tuple[float, float] = (0.0, 0.0)
+
+    # Test with default
+    result = tyro.cli(TupleConfig, args=[])
+    assert result.coords == (0.0, 0.0)
+
+    # Test with custom values
+    result = tyro.cli(TupleConfig, args=["--coords", "1.5", "2.5"])
+    assert result.coords == (1.5, 2.5)
+
+
+def test_msgspec_with_positional():
+    class PositionalConfig(msgspec.Struct):
+        command: Positional[str]
+        verbose: bool = False
+
+    # Test with positional arg
+    result = tyro.cli(PositionalConfig, args=["run"])
+    assert result.command == "run"
+    assert result.verbose is False
+
+    # Test with positional and flag
+    result = tyro.cli(PositionalConfig, args=["test", "--verbose"])
+    assert result.command == "test"
+    assert result.verbose is True
+
+
+def test_msgspec_with_suppress():
+    class ConfigWithSuppressed(msgspec.Struct):
+        visible: str
+        hidden: Suppress[str] = "secret"
+
+    # Test with visible field
+    result = tyro.cli(ConfigWithSuppressed, args=["--visible", "hello"])
+    assert result.visible == "hello"
+    assert result.hidden == "secret"  # Should still have the default value
+
+    # Verify hidden field is not in helptext
+    helptext = get_helptext_with_checks(ConfigWithSuppressed)
+    assert "--visible" in helptext
+    assert "--hidden" not in helptext
+
+
+def test_msgspec_with_aliases():
+    class AliasConfig(msgspec.Struct):
+        long_option: Annotated[str, arg(aliases=["-l"])]
+        another_option: Annotated[int, arg(aliases=["--alt", "-a"])] = 0
+
+    # Test with long form
+    result = tyro.cli(AliasConfig, args=["--long-option", "value"])
+    assert result.long_option == "value"
+    assert result.another_option == 0
+
+    # Test with short form
+    result = tyro.cli(AliasConfig, args=["-l", "value", "-a", "42"])
+    assert result.long_option == "value"
+    assert result.another_option == 42
+
+    # Test with alternate form
+    result = tyro.cli(AliasConfig, args=["-l", "value", "--alt", "42"])
+    assert result.long_option == "value"
+    assert result.another_option == 42
+
+
+def test_msgspec_helptext():
+    class Helptext(msgspec.Struct):
+        """This docstring should be printed as a description."""
+
+        x: int
+        """Documentation for x."""
+
+        y: int
+        """Documentation for y."""
+
+        z: int = 42
+        """Documentation for z."""
+
+    # Check that the docstrings are included in the helptext
+    helptext = get_helptext_with_checks(Helptext)
+    assert "This docstring should be printed as a description" in helptext
+    assert "Documentation for x" in helptext
+    assert "Documentation for y" in helptext
+    assert "Documentation for z" in helptext
+
+
+def test_msgspec_with_field_metadata():
+    class ExplicitMetadata(msgspec.Struct):
+        name: str
+        """The name of the user."""
+
+        age: int
+        """The age of the user."""
+
+        tags: List[str] = msgspec.field(default_factory=list)
+        """User tags."""
+
+    # Check that field metadata is included in helptext
+    helptext = get_helptext_with_checks(ExplicitMetadata)
+    assert "The name of the user" in helptext
+    assert "The age of the user" in helptext
+    assert "User tags" in helptext
+
+
+# Define TypeVar for generic tests
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+def test_msgspec_with_generics():
+    class GenericStruct(msgspec.Struct, Generic[T]):
+        value: T
+        name: str = "generic"
+
+    # Test with int type
+    result = tyro.cli(GenericStruct[int], args=["--value", "42"])
+    assert result.value == 42
+    assert result.name == "generic"
+
+    # Test with str type
+    result = tyro.cli(GenericStruct[str], args=["--value", "hello"])
+    assert result.value == "hello"
+    assert result.name == "generic"
+
+    # Test with float type
+    result = tyro.cli(GenericStruct[float], args=["--value", "3.14"])
+    assert result.value == 3.14
+    assert result.name == "generic"
+
+
+def test_msgspec_with_multiple_generics():
+    class MultiGenericStruct(msgspec.Struct, Generic[T, S]):
+        t_value: T
+        s_value: S
+        name: str = "multi-generic"
+
+    # Test with int, str combination
+    result = tyro.cli(
+        MultiGenericStruct[int, str], args=["--t-value", "42", "--s-value", "hello"]
+    )
+    assert result.t_value == 42
+    assert result.s_value == "hello"
+    assert result.name == "multi-generic"
+
+
+def test_msgspec_default_instance():
+    class Inside(msgspec.Struct, frozen=True):  # Must be frozen for mutable default
+        x: int = 1
+
+    class Outside(msgspec.Struct):
+        i: Inside = Inside(x=2)
+
+    assert tyro.cli(Outside, args=[]).i.x == 2, (
+        "Expected x value from the default instance"
+    )
+    assert tyro.cli(Outside, args=["--i.x", "3"]).i.x == 3
+
+
+def test_msgspec_nested_default_instance():
+    class Inside(msgspec.Struct, frozen=True):  # Must be frozen
+        x: int = 1
+
+    class Middle(msgspec.Struct, frozen=True):  # Must be frozen
+        i: Inside = Inside(x=2)
+
+    class Outside(msgspec.Struct):
+        m: Middle = Middle(i=Inside(x=2))
+
+    assert tyro.cli(Outside, args=[]).m.i.x == 2, (
+        "Expected x value from the default instance"
+    )
+    assert tyro.cli(Outside, args=["--m.i.x", "3"]).m.i.x == 3

--- a/tests/test_msgspec_advanced.py
+++ b/tests/test_msgspec_advanced.py
@@ -1,0 +1,228 @@
+from typing import Dict, FrozenSet, Generic, List, Literal, Optional, Set, TypeVar
+
+import msgspec
+import pytest
+from helptext_utils import get_helptext_with_checks
+from typing_extensions import NewType
+
+import tyro
+
+# Define TypeVars for generics tests
+T = TypeVar("T")
+S = TypeVar("S")
+U = TypeVar("U", bound=float)
+
+# Define NewType for testing
+UserId = NewType("UserId", int)
+
+
+def test_msgspec_with_complex_generics():
+    """Test msgspec structs with complex generic parameters."""
+
+    class Container(msgspec.Struct, Generic[T]):
+        value: T
+        name: str = "container"
+
+    class NestedContainer(msgspec.Struct, Generic[T, S]):
+        outer: Container[T]
+        inner_value: S
+        description: str = "nested"
+
+    # Test with int, str combination
+    result = tyro.cli(
+        NestedContainer[int, str],
+        args=[
+            "--outer.value",
+            "42",
+            "--outer.name",
+            "custom",
+            "--inner-value",
+            "hello",
+        ],
+    )
+    assert result.outer.value == 42
+    assert result.outer.name == "custom"
+    assert result.inner_value == "hello"
+    assert result.description == "nested"
+
+    # Test with defaults
+    result = tyro.cli(
+        NestedContainer[float, bool],
+        args=["--outer.value", "3.14", "--inner-value", "True"],
+    )
+    assert result.outer.value == 3.14
+    assert result.outer.name == "container"  # default
+    assert result.inner_value is True
+    assert result.description == "nested"  # default
+
+
+def test_msgspec_with_bound_typevars():
+    """Test msgspec structs with bounded TypeVars."""
+
+    class NumericValue(msgspec.Struct, Generic[U]):
+        value: U
+        name: str = "numeric"
+
+    # Test with int (within bounds)
+    result = tyro.cli(NumericValue[int], args=["--value", "42"])
+    assert result.value == 42.0
+    assert result.name == "numeric"
+
+    # Test with float (within bounds)
+    result = tyro.cli(NumericValue[float], args=["--value", "3.14"])
+    assert result.value == 3.14
+    assert result.name == "numeric"
+
+
+def test_msgspec_with_generic_containers():
+    """Test msgspec structs with generic container types."""
+
+    class GenericListContainer(msgspec.Struct, Generic[T]):
+        items: List[T]
+        name: str = "list_container"
+
+    # Test with list of strings
+    result = tyro.cli(GenericListContainer[str], args=["--items", "a", "b", "c"])
+    assert result.items == ["a", "b", "c"]
+    assert result.name == "list_container"
+
+    # Test with list of integers
+    result = tyro.cli(GenericListContainer[int], args=["--items", "1", "2", "3"])
+    assert result.items == [1, 2, 3]
+    assert result.name == "list_container"
+
+
+def test_msgspec_with_generic_union_types():
+    """Test msgspec structs with Union types inside generics."""
+
+    class GenericOptional(msgspec.Struct, Generic[T]):
+        value: Optional[T] = None
+        description: str = "optional"
+
+    # Test with None (default)
+    result = tyro.cli(GenericOptional[int], args=[])
+    assert result.value is None
+
+    # Test with int value
+    result = tyro.cli(GenericOptional[int], args=["--value", "42"])
+    assert result.value == 42
+
+    # Test with str value
+    result = tyro.cli(GenericOptional[str], args=["--value", "hello"])
+    assert result.value == "hello"
+
+
+def test_msgspec_with_literal_types():
+    """Test msgspec structs with Literal types."""
+
+    class ConfigMode(msgspec.Struct):
+        mode: Literal["development", "production", "testing"] = "development"
+        debug: bool = False
+
+    # Test with default
+    result = tyro.cli(ConfigMode, args=[])
+    assert result.mode == "development"
+    assert result.debug is False
+
+    # Test with explicit mode
+    result = tyro.cli(ConfigMode, args=["--mode", "production", "--debug"])
+    assert result.mode == "production"
+    assert result.debug is True
+
+    # Test with invalid mode (should fail)
+    with pytest.raises(SystemExit):
+        tyro.cli(ConfigMode, args=["--mode", "invalid"])
+
+
+def test_msgspec_with_newtype():
+    """Test msgspec structs with NewType."""
+
+    class User(msgspec.Struct):
+        id: UserId
+        name: str
+
+    # Test with valid UserId
+    result = tyro.cli(User, args=["--id", "12345", "--name", "John"])
+    assert result.id == 12345
+    assert isinstance(result.id, int)
+    assert result.name == "John"
+
+
+def test_msgspec_with_set_types():
+    """Test msgspec structs with Set and FrozenSet types."""
+
+    class SetContainer(msgspec.Struct):
+        mutable_set: Set[int] = msgspec.field(default_factory=set)
+        immutable_set: FrozenSet[str] = frozenset()
+
+    # Test with default values
+    result = tyro.cli(SetContainer, args=[])
+    assert result.mutable_set == set()
+    assert result.immutable_set == frozenset()
+
+    # Test with custom values
+    result = tyro.cli(
+        SetContainer,
+        args=["--mutable-set", "1", "2", "3", "--immutable-set", "a", "b", "c"],
+    )
+    assert result.mutable_set == {1, 2, 3}
+    assert result.immutable_set == frozenset({"a", "b", "c"})
+
+
+def test_msgspec_with_bytes():
+    """Test msgspec structs with bytes and bytearray types."""
+
+    class BinaryData(msgspec.Struct):
+        data: bytes = b""
+
+    # Test with default
+    result = tyro.cli(BinaryData, args=[])
+    assert result.data == b""
+
+    # Test with string that gets converted to bytes
+    # This relies on tyro's handling of bytes conversion
+    result = tyro.cli(BinaryData, args=["--data", "hello"])
+    assert result.data == b"hello"
+
+
+def test_msgspec_with_dict():
+    """Test msgspec structs with Dict type."""
+
+    class DictContainer(msgspec.Struct):
+        metadata: Dict[str, int] = msgspec.field(default_factory=dict)
+
+    # Test with empty dict (default)
+    result = tyro.cli(DictContainer, args=[])
+    assert result.metadata == {}
+
+
+def test_msgspec_with_generics_helptext():
+    """Test helptext generation for generic msgspec structs."""
+
+    class GenericConfig(msgspec.Struct, Generic[T]):
+        """A generic configuration.
+
+        This is used to configure generic values.
+        """
+
+        value: T
+        """The generic value."""
+
+        name: str = "config"
+        """Configuration name."""
+
+    # Verify helptext contains the docstrings
+    helptext = get_helptext_with_checks(GenericConfig[int])
+    assert "A generic configuration" in helptext
+    assert "This is used to configure generic values" in helptext
+    assert "The generic value" in helptext
+    assert "Configuration name" in helptext
+
+    # Verify the parameter type is shown correctly
+    # For int instantiation
+    helptext_int = get_helptext_with_checks(GenericConfig[int])
+    assert "--value INT" in helptext_int
+
+    # For str instantiation
+    helptext_str = get_helptext_with_checks(GenericConfig[str])
+    assert "--value STR" in helptext_str

--- a/tests/test_msgspec_subcommands.py
+++ b/tests/test_msgspec_subcommands.py
@@ -1,0 +1,184 @@
+import dataclasses
+import enum
+from pathlib import Path
+from typing import Any, Callable, Generic, Optional, TypeVar, Union, cast
+
+import msgspec
+import pytest
+from helptext_utils import get_helptext_with_checks
+
+import tyro
+
+# Define TypeVars for generics tests
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+def as_callable(union_type: Any) -> Callable[..., Any]:
+    """Helper function to cast Union types as callables for type checking.
+
+    This is needed because pyright expects get_helptext_with_checks to receive a callable,
+    but we're passing Union types directly. The actual runtime behavior is unchanged.
+    """
+    return cast(Callable[..., Any], union_type)
+
+
+def test_basic_msgspec_subcommands():
+    """Test basic msgspec subcommands with Union types."""
+
+    class Checkout(msgspec.Struct):
+        """Checkout a branch."""
+
+        branch: str
+
+    class Commit(msgspec.Struct):
+        """Commit changes."""
+
+        message: str
+        amend: bool = False
+
+    # Test checkout subcommand
+    result = tyro.cli(
+        as_callable(Union[Checkout, Commit]), args=["checkout", "--branch", "main"]
+    )
+    assert isinstance(result, Checkout)
+    assert result.branch == "main"
+
+    # Test commit subcommand
+    result = tyro.cli(
+        as_callable(Union[Checkout, Commit]),
+        args=["commit", "--message", "Initial commit"],
+    )
+    assert isinstance(result, Commit)
+    assert result.message == "Initial commit"
+    assert result.amend is False
+
+    # Test commit with additional flag
+    result = tyro.cli(
+        as_callable(Union[Checkout, Commit]),
+        args=["commit", "--message", "Fix bug", "--amend"],
+    )
+    assert isinstance(result, Commit)
+    assert result.message == "Fix bug"
+    assert result.amend is True
+
+    # Verify helptext
+    helptext = get_helptext_with_checks(as_callable(Union[Checkout, Commit]))
+    assert "checkout" in helptext
+    assert "commit" in helptext
+    assert "Checkout a branch" in helptext
+    assert "Commit changes" in helptext
+
+
+def test_msgspec_subcommands_with_same_type_different_generics():
+    """Test msgspec subcommands with the same type but different generic parameters."""
+
+    class Process(msgspec.Struct, Generic[T]):
+        """Process data of a specific type."""
+
+        data: T
+        debug: bool = False
+
+    # Create command with different generic instantiations
+    Command = Union[Process[int], Process[str]]
+
+    # This will work with tyro if the CLI args can disambiguate the types
+    # Test with int type (first option in union)
+    result_int = tyro.cli(as_callable(Command), args=["process-int", "--data", "42"])
+    assert isinstance(result_int, Process)
+    assert result_int.data == 42
+
+    # Test with str type (second option in union)
+    result_str = tyro.cli(as_callable(Command), args=["process-str", "--data", "hello"])
+    assert isinstance(result_str, Process)
+    assert result_str.data == "hello"
+
+
+def test_msgspec_mixed_dataclass_and_msgspec_subcommands():
+    """Test mixing dataclass and msgspec types in subcommands."""
+
+    @dataclasses.dataclass
+    class DataclassCommand:
+        """A command implemented as a dataclass."""
+
+        value: int
+        flag: bool = False
+
+    class MsgspecCommand(msgspec.Struct):
+        """A command implemented as a msgspec struct."""
+
+        name: str
+        count: int = 1
+
+    # Test dataclass subcommand
+    result = tyro.cli(
+        as_callable(Union[DataclassCommand, MsgspecCommand]),
+        args=["dataclass-command", "--value", "42"],
+    )
+    assert isinstance(result, DataclassCommand)
+    assert result.value == 42
+    assert result.flag is False
+
+    # Test msgspec subcommand
+    result = tyro.cli(
+        as_callable(Union[DataclassCommand, MsgspecCommand]),
+        args=["msgspec-command", "--name", "test"],
+    )
+    assert isinstance(result, MsgspecCommand)
+    assert result.name == "test"
+    assert result.count == 1
+
+    # Verify helptext
+    helptext = get_helptext_with_checks(
+        as_callable(Union[DataclassCommand, MsgspecCommand])
+    )
+    assert "dataclass-command" in helptext
+    assert "msgspec-command" in helptext
+    assert "A command implemented as a dataclass" in helptext
+    assert "A command implemented as a msgspec struct" in helptext
+
+
+def test_msgspec_subcommands_with_enums():
+    """Test msgspec subcommands with enum types."""
+
+    class LogLevel(enum.Enum):
+        DEBUG = "debug"
+        INFO = "info"
+        WARNING = "warning"
+        ERROR = "error"
+
+    class Configure(msgspec.Struct):
+        """Configure application settings."""
+
+        log_level: LogLevel = LogLevel.INFO
+        verbose: bool = False
+
+    class Run(msgspec.Struct):
+        """Run the application."""
+
+        log_level: LogLevel = LogLevel.INFO
+        input_file: Optional[Path] = None
+
+    # Test configure subcommand with enum
+    result = tyro.cli(
+        as_callable(Union[Configure, Run]), args=["configure", "--log-level", "DEBUG"]
+    )
+    assert isinstance(result, Configure)
+    assert result.log_level == LogLevel.DEBUG
+    assert result.verbose is False
+
+    # Test run subcommand with enum
+    result = tyro.cli(
+        as_callable(Union[Configure, Run]),
+        args=["run", "--log-level", "ERROR", "--input-file", "data.txt"],
+    )
+    assert isinstance(result, Run)
+    assert result.log_level == LogLevel.ERROR
+    assert result.input_file == Path("data.txt")
+
+    # Test invalid enum value
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            as_callable(Union[Configure, Run]),
+            args=["configure", "--log-level", "INVALID"],
+        )

--- a/tests/test_py311_generated/test_msgspec_advanced_generated.py
+++ b/tests/test_py311_generated/test_msgspec_advanced_generated.py
@@ -1,0 +1,237 @@
+from typing import (
+    Dict,
+    FrozenSet,
+    Generic,
+    List,
+    Literal,
+    NewType,
+    Optional,
+    Set,
+    TypeVar,
+)
+
+import msgspec
+import pytest
+from helptext_utils import get_helptext_with_checks
+
+import tyro
+
+# Define TypeVars for generics tests
+T = TypeVar("T")
+S = TypeVar("S")
+U = TypeVar("U", bound=float)
+
+# Define NewType for testing
+UserId = NewType("UserId", int)
+
+
+def test_msgspec_with_complex_generics():
+    """Test msgspec structs with complex generic parameters."""
+
+    class Container(msgspec.Struct, Generic[T]):
+        value: T
+        name: str = "container"
+
+    class NestedContainer(msgspec.Struct, Generic[T, S]):
+        outer: Container[T]
+        inner_value: S
+        description: str = "nested"
+
+    # Test with int, str combination
+    result = tyro.cli(
+        NestedContainer[int, str],
+        args=[
+            "--outer.value",
+            "42",
+            "--outer.name",
+            "custom",
+            "--inner-value",
+            "hello",
+        ],
+    )
+    assert result.outer.value == 42
+    assert result.outer.name == "custom"
+    assert result.inner_value == "hello"
+    assert result.description == "nested"
+
+    # Test with defaults
+    result = tyro.cli(
+        NestedContainer[float, bool],
+        args=["--outer.value", "3.14", "--inner-value", "True"],
+    )
+    assert result.outer.value == 3.14
+    assert result.outer.name == "container"  # default
+    assert result.inner_value is True
+    assert result.description == "nested"  # default
+
+
+def test_msgspec_with_bound_typevars():
+    """Test msgspec structs with bounded TypeVars."""
+
+    class NumericValue(msgspec.Struct, Generic[U]):
+        value: U
+        name: str = "numeric"
+
+    # Test with int (within bounds)
+    result = tyro.cli(NumericValue[int], args=["--value", "42"])
+    assert result.value == 42.0
+    assert result.name == "numeric"
+
+    # Test with float (within bounds)
+    result = tyro.cli(NumericValue[float], args=["--value", "3.14"])
+    assert result.value == 3.14
+    assert result.name == "numeric"
+
+
+def test_msgspec_with_generic_containers():
+    """Test msgspec structs with generic container types."""
+
+    class GenericListContainer(msgspec.Struct, Generic[T]):
+        items: List[T]
+        name: str = "list_container"
+
+    # Test with list of strings
+    result = tyro.cli(GenericListContainer[str], args=["--items", "a", "b", "c"])
+    assert result.items == ["a", "b", "c"]
+    assert result.name == "list_container"
+
+    # Test with list of integers
+    result = tyro.cli(GenericListContainer[int], args=["--items", "1", "2", "3"])
+    assert result.items == [1, 2, 3]
+    assert result.name == "list_container"
+
+
+def test_msgspec_with_generic_union_types():
+    """Test msgspec structs with Union types inside generics."""
+
+    class GenericOptional(msgspec.Struct, Generic[T]):
+        value: Optional[T] = None
+        description: str = "optional"
+
+    # Test with None (default)
+    result = tyro.cli(GenericOptional[int], args=[])
+    assert result.value is None
+
+    # Test with int value
+    result = tyro.cli(GenericOptional[int], args=["--value", "42"])
+    assert result.value == 42
+
+    # Test with str value
+    result = tyro.cli(GenericOptional[str], args=["--value", "hello"])
+    assert result.value == "hello"
+
+
+def test_msgspec_with_literal_types():
+    """Test msgspec structs with Literal types."""
+
+    class ConfigMode(msgspec.Struct):
+        mode: Literal["development", "production", "testing"] = "development"
+        debug: bool = False
+
+    # Test with default
+    result = tyro.cli(ConfigMode, args=[])
+    assert result.mode == "development"
+    assert result.debug is False
+
+    # Test with explicit mode
+    result = tyro.cli(ConfigMode, args=["--mode", "production", "--debug"])
+    assert result.mode == "production"
+    assert result.debug is True
+
+    # Test with invalid mode (should fail)
+    with pytest.raises(SystemExit):
+        tyro.cli(ConfigMode, args=["--mode", "invalid"])
+
+
+def test_msgspec_with_newtype():
+    """Test msgspec structs with NewType."""
+
+    class User(msgspec.Struct):
+        id: UserId
+        name: str
+
+    # Test with valid UserId
+    result = tyro.cli(User, args=["--id", "12345", "--name", "John"])
+    assert result.id == 12345
+    assert isinstance(result.id, int)
+    assert result.name == "John"
+
+
+def test_msgspec_with_set_types():
+    """Test msgspec structs with Set and FrozenSet types."""
+
+    class SetContainer(msgspec.Struct):
+        mutable_set: Set[int] = msgspec.field(default_factory=set)
+        immutable_set: FrozenSet[str] = frozenset()
+
+    # Test with default values
+    result = tyro.cli(SetContainer, args=[])
+    assert result.mutable_set == set()
+    assert result.immutable_set == frozenset()
+
+    # Test with custom values
+    result = tyro.cli(
+        SetContainer,
+        args=["--mutable-set", "1", "2", "3", "--immutable-set", "a", "b", "c"],
+    )
+    assert result.mutable_set == {1, 2, 3}
+    assert result.immutable_set == frozenset({"a", "b", "c"})
+
+
+def test_msgspec_with_bytes():
+    """Test msgspec structs with bytes and bytearray types."""
+
+    class BinaryData(msgspec.Struct):
+        data: bytes = b""
+
+    # Test with default
+    result = tyro.cli(BinaryData, args=[])
+    assert result.data == b""
+
+    # Test with string that gets converted to bytes
+    # This relies on tyro's handling of bytes conversion
+    result = tyro.cli(BinaryData, args=["--data", "hello"])
+    assert result.data == b"hello"
+
+
+def test_msgspec_with_dict():
+    """Test msgspec structs with Dict type."""
+
+    class DictContainer(msgspec.Struct):
+        metadata: Dict[str, int] = msgspec.field(default_factory=dict)
+
+    # Test with empty dict (default)
+    result = tyro.cli(DictContainer, args=[])
+    assert result.metadata == {}
+
+
+def test_msgspec_with_generics_helptext():
+    """Test helptext generation for generic msgspec structs."""
+
+    class GenericConfig(msgspec.Struct, Generic[T]):
+        """A generic configuration.
+
+        This is used to configure generic values.
+        """
+
+        value: T
+        """The generic value."""
+
+        name: str = "config"
+        """Configuration name."""
+
+    # Verify helptext contains the docstrings
+    helptext = get_helptext_with_checks(GenericConfig[int])
+    assert "A generic configuration" in helptext
+    assert "This is used to configure generic values" in helptext
+    assert "The generic value" in helptext
+    assert "Configuration name" in helptext
+
+    # Verify the parameter type is shown correctly
+    # For int instantiation
+    helptext_int = get_helptext_with_checks(GenericConfig[int])
+    assert "--value INT" in helptext_int
+
+    # For str instantiation
+    helptext_str = get_helptext_with_checks(GenericConfig[str])
+    assert "--value STR" in helptext_str

--- a/tests/test_py311_generated/test_msgspec_generated.py
+++ b/tests/test_py311_generated/test_msgspec_generated.py
@@ -1,0 +1,499 @@
+import enum
+import pathlib
+from datetime import date, datetime, time
+from typing import Annotated, Generic, List, Optional, Set, Tuple, TypeVar
+
+import msgspec
+import pytest
+from helptext_utils import get_helptext_with_checks
+
+import tyro
+import tyro._strings
+from tyro.conf import Positional, Suppress, arg
+
+
+def test_basic_msgspec_struct():
+    class User(msgspec.Struct):
+        name: str
+        age: int = 25
+        email: Optional[str] = None
+
+    # Test with all fields
+    result = tyro.cli(
+        User, args=["--name", "Alice", "--age", "30", "--email", "alice@example.com"]
+    )
+    assert result.name == "Alice"
+    assert result.age == 30
+    assert result.email == "alice@example.com"
+
+    # Test with defaults
+    result = tyro.cli(User, args=["--name", "Bob"])
+    assert result.name == "Bob"
+    assert result.age == 25  # default value
+    assert result.email is None  # default value
+
+
+def test_msgspec_struct_with_collections():
+    class Config(msgspec.Struct):
+        tags: List[str] = []
+        flags: Set[int] = set()
+
+    # Test with empty collections
+    result = tyro.cli(Config, args=[])
+    assert result.tags == []
+    assert result.flags == set()
+
+    # Test with populated collections
+    result = tyro.cli(Config, args=["--tags", "tag1", "tag2", "--flags", "1", "2", "3"])
+    assert result.tags == ["tag1", "tag2"]
+    assert result.flags == {1, 2, 3}
+
+
+def test_msgspec_struct_with_default_factory():
+    class Settings(msgspec.Struct):
+        values: List[str] = msgspec.field(default_factory=lambda: ["default"])
+
+    # Test with default factory
+    result = tyro.cli(Settings, args=[])
+    assert result.values == ["default"]
+
+    # Test with custom values
+    result = tyro.cli(Settings, args=["--values", "custom1", "custom2"])
+    assert result.values == ["custom1", "custom2"]
+
+
+def test_msgspec_struct_validation():
+    class Point(msgspec.Struct):
+        x: int
+        y: int
+
+    # Test valid input
+    result = tyro.cli(Point, args=["--x", "10", "--y", "20"])
+    assert result.x == 10
+    assert result.y == 20
+
+    # Test invalid input (missing required field)
+    with pytest.raises(SystemExit):
+        tyro.cli(Point, args=["--x", "10"])
+
+    # Test invalid input (wrong type)
+    with pytest.raises(SystemExit):
+        tyro.cli(Point, args=["--x", "10.5", "--y", "20"])
+
+
+def test_nested_msgspec_struct():
+    class Address(msgspec.Struct):
+        street: str
+        city: str
+        zip_code: str
+
+    class Person(msgspec.Struct):
+        name: str
+        address: Address
+
+    # Test nested struct
+    result = tyro.cli(
+        Person,
+        args=[
+            "--name",
+            "John",
+            "--address.street",
+            "123 Main St",
+            "--address.city",
+            "Boston",
+            "--address.zip_code",
+            "02108",
+        ],
+    )
+    assert result.name == "John"
+    assert result.address.street == "123 Main St"
+    assert result.address.city == "Boston"
+    assert result.address.zip_code == "02108"
+
+
+def test_msgspec_struct_inheritance():
+    class Animal(msgspec.Struct):
+        name: str
+        age: int = 0
+        species: str = "unknown"
+
+    class Dog(Animal):
+        breed: str = "mixed"
+        is_good_boy: bool = True
+
+    class WorkingDog(Dog):
+        job: str = "guard"
+        hours_per_day: int = 8
+
+    # Test base class
+    result = tyro.cli(Animal, args=["--name", "Generic"])
+    assert result.name == "Generic"
+    assert result.age == 0
+    assert result.species == "unknown"
+
+    # Test single inheritance
+    result = tyro.cli(Dog, args=["--name", "Rex", "--breed", "German Shepherd"])
+    assert result.name == "Rex"
+    assert result.age == 0  # inherited default
+    assert result.species == "unknown"  # inherited default
+    assert result.breed == "German Shepherd"
+    assert result.is_good_boy is True  # inherited default
+
+    # Test multiple inheritance
+    result = tyro.cli(
+        WorkingDog,
+        args=[
+            "--name",
+            "Max",
+            "--breed",
+            "Belgian Malinois",
+            "--job",
+            "police",
+            "--hours_per_day",
+            "10",
+        ],
+    )
+    assert result.name == "Max"
+    assert result.age == 0  # inherited from Animal
+    assert result.species == "unknown"  # inherited from Animal
+    assert result.breed == "Belgian Malinois"  # inherited from Dog
+    assert result.is_good_boy is True  # inherited from Dog
+    assert result.job == "police"
+    assert result.hours_per_day == 10
+
+
+def test_msgspec_struct_with_datetime_types():
+    class Event(msgspec.Struct):
+        name: str
+        start_time: datetime
+        event_date: date
+        check_in: time
+
+    # Test with all datetime types
+    result = tyro.cli(
+        Event,
+        args=[
+            "--name",
+            "Conference",
+            "--start-time",
+            "2024-03-20T09:00:00",
+            "--event-date",
+            "2024-03-20",
+            "--check-in",
+            "08:30:00",
+        ],
+    )
+    assert result.name == "Conference"
+    assert result.start_time == datetime(2024, 3, 20, 9, 0)
+    assert result.event_date == date(2024, 3, 20)
+    assert result.check_in == time(8, 30)
+
+
+def test_msgspec_struct_with_enums():
+    class Color(enum.Enum):
+        RED = enum.auto()
+        GREEN = enum.auto()
+        BLUE = enum.auto()
+
+    class Priority(enum.IntEnum):
+        LOW = enum.auto()
+        MEDIUM = enum.auto()
+        HIGH = enum.auto()
+
+    class Task(msgspec.Struct):
+        name: str
+        color: Color
+        priority: Priority
+        status: str = "pending"
+
+    # Test with enum types
+    result = tyro.cli(
+        Task,
+        args=[
+            "--name",
+            "Important Task",
+            "--color",
+            "RED",
+            "--priority",
+            "HIGH",
+        ],
+    )
+    assert result.name == "Important Task"
+    assert result.color == Color.RED
+    assert result.priority == Priority.HIGH
+    assert result.status == "pending"
+
+    # Test invalid enum value
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            Task, args=["--name", "Task", "--color", "YELLOW", "--priority", "HIGH"]
+        )
+
+
+def test_msgspec_with_post_init_validation():
+    class Interval(msgspec.Struct):
+        start: int
+        end: int
+
+        def __post_init__(self):
+            if self.start > self.end:
+                raise ValueError("start must be less than or equal to end")
+
+    # Test with valid values
+    result = tyro.cli(Interval, args=["--start", "10", "--end", "20"])
+    assert result.start == 10
+    assert result.end == 20
+
+    # Test with invalid values
+    with pytest.raises(ValueError, match="start must be less than or equal to end"):
+        tyro.cli(Interval, args=["--start", "30", "--end", "20"])
+
+
+def test_msgspec_with_meta_validation():
+    class Constraints(msgspec.Struct):
+        name: Annotated[str, msgspec.Meta(min_length=3, max_length=50)]
+        age: Annotated[int, msgspec.Meta(gt=0, lt=120)]
+        score: Annotated[float, msgspec.Meta(ge=0.0, le=100.0)] = 0.0
+        tags: Annotated[List[str], msgspec.Meta(min_length=1)] = msgspec.field(
+            default_factory=lambda: ["default"]
+        )
+
+    # Test with valid values
+    result = tyro.cli(
+        Constraints,
+        args=[
+            "--name",
+            "Alice",
+            "--age",
+            "25",
+            "--score",
+            "95.5",
+            "--tags",
+            "tag1",
+            "tag2",
+        ],
+    )
+    assert result.name == "Alice"
+    assert result.age == 25
+    assert result.score == 95.5
+    assert result.tags == ["tag1", "tag2"]
+
+    # Post-init validation is not triggered during CLI parsing for Meta constraints
+    # It would only happen during deserialization
+    # Test with defaults
+    result = tyro.cli(Constraints, args=["--name", "Bob", "--age", "30"])
+    assert result.name == "Bob"
+    assert result.age == 30
+    assert result.score == 0.0
+    assert result.tags == ["default"]
+
+
+def test_msgspec_with_path_conversion():
+    class FileConfig(msgspec.Struct):
+        config_path: pathlib.Path
+        output_dir: pathlib.Path = pathlib.Path("./output")
+
+    # Test with path values
+    result = tyro.cli(FileConfig, args=["--config-path", "~/config.yaml"])
+    assert result.config_path == pathlib.Path("~/config.yaml")
+    assert result.output_dir == pathlib.Path("./output")
+
+    # Test with custom output dir
+    result = tyro.cli(
+        FileConfig,
+        args=["--config-path", "/etc/config.yaml", "--output-dir", "/var/log"],
+    )
+    assert result.config_path == pathlib.Path("/etc/config.yaml")
+    assert result.output_dir == pathlib.Path("/var/log")
+
+
+def test_msgspec_with_union_type():
+    class UnionConfig(msgspec.Struct):
+        value: int | str = "default"
+
+    # Test with default
+    result = tyro.cli(UnionConfig, args=[])
+    assert result.value == "default"
+
+    # Test with int
+    result = tyro.cli(UnionConfig, args=["--value", "42"])
+    assert result.value == 42
+
+    # Test with str
+    result = tyro.cli(UnionConfig, args=["--value", "hello"])
+    assert result.value == "hello"
+
+
+def test_msgspec_with_tuple_type():
+    class TupleConfig(msgspec.Struct):
+        coords: Tuple[float, float] = (0.0, 0.0)
+
+    # Test with default
+    result = tyro.cli(TupleConfig, args=[])
+    assert result.coords == (0.0, 0.0)
+
+    # Test with custom values
+    result = tyro.cli(TupleConfig, args=["--coords", "1.5", "2.5"])
+    assert result.coords == (1.5, 2.5)
+
+
+def test_msgspec_with_positional():
+    class PositionalConfig(msgspec.Struct):
+        command: Positional[str]
+        verbose: bool = False
+
+    # Test with positional arg
+    result = tyro.cli(PositionalConfig, args=["run"])
+    assert result.command == "run"
+    assert result.verbose is False
+
+    # Test with positional and flag
+    result = tyro.cli(PositionalConfig, args=["test", "--verbose"])
+    assert result.command == "test"
+    assert result.verbose is True
+
+
+def test_msgspec_with_suppress():
+    class ConfigWithSuppressed(msgspec.Struct):
+        visible: str
+        hidden: Suppress[str] = "secret"
+
+    # Test with visible field
+    result = tyro.cli(ConfigWithSuppressed, args=["--visible", "hello"])
+    assert result.visible == "hello"
+    assert result.hidden == "secret"  # Should still have the default value
+
+    # Verify hidden field is not in helptext
+    helptext = get_helptext_with_checks(ConfigWithSuppressed)
+    assert "--visible" in helptext
+    assert "--hidden" not in helptext
+
+
+def test_msgspec_with_aliases():
+    class AliasConfig(msgspec.Struct):
+        long_option: Annotated[str, arg(aliases=["-l"])]
+        another_option: Annotated[int, arg(aliases=["--alt", "-a"])] = 0
+
+    # Test with long form
+    result = tyro.cli(AliasConfig, args=["--long-option", "value"])
+    assert result.long_option == "value"
+    assert result.another_option == 0
+
+    # Test with short form
+    result = tyro.cli(AliasConfig, args=["-l", "value", "-a", "42"])
+    assert result.long_option == "value"
+    assert result.another_option == 42
+
+    # Test with alternate form
+    result = tyro.cli(AliasConfig, args=["-l", "value", "--alt", "42"])
+    assert result.long_option == "value"
+    assert result.another_option == 42
+
+
+def test_msgspec_helptext():
+    class Helptext(msgspec.Struct):
+        """This docstring should be printed as a description."""
+
+        x: int
+        """Documentation for x."""
+
+        y: int
+        """Documentation for y."""
+
+        z: int = 42
+        """Documentation for z."""
+
+    # Check that the docstrings are included in the helptext
+    helptext = get_helptext_with_checks(Helptext)
+    assert "This docstring should be printed as a description" in helptext
+    assert "Documentation for x" in helptext
+    assert "Documentation for y" in helptext
+    assert "Documentation for z" in helptext
+
+
+def test_msgspec_with_field_metadata():
+    class ExplicitMetadata(msgspec.Struct):
+        name: str
+        """The name of the user."""
+
+        age: int
+        """The age of the user."""
+
+        tags: List[str] = msgspec.field(default_factory=list)
+        """User tags."""
+
+    # Check that field metadata is included in helptext
+    helptext = get_helptext_with_checks(ExplicitMetadata)
+    assert "The name of the user" in helptext
+    assert "The age of the user" in helptext
+    assert "User tags" in helptext
+
+
+# Define TypeVar for generic tests
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+def test_msgspec_with_generics():
+    class GenericStruct(msgspec.Struct, Generic[T]):
+        value: T
+        name: str = "generic"
+
+    # Test with int type
+    result = tyro.cli(GenericStruct[int], args=["--value", "42"])
+    assert result.value == 42
+    assert result.name == "generic"
+
+    # Test with str type
+    result = tyro.cli(GenericStruct[str], args=["--value", "hello"])
+    assert result.value == "hello"
+    assert result.name == "generic"
+
+    # Test with float type
+    result = tyro.cli(GenericStruct[float], args=["--value", "3.14"])
+    assert result.value == 3.14
+    assert result.name == "generic"
+
+
+def test_msgspec_with_multiple_generics():
+    class MultiGenericStruct(msgspec.Struct, Generic[T, S]):
+        t_value: T
+        s_value: S
+        name: str = "multi-generic"
+
+    # Test with int, str combination
+    result = tyro.cli(
+        MultiGenericStruct[int, str], args=["--t-value", "42", "--s-value", "hello"]
+    )
+    assert result.t_value == 42
+    assert result.s_value == "hello"
+    assert result.name == "multi-generic"
+
+
+def test_msgspec_default_instance():
+    class Inside(msgspec.Struct, frozen=True):  # Must be frozen for mutable default
+        x: int = 1
+
+    class Outside(msgspec.Struct):
+        i: Inside = Inside(x=2)
+
+    assert tyro.cli(Outside, args=[]).i.x == 2, (
+        "Expected x value from the default instance"
+    )
+    assert tyro.cli(Outside, args=["--i.x", "3"]).i.x == 3
+
+
+def test_msgspec_nested_default_instance():
+    class Inside(msgspec.Struct, frozen=True):  # Must be frozen
+        x: int = 1
+
+    class Middle(msgspec.Struct, frozen=True):  # Must be frozen
+        i: Inside = Inside(x=2)
+
+    class Outside(msgspec.Struct):
+        m: Middle = Middle(i=Inside(x=2))
+
+    assert tyro.cli(Outside, args=[]).m.i.x == 2, (
+        "Expected x value from the default instance"
+    )
+    assert tyro.cli(Outside, args=["--m.i.x", "3"]).m.i.x == 3

--- a/tests/test_py311_generated/test_msgspec_subcommands_generated.py
+++ b/tests/test_py311_generated/test_msgspec_subcommands_generated.py
@@ -1,0 +1,182 @@
+import dataclasses
+import enum
+from pathlib import Path
+from typing import Any, Callable, Generic, Optional, TypeVar, cast
+
+import msgspec
+import pytest
+from helptext_utils import get_helptext_with_checks
+
+import tyro
+
+# Define TypeVars for generics tests
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+def as_callable(union_type: Any) -> Callable[..., Any]:
+    """Helper function to cast Union types as callables for type checking.
+
+    This is needed because pyright expects get_helptext_with_checks to receive a callable,
+    but we're passing Union types directly. The actual runtime behavior is unchanged.
+    """
+    return cast(Callable[..., Any], union_type)
+
+
+def test_basic_msgspec_subcommands():
+    """Test basic msgspec subcommands with Union types."""
+
+    class Checkout(msgspec.Struct):
+        """Checkout a branch."""
+
+        branch: str
+
+    class Commit(msgspec.Struct):
+        """Commit changes."""
+
+        message: str
+        amend: bool = False
+
+    # Test checkout subcommand
+    result = tyro.cli(
+        as_callable(Checkout | Commit), args=["checkout", "--branch", "main"]
+    )
+    assert isinstance(result, Checkout)
+    assert result.branch == "main"
+
+    # Test commit subcommand
+    result = tyro.cli(
+        as_callable(Checkout | Commit),
+        args=["commit", "--message", "Initial commit"],
+    )
+    assert isinstance(result, Commit)
+    assert result.message == "Initial commit"
+    assert result.amend is False
+
+    # Test commit with additional flag
+    result = tyro.cli(
+        as_callable(Checkout | Commit),
+        args=["commit", "--message", "Fix bug", "--amend"],
+    )
+    assert isinstance(result, Commit)
+    assert result.message == "Fix bug"
+    assert result.amend is True
+
+    # Verify helptext
+    helptext = get_helptext_with_checks(as_callable(Checkout | Commit))
+    assert "checkout" in helptext
+    assert "commit" in helptext
+    assert "Checkout a branch" in helptext
+    assert "Commit changes" in helptext
+
+
+def test_msgspec_subcommands_with_same_type_different_generics():
+    """Test msgspec subcommands with the same type but different generic parameters."""
+
+    class Process(msgspec.Struct, Generic[T]):
+        """Process data of a specific type."""
+
+        data: T
+        debug: bool = False
+
+    # Create command with different generic instantiations
+    Command = Process[int] | Process[str]
+
+    # This will work with tyro if the CLI args can disambiguate the types
+    # Test with int type (first option in union)
+    result_int = tyro.cli(as_callable(Command), args=["process-int", "--data", "42"])
+    assert isinstance(result_int, Process)
+    assert result_int.data == 42
+
+    # Test with str type (second option in union)
+    result_str = tyro.cli(as_callable(Command), args=["process-str", "--data", "hello"])
+    assert isinstance(result_str, Process)
+    assert result_str.data == "hello"
+
+
+def test_msgspec_mixed_dataclass_and_msgspec_subcommands():
+    """Test mixing dataclass and msgspec types in subcommands."""
+
+    @dataclasses.dataclass
+    class DataclassCommand:
+        """A command implemented as a dataclass."""
+
+        value: int
+        flag: bool = False
+
+    class MsgspecCommand(msgspec.Struct):
+        """A command implemented as a msgspec struct."""
+
+        name: str
+        count: int = 1
+
+    # Test dataclass subcommand
+    result = tyro.cli(
+        as_callable(DataclassCommand | MsgspecCommand),
+        args=["dataclass-command", "--value", "42"],
+    )
+    assert isinstance(result, DataclassCommand)
+    assert result.value == 42
+    assert result.flag is False
+
+    # Test msgspec subcommand
+    result = tyro.cli(
+        as_callable(DataclassCommand | MsgspecCommand),
+        args=["msgspec-command", "--name", "test"],
+    )
+    assert isinstance(result, MsgspecCommand)
+    assert result.name == "test"
+    assert result.count == 1
+
+    # Verify helptext
+    helptext = get_helptext_with_checks(as_callable(DataclassCommand | MsgspecCommand))
+    assert "dataclass-command" in helptext
+    assert "msgspec-command" in helptext
+    assert "A command implemented as a dataclass" in helptext
+    assert "A command implemented as a msgspec struct" in helptext
+
+
+def test_msgspec_subcommands_with_enums():
+    """Test msgspec subcommands with enum types."""
+
+    class LogLevel(enum.Enum):
+        DEBUG = "debug"
+        INFO = "info"
+        WARNING = "warning"
+        ERROR = "error"
+
+    class Configure(msgspec.Struct):
+        """Configure application settings."""
+
+        log_level: LogLevel = LogLevel.INFO
+        verbose: bool = False
+
+    class Run(msgspec.Struct):
+        """Run the application."""
+
+        log_level: LogLevel = LogLevel.INFO
+        input_file: Optional[Path] = None
+
+    # Test configure subcommand with enum
+    result = tyro.cli(
+        as_callable(Configure | Run), args=["configure", "--log-level", "DEBUG"]
+    )
+    assert isinstance(result, Configure)
+    assert result.log_level == LogLevel.DEBUG
+    assert result.verbose is False
+
+    # Test run subcommand with enum
+    result = tyro.cli(
+        as_callable(Configure | Run),
+        args=["run", "--log-level", "ERROR", "--input-file", "data.txt"],
+    )
+    assert isinstance(result, Run)
+    assert result.log_level == LogLevel.ERROR
+    assert result.input_file == Path("data.txt")
+
+    # Test invalid enum value
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            as_callable(Configure | Run),
+            args=["configure", "--log-level", "INVALID"],
+        )


### PR DESCRIPTION
Added rule for `msgspec.Struct`, as implemented by @brentyi in https://github.com/brentyi/tyro/issues/292#issuecomment-2831509237.

Added tests, mostly generated by Cursor!