### PR TITLE
Fix + tests for inheritance regression when `tyro.conf.configure()` is used

### DIFF
--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -359,6 +359,10 @@ def _cli_impl(
     # We wrap our type with a dummy dataclass if it can't be treated as a nested type.
     # For example: passing in f=int will result in a dataclass with a single field
     # typed as int.
+    #
+    # Why don't we always use a dummy dataclass?
+    # => Docstrings for inner structs are currently lost when we nest struct types.
+    f = _resolver.TypeParamResolver.resolve_params_and_aliases(f)
     if not _fields.is_struct_type(cast(type, f), default_instance_internal):
         dummy_field = cast(
             dataclasses.Field,
@@ -372,7 +376,6 @@ def _cli_impl(
         default_instance_internal = f(default_instance_internal)  # type: ignore
         dummy_wrapped = True
     else:
-        f = _resolver.TypeParamResolver.resolve_params_and_aliases(f)
         dummy_wrapped = False
 
     # Read and fix arguments. If the user passes in --field_name instead of

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -105,7 +105,7 @@ class ParserSpecification:
                 default_instance=default_instance,
                 support_single_arg_types=support_single_arg_types,
             )
-            assert not isinstance(out, UnsupportedStructTypeMessage)
+            assert not isinstance(out, UnsupportedStructTypeMessage), out
             f, field_list = out
 
         has_required_args = False

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -762,6 +762,12 @@ def get_type_hints_resolve_type_params(
         # Substitution for forwarded type parameters; if we have:
         #     class A[T](Base[T]): ...
         # and we're resolving A[int], the base class should be treated as Base[int].
+        #
+        # We set `ignore_confstruct=True` to avoid swapping types from
+        # `tyro.conf.arg` and `tyro.conf.subcommand`'s `constructor_factory`
+        # attributes, which might be applied using the `@tyro.conf.configure`
+        # decorator. These attributes should be ignored when traversing
+        # inheritance hierarchies.
         with context:
             resolved_bases = [
                 TypeParamResolver.resolve_params_and_aliases(

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -330,16 +330,14 @@ def unwrap_annotated(
         else:
             return get_args(typ)[0]
 
-    # Check for __tyro_markers__ from @configure.
-    if hasattr(typ, "__tyro_markers__"):
-        if search_type == "all":
-            targets = getattr(typ, "__tyro_markers__")
-        else:
-            targets = tuple(
-                x
-                for x in getattr(typ, "__tyro_markers__")
-                if isinstance(x, search_type)  # type: ignore
-            )
+    # Check for __tyro_markers__ from @configure. Use `__dict__` instead of
+    # getattr() to prevent inheritance.
+    if hasattr(typ, "__dict__") and "__tyro_markers__" in typ.__dict__:
+        targets = tuple(
+            x
+            for x in typ.__dict__["__tyro_markers__"]
+            if search_type == "all" or isinstance(x, search_type)  # type: ignore
+        )
     else:
         targets = ()
 
@@ -378,7 +376,9 @@ class TypeParamResolver:
 
     @staticmethod
     def resolve_params_and_aliases(
-        typ: TypeOrCallable, seen: set[Any] | None = None
+        typ: TypeOrCallable,
+        seen: set[Any] | None = None,
+        ignore_confstruct: bool = False,
     ) -> TypeOrCallable:
         """Apply type parameter assignments based on the current context."""
 
@@ -392,13 +392,20 @@ class TypeParamResolver:
             seen.add(typ)
 
         # Resolve types recursively.
-        return TypeParamResolver._resolve_type_params(typ, seen=seen)
+        return TypeParamResolver._resolve_type_params(
+            typ, seen=seen, ignore_confstruct=ignore_confstruct
+        )
 
     @staticmethod
-    def _resolve_type_params(typ: TypeOrCallable, seen: set[Any]) -> TypeOrCallable:
+    def _resolve_type_params(
+        typ: TypeOrCallable,
+        seen: set[Any],
+        ignore_confstruct: bool,
+    ) -> TypeOrCallable:
         """Implementation of resolve_type_params(), which doesn't consider cycles."""
         # Handle aliases.
-        typ = swap_type_using_confstruct(typ)
+        if not ignore_confstruct:
+            typ = swap_type_using_confstruct(typ)
         typ = resolve_newtype_and_aliases(typ)
         GenericAlias = getattr(types, "GenericAlias", None)
         if GenericAlias is not None and isinstance(typ, GenericAlias):
@@ -409,11 +416,13 @@ class TypeParamResolver:
                 type_from_typevar = {}
                 for k, v in zip(type_params, get_args(typ)):
                     type_from_typevar[k] = TypeParamResolver._resolve_type_params(
-                        v, seen=seen
+                        v, seen=seen, ignore_confstruct=ignore_confstruct
                     )
                 typ = typ.__value__  # type: ignore
                 with TypeParamAssignmentContext(typ, type_from_typevar):
-                    return TypeParamResolver._resolve_type_params(typ, seen=seen)
+                    return TypeParamResolver._resolve_type_params(
+                        typ, seen=seen, ignore_confstruct=ignore_confstruct
+                    )
 
         # Search for type parameter assignments.
         for type_from_typevar in reversed(TypeParamResolver.param_assignments):
@@ -755,7 +764,10 @@ def get_type_hints_resolve_type_params(
         # and we're resolving A[int], the base class should be treated as Base[int].
         with context:
             resolved_bases = [
-                TypeParamResolver.resolve_params_and_aliases(base) for base in bases
+                TypeParamResolver.resolve_params_and_aliases(
+                    base, ignore_confstruct=True
+                )
+                for base in bases
             ]
 
         # Recursively resolve type parameters for all bases.

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -8,10 +8,10 @@ import shlex
 from typing import Any, Dict, Generic, List, Sequence, Tuple, Type, TypeVar, Union
 
 import pytest
-import tyro
+from helptext_utils import get_helptext_with_checks
 from typing_extensions import Annotated, TypedDict
 
-from helptext_utils import get_helptext_with_checks
+import tyro
 
 
 def test_suppress_subcommand() -> None:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2041,3 +2041,38 @@ def test_union_subcommand_specific_help_with_config():
             args=["union-command1", "--help"],
             config=(tyro.conf.FlagCreatePairsOff,),
         )
+
+
+def test_conf_inheritance():
+    """Adapted from: https://github.com/brentyi/tyro/pull/328"""
+
+    @tyro.conf.configure(
+        tyro.conf.arg(constructor_factory=lambda: AdamConfig | SgdConfig)  # type: ignore
+    )
+    @dataclasses.dataclass
+    class OptimizerConfig:
+        lr: float
+
+    @tyro.conf.configure(
+        tyro.conf.subcommand(name="adam")  # type: ignore
+    )
+    @dataclasses.dataclass
+    class AdamConfig(OptimizerConfig):
+        betas: tuple[float, float]
+
+    @dataclasses.dataclass
+    class SgdConfig(OptimizerConfig):
+        fused: bool
+
+    assert tyro.cli(
+        AdamConfig, args="--betas 0.99 0.95 --lr 1e-4".split(" ")
+    ) == AdamConfig(1e-4, (0.99, 0.95))
+    assert tyro.cli(SgdConfig, args="--lr 1e-4 --fused True".split(" ")) == SgdConfig(
+        1e-4, True
+    )
+    assert tyro.cli(
+        OptimizerConfig, args="adam --lr 1e-4 --betas 0.99 0.95".split(" ")
+    ) == AdamConfig(1e-4, (0.99, 0.95))
+    assert tyro.cli(
+        OptimizerConfig, args="sgd-config --lr 1e-4 --fused True".split(" ")
+    ) == SgdConfig(1e-4, fused=True)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2047,7 +2047,7 @@ def test_conf_inheritance():
     """Adapted from: https://github.com/brentyi/tyro/pull/328"""
 
     @tyro.conf.configure(
-        tyro.conf.arg(constructor_factory=lambda: AdamConfig | SgdConfig)  # type: ignore
+        tyro.conf.arg(constructor_factory=lambda: Union[AdamConfig, SgdConfig])  # type: ignore
     )
     @dataclasses.dataclass
     class OptimizerConfig:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 import argparse
 import contextlib
 import dataclasses
@@ -7,10 +8,10 @@ import shlex
 from typing import Any, Dict, Generic, List, Sequence, Tuple, Type, TypeVar, Union
 
 import pytest
-from helptext_utils import get_helptext_with_checks
+import tyro
 from typing_extensions import Annotated, TypedDict
 
-import tyro
+from helptext_utils import get_helptext_with_checks
 
 
 def test_suppress_subcommand() -> None:
@@ -1952,7 +1953,7 @@ class UnionCommand3:
     name: str = "default"
 
 
-def test_union_with_empty_config():
+def test_union_with_empty_config() -> None:
     """Union types should work with empty config tuple."""
     result = tyro.cli(
         Union[UnionCommand1, UnionCommand2],
@@ -1962,7 +1963,7 @@ def test_union_with_empty_config():
     assert result == UnionCommand1(arg1="test", flag1=False)
 
 
-def test_union_with_flag_create_pairs_off():
+def test_union_with_flag_create_pairs_off() -> None:
     """Union types should work with FlagCreatePairsOff config."""
     result = tyro.cli(
         Union[UnionCommand1, UnionCommand2],
@@ -1972,7 +1973,7 @@ def test_union_with_flag_create_pairs_off():
     assert result == UnionCommand1(arg1="test", flag1=True)
 
 
-def test_union_with_flag_conversion_off():
+def test_union_with_flag_conversion_off() -> None:
     """Union types should work with FlagConversionOff config."""
     result = tyro.cli(
         Union[UnionCommand1, UnionCommand2],
@@ -1982,7 +1983,7 @@ def test_union_with_flag_conversion_off():
     assert result == UnionCommand2(arg2=42, flag2=False)
 
 
-def test_union_with_omit_subcommand_prefixes():
+def test_union_with_omit_subcommand_prefixes() -> None:
     """Union types should work with OmitSubcommandPrefixes."""
     result = tyro.cli(
         Union[UnionCommand1, UnionCommand2],
@@ -1992,7 +1993,7 @@ def test_union_with_omit_subcommand_prefixes():
     assert result == UnionCommand1(arg1="test", flag1=False)
 
 
-def test_union_with_positional_required_args():
+def test_union_with_positional_required_args() -> None:
     """Union types should work with PositionalRequiredArgs."""
 
     @dataclasses.dataclass
@@ -2011,7 +2012,7 @@ def test_union_with_positional_required_args():
     assert result == SimpleUnionCmd1(required_arg="hello")
 
 
-def test_nested_union_with_config():
+def test_nested_union_with_config() -> None:
     """Nested union types should work with config."""
     result = tyro.cli(
         Union[UnionCommand1, UnionCommand3],
@@ -2021,7 +2022,7 @@ def test_nested_union_with_config():
     assert result == UnionCommand3(nested=NestedUnionConfig(value=2.5), name="test")
 
 
-def test_union_subcommand_help_with_config():
+def test_union_subcommand_help_with_config() -> None:
     """Test that help text works correctly with union types and config."""
     # This should not raise an exception
     with pytest.raises(SystemExit):
@@ -2032,7 +2033,7 @@ def test_union_subcommand_help_with_config():
         )
 
 
-def test_union_subcommand_specific_help_with_config():
+def test_union_subcommand_specific_help_with_config() -> None:
     """Test that subcommand-specific help works with config."""
     # This should not raise an exception
     with pytest.raises(SystemExit):
@@ -2043,10 +2044,10 @@ def test_union_subcommand_specific_help_with_config():
         )
 
 
-def test_conf_inheritance():
+def test_conf_inheritance() -> None:
     """Adapted from: https://github.com/brentyi/tyro/pull/328"""
 
-    @tyro.conf.configure(
+    @tyro.conf.configure(  # type: ignore
         tyro.conf.arg(constructor_factory=lambda: Union[AdamConfig, SgdConfig])  # type: ignore
     )
     @dataclasses.dataclass

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2058,7 +2058,7 @@ def test_conf_inheritance():
     )
     @dataclasses.dataclass
     class AdamConfig(OptimizerConfig):
-        betas: tuple[float, float]
+        betas: Tuple[float, float]
 
     @dataclasses.dataclass
     class SgdConfig(OptimizerConfig):


### PR DESCRIPTION
Fixes an edge case flagged in #328. Thanks @mirceamironenco for spotting this!

In cases like this:
```python
    @tyro.conf.configure(
        tyro.conf.arg(constructor_factory=lambda: AdamConfig | SgdConfig)  # type: ignore
    )
    @dataclasses.dataclass
    class OptimizerConfig:
        lr: float

    @dataclasses.dataclass
    class AdamConfig(OptimizerConfig):
        betas: tuple[float, float]

    @dataclasses.dataclass
    class SgdConfig(OptimizerConfig):
        fused: bool

    tyro.cli(AdamConfig)
```

The problem was:
- Type analysis for subclasses requires traversing the inheritance hierarchy
- We resolve type parameters and aliases along the way
- `constructor_factory=` fields are internally treated similarly to aliases, which was causing `OptimizerConfig` to be interpreted as `AdamConfig | SgdConfig`
- This was causing runtime errors