### PR TITLE
More robust `typing.*` identity checks; fix edge case for generic Protocol subclasses

### DIFF
--- a/src/tyro/_docstrings.py
+++ b/src/tyro/_docstrings.py
@@ -12,7 +12,6 @@ import tokenize
 from typing import (
     Callable,
     Dict,
-    Generic,
     Hashable,
     List,
     Optional,
@@ -23,10 +22,9 @@ from typing import (
 )
 
 import docstring_parser
-from typing_extensions import (
-    get_origin,
-    is_typeddict,
-)
+from typing_extensions import get_origin, is_typeddict
+
+from tyro._typing_compat import is_typing_generic
 
 from . import _resolver, _strings, _unsafe_cache
 from .conf import _markers
@@ -139,7 +137,7 @@ def get_class_tokenization_with_field(
     for search_cls in classes_to_search:
         # Inherited generics seem challenging for now.
         # https://github.com/python/typing/issues/777
-        assert search_cls is Generic or get_origin(search_cls) is None
+        assert is_typing_generic(search_cls) or get_origin(search_cls) is None
 
         try:
             tokenization = _ClassTokenization.make(search_cls)  # type: ignore

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -17,6 +17,7 @@ from typing_extensions import Annotated, Doc, get_args, get_origin, get_original
 from . import _docstrings, _resolver, _strings, _unsafe_cache
 from ._singleton import MISSING_AND_MISSING_NONPROP, MISSING_NONPROP
 from ._typing import TypeForm
+from ._typing_compat import is_typing_annotated
 from .conf import _confstruct, _markers
 from .constructors._registry import ConstructorRegistry, check_default_instances
 from .constructors._struct_spec import (
@@ -153,7 +154,7 @@ class FieldDefinition:
     def with_new_type_stripped(
         self, new_type_stripped: TypeForm[Any] | Callable
     ) -> FieldDefinition:
-        if get_origin(self.type) is Annotated:
+        if is_typing_annotated(get_origin(self.type)):
             new_type = Annotated[(new_type_stripped, *get_args(self.type)[1:])]  # type: ignore
         else:
             new_type = new_type_stripped  # type: ignore

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -24,6 +24,7 @@ from . import (
     _subcommand_matching,
 )
 from ._typing import TypeForm
+from ._typing_compat import is_typing_union
 from .conf import _confstruct, _markers
 from .constructors._primitive_spec import (
     PrimitiveConstructorSpec,
@@ -431,7 +432,7 @@ class SubparsersSpecification:
     ) -> SubparsersSpecification | None:
         # Union of classes should create subparsers.
         typ = _resolver.unwrap_annotated(field.type_stripped)
-        if get_origin(typ) not in (Union, _resolver.UnionType):
+        if not is_typing_union(get_origin(typ)):
             return None
 
         # We don't use sets here to retain order of subcommands.

--- a/src/tyro/_typing_compat.py
+++ b/src/tyro/_typing_compat.py
@@ -1,0 +1,67 @@
+import types
+import typing
+from typing import Any
+
+import typing_extensions
+
+LiteralTypes = {typing.Literal, typing_extensions.Literal}
+UnionTypes = {
+    typing.Union,
+    typing_extensions.Union,
+    getattr(types, "UnionType", typing.Union),
+}
+FinalTypes = {typing.Final, typing_extensions.Final}
+AnnotatedTypes = {
+    getattr(typing, "Annotated", typing_extensions.Annotated),
+    typing_extensions.Annotated,
+}
+GenericTypes = {typing.Generic, typing_extensions.Generic}
+ProtocolTypes = {typing.Protocol, typing_extensions.Protocol}
+RequiredTypes = {
+    getattr(typing, "Required", typing_extensions.Required),
+    typing_extensions.Required,
+}
+NotRequiredTypes = {
+    getattr(typing, "NotRequired", typing_extensions.NotRequired),
+    typing_extensions.NotRequired,
+}
+ClassVarTypes = {
+    getattr(typing, "ClassVar", typing_extensions.ClassVar),
+    typing_extensions.ClassVar,
+}
+
+
+def is_typing_literal(obj: Any) -> bool:
+    return obj in LiteralTypes
+
+
+def is_typing_union(obj: Any) -> bool:
+    return obj in UnionTypes
+
+
+def is_typing_final(obj: Any) -> bool:
+    return obj in FinalTypes
+
+
+def is_typing_annotated(obj: Any) -> bool:
+    return obj in AnnotatedTypes
+
+
+def is_typing_generic(obj: Any) -> bool:
+    return obj in GenericTypes
+
+
+def is_typing_protocol(obj: Any) -> bool:
+    return obj in ProtocolTypes
+
+
+def is_typing_required(obj: Any) -> bool:
+    return obj in RequiredTypes
+
+
+def is_typing_notrequired(obj: Any) -> bool:
+    return obj in NotRequiredTypes
+
+
+def is_typing_classvar(obj: Any) -> bool:
+    return obj in ClassVarTypes

--- a/src/tyro/constructors/_primitive_spec.py
+++ b/src/tyro/constructors/_primitive_spec.py
@@ -28,9 +28,8 @@ from typing import (
 )
 
 from typing_extensions import TYPE_CHECKING, assert_never, get_args, get_origin
-from typing_extensions import (
-    Literal as LiteralAlternate,
-)  # Sometimes different from typing.Literal.
+
+from .._typing_compat import is_typing_literal, is_typing_union
 
 if TYPE_CHECKING:
     from ._registry import ConstructorRegistry
@@ -595,7 +594,7 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
 
     @registry.primitive_rule
     def literal_rule(type_info: PrimitiveTypeInfo) -> PrimitiveConstructorSpec | None:
-        if type_info.type_origin not in (Literal, LiteralAlternate):
+        if not is_typing_literal(type_info.type_origin):
             return None
         choices = get_args(type_info.type)
         str_choices = tuple(
@@ -623,7 +622,7 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
     def union_rule(
         type_info: PrimitiveTypeInfo,
     ) -> PrimitiveConstructorSpec | UnsupportedTypeAnnotationError | None:
-        if type_info.type_origin not in (Union, _resolver.UnionType):
+        if not is_typing_union(type_info.type_origin):
             return None
         options = list(get_args(type_info.type))
         if type(None) in options:

--- a/src/tyro/constructors/_struct_spec.py
+++ b/src/tyro/constructors/_struct_spec.py
@@ -5,15 +5,9 @@ import dataclasses
 import enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Sequence
 
-from typing_extensions import (
-    NotRequired,
-    Required,
-    cast,
-    get_args,
-    get_origin,
-    is_typeddict,
-)
+from typing_extensions import cast, get_args, get_origin, is_typeddict
 
+from tyro._typing_compat import is_typing_notrequired, is_typing_required
 from tyro.constructors._primitive_spec import (
     PrimitiveTypeInfo,
     UnsupportedTypeAnnotationError,
@@ -193,7 +187,7 @@ def apply_default_struct_rules(registry: ConstructorRegistry) -> None:
             typ_origin = get_origin(typ)
             if valid_default_instance and name in cast(dict, info.default):
                 default = cast(dict, info.default)[name]
-            elif typ_origin is Required and total is False:
+            elif is_typing_required(typ_origin) and total is False:
                 # Support total=False.
                 default = MISSING
             elif total is False:
@@ -205,7 +199,7 @@ def apply_default_struct_rules(registry: ConstructorRegistry) -> None:
                     # raise _instantiators.UnsupportedTypeAnnotationError(
                     #     "`total=False` not supported for nested structures."
                     # )
-            elif typ_origin is NotRequired:
+            elif is_typing_notrequired(typ_origin):
                 # Support typing.NotRequired[].
                 default = EXCLUDE_FROM_CALL
             else:
@@ -215,7 +209,7 @@ def apply_default_struct_rules(registry: ConstructorRegistry) -> None:
             if default is EXCLUDE_FROM_CALL and is_struct_type(typ, MISSING_NONPROP):
                 default = MISSING_NONPROP
 
-            if typ_origin in (Required, NotRequired):
+            if is_typing_required(typ_origin) or is_typing_notrequired(typ_origin):
                 args = get_args(typ)
                 assert len(args) == 1, (
                     "typing.Required[] and typing.NotRequired[T] require a concrete type T."

--- a/tests/test_protocol_typevar.py
+++ b/tests/test_protocol_typevar.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, Type, TypeVar, runtime_checkable
+
+import tyro
+
+OutT_co = TypeVar("OutT_co", covariant=True)
+
+
+@runtime_checkable
+class BuilderProtocol(Protocol[OutT_co]):
+    def build(self, **kwd_override: Any) -> OutT_co: ...
+
+
+OutT = TypeVar("OutT")
+
+
+class SomeConfig(Generic[OutT]):
+    _target: Type[OutT]
+
+    def _configure(self) -> OutT: ...
+
+
+class Foo: ...
+
+
+@dataclass
+class RealConfig(SomeConfig[Foo], BuilderProtocol[Foo]):
+    bar: str = "foo_bar"
+
+
+def test_protocol_typevar() -> None:
+    """Adapted from: https://github.com/brentyi/tyro/issues/335"""
+    assert tyro.cli(RealConfig, args=["--bar", "baz"]) == RealConfig(bar="baz")
+
+
+test_protocol_typevar()

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 import argparse
 import contextlib
 import dataclasses
@@ -1959,7 +1960,7 @@ class UnionCommand3:
     name: str = "default"
 
 
-def test_union_with_empty_config():
+def test_union_with_empty_config() -> None:
     """Union types should work with empty config tuple."""
     result = tyro.cli(
         UnionCommand1 | UnionCommand2,
@@ -1969,7 +1970,7 @@ def test_union_with_empty_config():
     assert result == UnionCommand1(arg1="test", flag1=False)
 
 
-def test_union_with_flag_create_pairs_off():
+def test_union_with_flag_create_pairs_off() -> None:
     """Union types should work with FlagCreatePairsOff config."""
     result = tyro.cli(
         UnionCommand1 | UnionCommand2,
@@ -1979,7 +1980,7 @@ def test_union_with_flag_create_pairs_off():
     assert result == UnionCommand1(arg1="test", flag1=True)
 
 
-def test_union_with_flag_conversion_off():
+def test_union_with_flag_conversion_off() -> None:
     """Union types should work with FlagConversionOff config."""
     result = tyro.cli(
         UnionCommand1 | UnionCommand2,
@@ -1989,7 +1990,7 @@ def test_union_with_flag_conversion_off():
     assert result == UnionCommand2(arg2=42, flag2=False)
 
 
-def test_union_with_omit_subcommand_prefixes():
+def test_union_with_omit_subcommand_prefixes() -> None:
     """Union types should work with OmitSubcommandPrefixes."""
     result = tyro.cli(
         UnionCommand1 | UnionCommand2,
@@ -1999,7 +2000,7 @@ def test_union_with_omit_subcommand_prefixes():
     assert result == UnionCommand1(arg1="test", flag1=False)
 
 
-def test_union_with_positional_required_args():
+def test_union_with_positional_required_args() -> None:
     """Union types should work with PositionalRequiredArgs."""
 
     @dataclasses.dataclass
@@ -2018,7 +2019,7 @@ def test_union_with_positional_required_args():
     assert result == SimpleUnionCmd1(required_arg="hello")
 
 
-def test_nested_union_with_config():
+def test_nested_union_with_config() -> None:
     """Nested union types should work with config."""
     result = tyro.cli(
         UnionCommand1 | UnionCommand3,
@@ -2028,7 +2029,7 @@ def test_nested_union_with_config():
     assert result == UnionCommand3(nested=NestedUnionConfig(value=2.5), name="test")
 
 
-def test_union_subcommand_help_with_config():
+def test_union_subcommand_help_with_config() -> None:
     """Test that help text works correctly with union types and config."""
     # This should not raise an exception
     with pytest.raises(SystemExit):
@@ -2039,7 +2040,7 @@ def test_union_subcommand_help_with_config():
         )
 
 
-def test_union_subcommand_specific_help_with_config():
+def test_union_subcommand_specific_help_with_config() -> None:
     """Test that subcommand-specific help works with config."""
     # This should not raise an exception
     with pytest.raises(SystemExit):
@@ -2050,10 +2051,10 @@ def test_union_subcommand_specific_help_with_config():
         )
 
 
-def test_conf_inheritance():
+def test_conf_inheritance() -> None:
     """Adapted from: https://github.com/brentyi/tyro/pull/328"""
 
-    @tyro.conf.configure(
+    @tyro.conf.configure(  # type: ignore
         tyro.conf.arg(constructor_factory=lambda: AdamConfig | SgdConfig)  # type: ignore
     )
     @dataclasses.dataclass
@@ -2065,7 +2066,7 @@ def test_conf_inheritance():
     )
     @dataclasses.dataclass
     class AdamConfig(OptimizerConfig):
-        betas: tuple[float, float]
+        betas: Tuple[float, float]
 
     @dataclasses.dataclass
     class SgdConfig(OptimizerConfig):

--- a/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
+++ b/tests/test_py311_generated/test_duplicate_subcommand_warning_generated.py
@@ -1,3 +1,4 @@
+
 from typing import Literal
 
 import pytest

--- a/tests/test_py311_generated/test_protocol_typevar_generated.py
+++ b/tests/test_py311_generated/test_protocol_typevar_generated.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, Type, TypeVar, runtime_checkable
+
+import tyro
+
+OutT_co = TypeVar("OutT_co", covariant=True)
+
+
+@runtime_checkable
+class BuilderProtocol(Protocol[OutT_co]):
+    def build(self, **kwd_override: Any) -> OutT_co: ...
+
+
+OutT = TypeVar("OutT")
+
+
+class SomeConfig(Generic[OutT]):
+    _target: Type[OutT]
+
+    def _configure(self) -> OutT: ...
+
+
+class Foo: ...
+
+
+@dataclass
+class RealConfig(SomeConfig[Foo], BuilderProtocol[Foo]):
+    bar: str = "foo_bar"
+
+
+def test_protocol_typevar() -> None:
+    """Adapted from: https://github.com/brentyi/tyro/issues/335"""
+    assert tyro.cli(RealConfig, args=["--bar", "baz"]) == RealConfig(bar="baz")
+
+
+test_protocol_typevar()


### PR DESCRIPTION
1. Standardized how we do identity checks for names in the `typing` module. This should be more robust to future updates of `typing_extensions`.
2. Fixed runtime error for generic subclasses of `typing.Protocol`. Closes #335; thanks @mirceamironenco!