### PR TITLE
Fix helptext edge case for unions of tuples of Literals

### DIFF
--- a/src/tyro/_strings.py
+++ b/src/tyro/_strings.py
@@ -186,13 +186,27 @@ def join_union_metavars(metavars: Iterable[str]) -> str:
     for i in range(1, len(metavars)):
         prev = merged_metavars[-1]
         curr = metavars[i]
+        # Only merge curly brace expressions that represent literal choices (contain commas).
+        # Don't merge if either contains spaces (indicating tuples/sequences) or nested braces.
         if (
             prev.startswith("{")
             and prev.endswith("}")
             and curr.startswith("{")
             and curr.endswith("}")
+            and " " not in prev
+            and " " not in curr
+            and "{" not in prev[1:-1]
+            and "{" not in curr[1:-1]
         ):
-            merged_metavars[-1] = prev[:-1] + "," + curr[1:]
+            prev_content = prev[1:-1]
+            curr_content = curr[1:-1]
+            # Only merge if contents are different and don't overlap
+            prev_items = set(prev_content.split(","))
+            curr_items = set(curr_content.split(","))
+            if prev_items.isdisjoint(curr_items):
+                merged_metavars[-1] = prev[:-1] + "," + curr[1:]
+            else:
+                merged_metavars.append(curr)
         else:
             merged_metavars.append(curr)
 

--- a/src/tyro/_strings.py
+++ b/src/tyro/_strings.py
@@ -198,15 +198,7 @@ def join_union_metavars(metavars: Iterable[str]) -> str:
             and "{" not in prev[1:-1]
             and "{" not in curr[1:-1]
         ):
-            prev_content = prev[1:-1]
-            curr_content = curr[1:-1]
-            # Only merge if contents are different and don't overlap
-            prev_items = set(prev_content.split(","))
-            curr_items = set(curr_content.split(","))
-            if prev_items.isdisjoint(curr_items):
-                merged_metavars[-1] = prev[:-1] + "," + curr[1:]
-            else:
-                merged_metavars.append(curr)
+            merged_metavars[-1] = prev[:-1] + "," + curr[1:]
         else:
             merged_metavars.append(curr)
 

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -1036,3 +1036,34 @@ def test_long_literal_options() -> None:
 
     # Check that there's no ellipsis character in the helptext
     assert "…" not in helptext
+
+
+def test_bool_help_edge_cases() -> None:
+    """Test edge cases in metavar generation for unions with tuples and literals."""
+
+    # Use the exact same pattern as in bool_help_edge.py but as individual function definitions
+    # Currently this passes, but represents edge cases that were problematic
+    def main_int(x_int: Union[Tuple[int], Tuple[int, int]] = (1,)) -> None:
+        pass
+
+    def main_literal(
+        x_literal: Union[
+            Tuple[Literal[0, 1, 2]], Tuple[Literal[0, 1, 2], Literal[0, 1, 2]]
+        ] = (0,),
+    ) -> None:
+        pass
+
+    def main_bool(x_bool: Union[Tuple[bool], Tuple[bool, bool]] = (True,)) -> None:
+        pass
+
+    # Test int case - should show INT|{INT INT}
+    helptext_int = get_helptext_with_checks(main_int)
+    assert "--x-int INT|{INT INT}" in helptext_int
+
+    # Test literal case - should show {0,1,2}|{{0,1,2} {0,1,2}}
+    helptext_literal = get_helptext_with_checks(main_literal)
+    assert "--x-literal {0,1,2}|{{0,1,2} {0,1,2}}" in helptext_literal
+
+    # Test bool case - should show {True,False}|{{True,False} {True,False}}
+    helptext_bool = get_helptext_with_checks(main_bool)
+    assert "--x-bool {True,False}|{{True,False} {True,False}}" in helptext_bool

--- a/tests/test_py311_generated/test_helptext_generated.py
+++ b/tests/test_py311_generated/test_helptext_generated.py
@@ -1037,3 +1037,33 @@ def test_long_literal_options() -> None:
 
     # Check that there's no ellipsis character in the helptext
     assert "…" not in helptext
+
+
+def test_bool_help_edge_cases() -> None:
+    """Test edge cases in metavar generation for unions with tuples and literals."""
+
+    # Use the exact same pattern as in bool_help_edge.py but as individual function definitions
+    # Currently this passes, but represents edge cases that were problematic
+    def main_int(x_int: Tuple[int] | Tuple[int, int] = (1,)) -> None:
+        pass
+
+    def main_literal(
+        x_literal: Tuple[Literal[0, 1, 2]]
+        | Tuple[Literal[0, 1, 2], Literal[0, 1, 2]] = (0,),
+    ) -> None:
+        pass
+
+    def main_bool(x_bool: Tuple[bool] | Tuple[bool, bool] = (True,)) -> None:
+        pass
+
+    # Test int case - should show INT|{INT INT}
+    helptext_int = get_helptext_with_checks(main_int)
+    assert "--x-int INT|{INT INT}" in helptext_int
+
+    # Test literal case - should show {0,1,2}|{{0,1,2} {0,1,2}}
+    helptext_literal = get_helptext_with_checks(main_literal)
+    assert "--x-literal {0,1,2}|{{0,1,2} {0,1,2}}" in helptext_literal
+
+    # Test bool case - should show {True,False}|{{True,False} {True,False}}
+    helptext_bool = get_helptext_with_checks(main_bool)
+    assert "--x-bool {True,False}|{{True,False} {True,False}}" in helptext_bool


### PR DESCRIPTION
Helptext for this example was previously failing for the `Literal` and `bool` types:
```python
from typing import Literal
import tyro

type SingleOrPair[T] = tuple[T] | tuple[T, T]

def main(
    x_int: SingleOrPair[int] = (1,),  # OK
    x_literal: SingleOrPair[Literal[0, 1, 2]] = (0,),  # Not OK
    x_bool: SingleOrPair[bool] = (True,),  # Not OK
):
    pass

tyro.cli(main)
```

We were getting:
```
usage: bool_help_edge.py [-h] [--x-int INT|{INT INT}] [--x-literal {{0,1,2,0,1,2} {0,1,2}}] [--x-bool {{True,False,True,False} {True,False}}]

╭─ options ───────────────────────────────────────────────╮
│ -h, --help              show this help message and exit │
│ --x-int INT|{INT INT}   (default: 1)                    │
│ --x-literal {{0,1,2,0,1,2} {0,1,2}}                     │
│                         (default: 0)                    │
│ --x-bool {{True,False,True,False} {True,False}}         │
│                         (default: True)                 │
╰─────────────────────────────────────────────────────────╯
```

With this fix:
```
usage: bool_help_edge.py [-h] [--x-int INT|{INT INT}] [--x-literal {0,1,2}|{{0,1,2} {0,1,2}}] [--x-bool {True,False}|{{True,False} {True,False}}]

╭─ options ───────────────────────────────────────────────╮
│ -h, --help              show this help message and exit │
│ --x-int INT|{INT INT}   (default: 1)                    │
│ --x-literal {0,1,2}|{{0,1,2} {0,1,2}}                   │
│                         (default: 0)                    │
│ --x-bool {True,False}|{{True,False} {True,False}}       │
│                         (default: True)                 │
╰─────────────────────────────────────────────────────────╯
```