### PR TITLE
Fix handling of ellipsis in Callable type annotations

### DIFF
--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -468,6 +468,7 @@ class TypeParamResolver:
                 return Union[new_args]  # type: ignore
             elif hasattr(typ, "copy_with"):
                 # typing.List, typing.Dict, etc.
+                # `.copy_with((a, b, c, d))` on a Callable type will return `Callable[[a, b, c], d]`.
                 return typ.copy_with(new_args)  # type: ignore
             else:
                 # list[], dict[], etc.

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -447,8 +447,7 @@ class TypeParamResolver:
         if len(args) > 0:
             if origin is Annotated:
                 args = args[:1]
-            if origin is collections.abc.Callable:
-                assert isinstance(args[0], list)
+            if origin is collections.abc.Callable and isinstance(args[0], list):
                 args = tuple(args[0]) + args[1:]
 
             new_args_list = []

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -621,6 +621,14 @@ def test_fixed_dataclass_type() -> None:
         tyro.cli(main, args=["--x", "something"])
 
 
+def test_callable_ellipsis() -> None:
+    @dataclasses.dataclass
+    class SimpleCallable:
+        x: Callable[..., None] = lambda: None
+
+    assert tyro.cli(SimpleCallable, args=[]) == SimpleCallable()
+
+
 def test_missing_singleton() -> None:
     assert tyro.MISSING is copy.deepcopy(tyro.MISSING)
 

--- a/tests/test_dcargs.py
+++ b/tests/test_dcargs.py
@@ -266,6 +266,16 @@ def test_union_literal() -> None:
     assert tyro.cli(main, args=["--x", "five"]) == "five"
 
 
+def test_literal_bad_default() -> None:
+    def main(x: Literal[1, 2] = 3) -> int:  # type: ignore
+        return x
+
+    assert tyro.cli(main, args=[]) == 3
+    assert tyro.cli(main, args=["--x", "2"]) == 2
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--x", "five"])
+
+
 def test_func_typevar() -> None:
     T = TypeVar("T", int, str)
 

--- a/tests/test_generics_and_serialization.py
+++ b/tests/test_generics_and_serialization.py
@@ -30,14 +30,6 @@ def test_generic_callable() -> None:
     assert tyro.cli(AGenericCallable, args=[]) == AGenericCallable()
 
 
-def test_simple_callable_ellipsis() -> None:
-    @dataclasses.dataclass
-    class SimpleCallable:
-        x: Callable[..., None] = lambda: None
-
-    assert tyro.cli(SimpleCallable, args=[]) == SimpleCallable()
-
-
 def test_tuple_generic_variable() -> None:
     @dataclasses.dataclass
     class TupleGenericVariable(Generic[ScalarType]):

--- a/tests/test_generics_and_serialization.py
+++ b/tests/test_generics_and_serialization.py
@@ -2,7 +2,7 @@ import contextlib
 import dataclasses
 import enum
 import io
-from typing import Generic, List, NewType, Tuple, Type, TypeVar, Union
+from typing import Callable, Generic, List, NewType, Tuple, Type, TypeVar, Union
 
 import pytest
 import yaml
@@ -19,6 +19,23 @@ def _check_serialization_identity(cls: Type[T], instance: T) -> None:
 
 
 ScalarType = TypeVar("ScalarType")
+
+
+@dataclasses.dataclass
+class AGenericCallable(Generic[T]):
+    x: Callable[..., T] = lambda: None  # type: ignore
+
+
+def test_generic_callable() -> None:
+    assert tyro.cli(AGenericCallable, args=[]) == AGenericCallable()
+
+
+def test_simple_callable_ellipsis() -> None:
+    @dataclasses.dataclass
+    class SimpleCallable:
+        x: Callable[..., None] = lambda: None
+
+    assert tyro.cli(SimpleCallable, args=[]) == SimpleCallable()
 
 
 def test_tuple_generic_variable() -> None:

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -618,6 +618,14 @@ def test_fixed_dataclass_type() -> None:
         tyro.cli(main, args=["--x", "something"])
 
 
+def test_callable_ellipsis() -> None:
+    @dataclasses.dataclass
+    class SimpleCallable:
+        x: Callable[..., None] = lambda: None
+
+    assert tyro.cli(SimpleCallable, args=[]) == SimpleCallable()
+
+
 def test_missing_singleton() -> None:
     assert tyro.MISSING is copy.deepcopy(tyro.MISSING)
 

--- a/tests/test_py311_generated/test_dcargs_generated.py
+++ b/tests/test_py311_generated/test_dcargs_generated.py
@@ -263,6 +263,16 @@ def test_union_literal() -> None:
     assert tyro.cli(main, args=["--x", "five"]) == "five"
 
 
+def test_literal_bad_default() -> None:
+    def main(x: Literal[1, 2] = 3) -> int:  # type: ignore
+        return x
+
+    assert tyro.cli(main, args=[]) == 3
+    assert tyro.cli(main, args=["--x", "2"]) == 2
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--x", "five"])
+
+
 def test_func_typevar() -> None:
     T = TypeVar("T", int, str)
 

--- a/tests/test_py311_generated/test_generics_and_serialization_generated.py
+++ b/tests/test_py311_generated/test_generics_and_serialization_generated.py
@@ -38,14 +38,6 @@ def test_generic_callable() -> None:
     assert tyro.cli(AGenericCallable, args=[]) == AGenericCallable()
 
 
-def test_simple_callable_ellipsis() -> None:
-    @dataclasses.dataclass
-    class SimpleCallable:
-        x: Callable[..., None] = lambda: None
-
-    assert tyro.cli(SimpleCallable, args=[]) == SimpleCallable()
-
-
 def test_tuple_generic_variable() -> None:
     @dataclasses.dataclass
     class TupleGenericVariable(Generic[ScalarType]):

--- a/tests/test_py311_generated/test_generics_and_serialization_generated.py
+++ b/tests/test_py311_generated/test_generics_and_serialization_generated.py
@@ -2,7 +2,16 @@ import contextlib
 import dataclasses
 import enum
 import io
-from typing import Annotated, Generic, List, NewType, Tuple, Type, TypeVar
+from typing import (
+    Annotated,
+    Callable,
+    Generic,
+    List,
+    NewType,
+    Tuple,
+    Type,
+    TypeVar,
+)
 
 import pytest
 import yaml
@@ -18,6 +27,23 @@ def _check_serialization_identity(cls: Type[T], instance: T) -> None:
 
 
 ScalarType = TypeVar("ScalarType")
+
+
+@dataclasses.dataclass
+class AGenericCallable(Generic[T]):
+    x: Callable[..., T] = lambda: None  # type: ignore
+
+
+def test_generic_callable() -> None:
+    assert tyro.cli(AGenericCallable, args=[]) == AGenericCallable()
+
+
+def test_simple_callable_ellipsis() -> None:
+    @dataclasses.dataclass
+    class SimpleCallable:
+        x: Callable[..., None] = lambda: None
+
+    assert tyro.cli(SimpleCallable, args=[]) == SimpleCallable()
 
 
 def test_tuple_generic_variable() -> None:

--- a/tests/test_py311_generated/test_unsupported_but_should_work_generated.py
+++ b/tests/test_py311_generated/test_unsupported_but_should_work_generated.py
@@ -10,7 +10,6 @@ import omegaconf
 import pytest
 
 import tyro
-import tyro._strings
 
 
 def test_omegaconf_missing():

--- a/tests/test_unsupported_but_should_work.py
+++ b/tests/test_unsupported_but_should_work.py
@@ -10,7 +10,6 @@ import omegaconf
 import pytest
 
 import tyro
-import tyro._strings
 
 
 def test_omegaconf_missing():


### PR DESCRIPTION
## Summary
- Fixes handling of the ellipsis (...) in Callable[..., T] annotations
- Adds test cases for generic callables using ellipsis
- Fixes #299

## Test plan
- Added test_generic_callable() in tests/test_generics_and_serialization.py
- Added test_literal_bad_default() in tests/test_dcargs.py
- Regenerated test_py311_generated files

🤖 Generated with [Claude Code](https://claude.ai/code)