### PR TITLE
Fix recursive type detection edge case for type aliases

### DIFF
--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -459,7 +459,14 @@ class TypeParamResolver:
                 new_args_list.append(x)
 
             new_args = tuple(
-                TypeParamResolver.concretize_type_params(x, seen=seen)
+                TypeParamResolver.concretize_type_params(
+                    # We copy `seen` here to make sure inner types don't impact
+                    # each other. This is necessary because `seen` is mutated
+                    # in recursive calls; this is not ideal from a robustness
+                    # perspective, but convenient for performance reasons.
+                    x,
+                    seen=seen.copy() if len(new_args_list) > 1 else seen,
+                )
                 for x in new_args_list
             )
 

--- a/src/tyro/constructors/_primitive_spec.py
+++ b/src/tyro/constructors/_primitive_spec.py
@@ -725,7 +725,7 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
                 else:
                     errors.append(
                         f"{options[i]}: input length {len(strings)} did not match expected"
-                        f" argument count {option_spec.nargs}"
+                        f" argument count {option_spec.nargs} of `[bold]{option_spec.metavar}[/bold]`"
                     )
             raise ValueError(
                 f"no type in {options} could be instantiated from"

--- a/tests/test_new_style_annotations_min_py312.py
+++ b/tests/test_new_style_annotations_min_py312.py
@@ -464,8 +464,8 @@ def test_generic_type_alias_individual_resolution() -> None:
     alias_int = ConstrainedTuple[int]
     alias_bool = ConstrainedTuple[bool]
 
-    resolved_int = TypeParamResolver.concretize_type_params(alias_int)
-    resolved_bool = TypeParamResolver.concretize_type_params(alias_bool)
+    resolved_int = TypeParamResolver.concretize_type_params(alias_int)  # type: ignore
+    resolved_bool = TypeParamResolver.concretize_type_params(alias_bool)  # type: ignore
 
     # Check that the resolved types are what we expect
     from typing import Union
@@ -485,7 +485,7 @@ def test_generic_type_alias_union_resolution() -> None:
 
     # Test union resolution
     union_type = ConstrainedTuple[int] | ConstrainedTuple[bool]
-    resolved_union = TypeParamResolver.concretize_type_params(union_type)
+    resolved_union = TypeParamResolver.concretize_type_params(union_type)  # type: ignore
 
     # The resolved union should contain all four tuple types
     expected = Union[tuple[int], tuple[int, int], tuple[bool], tuple[bool, bool]]

--- a/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
@@ -464,8 +464,8 @@ def test_generic_type_alias_individual_resolution() -> None:
     alias_int = ConstrainedTuple[int]
     alias_bool = ConstrainedTuple[bool]
 
-    resolved_int = TypeParamResolver.concretize_type_params(alias_int)
-    resolved_bool = TypeParamResolver.concretize_type_params(alias_bool)
+    resolved_int = TypeParamResolver.concretize_type_params(alias_int)  # type: ignore
+    resolved_bool = TypeParamResolver.concretize_type_params(alias_bool)  # type: ignore
 
     # Check that the resolved types are what we expect
 
@@ -483,7 +483,7 @@ def test_generic_type_alias_union_resolution() -> None:
 
     # Test union resolution
     union_type = ConstrainedTuple[int] | ConstrainedTuple[bool]
-    resolved_union = TypeParamResolver.concretize_type_params(union_type)
+    resolved_union = TypeParamResolver.concretize_type_params(union_type)  # type: ignore
 
     # The resolved union should contain all four tuple types
     expected = tuple[int] | tuple[int, int] | tuple[bool] | tuple[bool, bool]

--- a/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
+++ b/tests/test_py311_generated/test_new_style_annotations_min_py312_generated.py
@@ -423,3 +423,86 @@ def test_bad_orig_bases() -> None:
     assert "--a" in get_helptext_with_checks(D)
     assert "STR" in get_helptext_with_checks(D)
     assert "INT|STR" not in get_helptext_with_checks(D)
+
+
+type ConstrainedTuple[T] = tuple[T] | tuple[T, T]
+
+
+def test_generic_type_alias_union() -> None:
+    """Test that unions of generic type aliases resolve type parameters correctly.
+
+    Regression test for bug where ConstrainedTuple[int] | ConstrainedTuple[bool]
+    would incorrectly resolve to typing.tuple[int]| tuple[int, int]| tuple[T]| tuple[T, T]
+    instead of typing.tuple[int]| tuple[int, int]| tuple[bool]| tuple[bool, bool].
+    """
+
+    def main(arg: ConstrainedTuple[int] | ConstrainedTuple[bool]) -> Any:
+        return arg
+
+    # Test with int tuple of length 1
+    assert tyro.cli(main, args=["--arg", "1"]) == (1,)
+
+    # Test with int tuple of length 2
+    assert tyro.cli(main, args=["--arg", "1", "2"]) == (1, 2)
+
+    # Test with bool tuple of length 1
+    assert tyro.cli(main, args=["--arg", "True"]) == (True,)
+
+    # Test with bool tuple of length 2
+    assert tyro.cli(main, args=["--arg", "False", "True"]) == (False, True)
+
+
+def test_generic_type_alias_individual_resolution() -> None:
+    """Test that individual generic type aliases resolve correctly.
+
+    This verifies that the type parameter resolution works correctly for
+    individual generic type aliases before testing unions.
+    """
+    from tyro._resolver import TypeParamResolver
+
+    # Test individual resolution
+    alias_int = ConstrainedTuple[int]
+    alias_bool = ConstrainedTuple[bool]
+
+    resolved_int = TypeParamResolver.concretize_type_params(alias_int)
+    resolved_bool = TypeParamResolver.concretize_type_params(alias_bool)
+
+    # Check that the resolved types are what we expect
+
+    assert resolved_int == tuple[int] | tuple[int, int]
+    assert resolved_bool == tuple[bool] | tuple[bool, bool]
+
+
+def test_generic_type_alias_union_resolution() -> None:
+    """Test that unions of generic type aliases resolve correctly at the type level.
+
+    This tests the internal type resolution mechanism that was buggy.
+    """
+
+    from tyro._resolver import TypeParamResolver
+
+    # Test union resolution
+    union_type = ConstrainedTuple[int] | ConstrainedTuple[bool]
+    resolved_union = TypeParamResolver.concretize_type_params(union_type)
+
+    # The resolved union should contain all four tuple types
+    expected = tuple[int] | tuple[int, int] | tuple[bool] | tuple[bool, bool]
+    assert resolved_union == expected
+
+    # Verify that no unresolved TypeVars remain (this was the bug)
+    # The resolved type should not contain any raw TypeVar instances
+    import typing
+    from typing import get_args
+
+    def contains_typevar(typ) -> bool:
+        """Recursively check if a type contains any TypeVar instances."""
+        if isinstance(typ, typing.TypeVar):
+            return True
+        for arg in get_args(typ):
+            if contains_typevar(arg):
+                return True
+        return False
+
+    assert not contains_typevar(resolved_union), (
+        f"Resolved type contains unresolved TypeVars: {resolved_union}"
+    )


### PR DESCRIPTION
Our logic for detecting recursive types had some edge cases. Here's an example:
```python
import tyro

type MaybeTuple[T] = T | tuple[T, ...]

tyro.cli(MaybeTuple[int] | MaybeTuple[str])  # Should be ok, but was raising a runtime error.
```

The error was caused by the way we mutate sets of "seen" types. After fixing, the script above produces this CLI interface: 
```
usage: example.py [-h] INT|{[INT [INT ...]]}|STR|{[STR [STR ...]]}

╭─ positional arguments ────────────────────────────╮
│ INT|{[INT [INT ...]]}|STR|{[STR [STR ...]]}       │
│                   (required)                      │
╰───────────────────────────────────────────────────╯
╭─ options ─────────────────────────────────────────╮
│ -h, --help        show this help message and exit │
╰───────────────────────────────────────────────────╯
```