### PR TITLE
Add `add_help: bool` argument, tests

### DIFF
--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -48,6 +48,7 @@ def cli(
     return_unknown_args: Literal[False] = False,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
 ) -> OutT: ...
@@ -64,6 +65,7 @@ def cli(
     return_unknown_args: Literal[True],
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
 ) -> tuple[OutT, list[str]]: ...
@@ -83,6 +85,7 @@ def cli(
     return_unknown_args: Literal[False] = False,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
 ) -> OutT: ...
@@ -102,6 +105,7 @@ def cli(
     return_unknown_args: Literal[True],
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
 ) -> tuple[OutT, list[str]]: ...
@@ -117,6 +121,7 @@ def cli(
     return_unknown_args: bool = False,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
     **deprecated_kwargs,
@@ -185,6 +190,8 @@ def cli(
         console_outputs: If set to False, suppresses parsing errors and help messages.
             This is useful in distributed settings where tyro.cli() is called from multiple
             workers but console output is only desired from the main process.
+        add_help: Add a -h/--help option to the parser. This mirrors the argument from
+            :py:class:`argparse.ArgumentParser()`.
         config: A sequence of configuration marker objects from :mod:`tyro.conf`. This
             allows applying markers globally instead of annotating individual fields.
             For example: ``tyro.cli(Config, config=(tyro.conf.PositionalRequiredArgs,))``
@@ -213,6 +220,7 @@ def cli(
             return_unknown_args=return_unknown_args,
             use_underscores=use_underscores,
             console_outputs=console_outputs,
+            add_help=add_help,
             config=config,
             registry=registry,
             **deprecated_kwargs,
@@ -239,6 +247,7 @@ def get_parser(
     default: None | OutT = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
 ) -> argparse.ArgumentParser: ...
@@ -253,6 +262,7 @@ def get_parser(
     default: None | OutT = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
 ) -> argparse.ArgumentParser: ...
@@ -268,6 +278,7 @@ def get_parser(
     default: None | OutT = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: None | Sequence[conf._markers.Marker] = None,
     registry: None | ConstructorRegistry = None,
 ) -> argparse.ArgumentParser:
@@ -284,6 +295,8 @@ def get_parser(
         default: An instance to use for default values.
         use_underscores: If True, uses underscores as word delimiters in the help text.
         console_outputs: If set to False, suppresses parsing errors and help messages.
+        add_help: Add a -h/--help option to the parser. This mirrors the argument from
+            :py:class:`argparse.ArgumentParser()`.
         config: A sequence of configuration marker objects from :mod:`tyro.conf`.
         registry: A :class:`tyro.constructors.ConstructorRegistry` instance containing custom
             constructor rules.
@@ -301,6 +314,7 @@ def get_parser(
                 return_unknown_args=False,
                 use_underscores=use_underscores,
                 console_outputs=console_outputs,
+                add_help=add_help,
                 config=config,
                 registry=registry,
             ),
@@ -317,6 +331,7 @@ def _cli_impl(
     return_parser: bool,
     return_unknown_args: bool,
     console_outputs: bool,
+    add_help: bool,
     config: None | Sequence[conf._markers.Marker],
     registry: None | ConstructorRegistry = None,
     **deprecated_kwargs,
@@ -467,6 +482,7 @@ def _cli_impl(
             prog=prog,
             formatter_class=_argparse_formatter.TyroArgparseHelpFormatter,
             allow_abbrev=False,
+            add_help=add_help,
         )
         parser._parser_specification = parser_spec
         parser._parsing_known_args = return_unknown_args

--- a/src/tyro/extras/_base_configs.py
+++ b/src/tyro/extras/_base_configs.py
@@ -20,6 +20,7 @@ def overridable_config_cli(
     args: Sequence[str] | None = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: Sequence[Any] | None = None,
     sort_subcommands: bool = False,
     registry: ConstructorRegistry | None = None,
@@ -78,6 +79,8 @@ def overridable_config_cli(
             https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
         console_outputs: If set to `False`, parsing errors and help messages will be
             suppressed.
+        add_help: Add a -h/--help option to the parser. This mirrors the argument from
+            `argparse.ArgumentParser()`.
         config: Sequence of config marker objects, from `tyro.conf`. We include
             :class:`tyro.conf.AvoidSubcommands` by default.
         sort_subcommands: If True, sort the subcommands alphabetically by name.
@@ -98,6 +101,7 @@ def overridable_config_cli(
         args=args,
         use_underscores=use_underscores,
         console_outputs=console_outputs,
+        add_help=add_help,
         # Don't create subcommands for union types within the config object.
         config=(tyro.conf.AvoidSubcommands,)
         + (tuple() if config is None else tuple(config)),

--- a/src/tyro/extras/_subcommand_app.py
+++ b/src/tyro/extras/_subcommand_app.py
@@ -100,6 +100,7 @@ class SubcommandApp:
         args: Sequence[str] | None = None,
         use_underscores: bool = False,
         console_outputs: bool = True,
+        add_help: bool = True,
         config: Sequence[Any] | None = None,
         sort_subcommands: bool = False,
         registry: ConstructorRegistry | None = None,
@@ -123,6 +124,8 @@ class SubcommandApp:
                 https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
             console_outputs: If set to `False`, parsing errors and help messages will be
                 suppressed.
+            add_help: Add a -h/--help option to the parser. This mirrors the argument from
+                `argparse.ArgumentParser()`.
             config: Sequence of config marker objects, from `tyro.conf`.
             sort_subcommands: If True, sort the subcommands alphabetically by name.
             registry: A :class:`tyro.constructors.ConstructorRegistry` instance containing custom
@@ -149,6 +152,7 @@ class SubcommandApp:
             args=args,
             use_underscores=use_underscores,
             console_outputs=console_outputs,
+            add_help=add_help,
             config=config,
             registry=registry,
         )

--- a/src/tyro/extras/_subcommand_cli_from_dict.py
+++ b/src/tyro/extras/_subcommand_cli_from_dict.py
@@ -22,6 +22,7 @@ def subcommand_cli_from_dict(
     args: Sequence[str] | None = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: Sequence[Marker] | None = None,
     sort_subcommands: bool = False,
     registry: ConstructorRegistry | None = None,
@@ -39,6 +40,7 @@ def subcommand_cli_from_dict(
     args: Sequence[str] | None = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: Sequence[Marker] | None = None,
     sort_subcommands: bool = False,
     registry: ConstructorRegistry | None = None,
@@ -53,6 +55,7 @@ def subcommand_cli_from_dict(
     args: Sequence[str] | None = None,
     use_underscores: bool = False,
     console_outputs: bool = True,
+    add_help: bool = True,
     config: Sequence[Marker] | None = None,
     sort_subcommands: bool = False,
     registry: ConstructorRegistry | None = None,
@@ -107,6 +110,8 @@ def subcommand_cli_from_dict(
             supressed. This can be useful for distributed settings, where :func:`tyro.cli()`
             is called from multiple workers but we only want console outputs from the
             main one.
+        add_help: Add a -h/--help option to the parser. This mirrors the argument from
+            :py:class:`argparse.ArgumentParser()`.
         config: Sequence of config marker objects, from :mod:`tyro.conf`.
         registry: A :class:`tyro.constructors.ConstructorRegistry` instance containing custom
             constructor rules.
@@ -141,6 +146,7 @@ def subcommand_cli_from_dict(
         args=args,
         use_underscores=use_underscores,
         console_outputs=console_outputs,
+        add_help=add_help,
         config=config,
         registry=registry,
     )

--- a/tests/test_add_help.py
+++ b/tests/test_add_help.py
@@ -1,0 +1,211 @@
+"""Tests for add_help parameter functionality."""
+
+import dataclasses
+import io
+import sys
+
+import pytest
+
+import tyro
+
+
+@dataclasses.dataclass
+class SimpleConfig:
+    """A simple configuration class."""
+
+    value: int
+    name: str = "default"
+
+
+def simple_function(x: int, y: str = "hello") -> str:
+    """A simple function for testing."""
+    return f"{x}:{y}"
+
+
+def test_cli_add_help_false():
+    """Test that add_help=False prevents help from being added."""
+    # Should raise an error when --help is provided with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.cli(SimpleConfig, args=["--help"], add_help=False)
+    assert excinfo.value.code == 2  # Should fail with parsing error, not help display
+
+
+def test_cli_add_help_true():
+    """Test that add_help=True (default) allows help."""
+    # Should show help and exit with code 0
+    with pytest.raises(SystemExit) as excinfo:
+        # Redirect stdout to capture help output
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            tyro.cli(SimpleConfig, args=["--help"], add_help=True)
+        finally:
+            sys.stdout = old_stdout
+    assert excinfo.value.code == 0  # Should exit cleanly after showing help
+
+
+def test_cli_default_add_help():
+    """Test that add_help defaults to True."""
+    # Should show help and exit with code 0
+    with pytest.raises(SystemExit) as excinfo:
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            tyro.cli(SimpleConfig, args=["--help"])
+        finally:
+            sys.stdout = old_stdout
+    assert excinfo.value.code == 0
+
+
+def test_get_parser_add_help_false():
+    """Test that get_parser with add_help=False doesn't add help option."""
+    parser = tyro.extras.get_parser(SimpleConfig, add_help=False)
+    assert "-h" not in parser._option_string_actions
+    assert "--help" not in parser._option_string_actions
+
+
+def test_get_parser_add_help_true():
+    """Test that get_parser with add_help=True adds help option."""
+    parser = tyro.extras.get_parser(SimpleConfig, add_help=True)
+    assert (
+        "-h" in parser._option_string_actions
+        or "--help" in parser._option_string_actions
+    )
+
+
+def test_get_parser_default_add_help():
+    """Test that get_parser defaults to add_help=True."""
+    parser = tyro.extras.get_parser(SimpleConfig)
+    assert (
+        "-h" in parser._option_string_actions
+        or "--help" in parser._option_string_actions
+    )
+
+
+def test_function_cli_add_help():
+    """Test add_help works with function targets."""
+    # Test with add_help=False
+    result = tyro.cli(simple_function, args=["--x", "42"], add_help=False)
+    assert result == "42:hello"
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.cli(simple_function, args=["--help"], add_help=False)
+    assert excinfo.value.code == 2
+
+
+def test_subcommand_app_add_help():
+    """Test add_help parameter with SubcommandApp."""
+    from tyro.extras import SubcommandApp
+
+    app = SubcommandApp()
+
+    @app.command
+    def cmd1(x: int) -> int:
+        return x
+
+    @app.command
+    def cmd2(y: str) -> str:
+        return y
+
+    # Test with add_help=False
+    result = app.cli(args=["cmd1", "--x", "5"], add_help=False)
+    assert result == 5
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        app.cli(args=["--help"], add_help=False)
+    assert excinfo.value.code == 2
+
+
+def test_subcommand_cli_from_dict_add_help():
+    """Test add_help parameter with subcommand_cli_from_dict."""
+
+    def cmd1(x: int) -> int:
+        return x * 2
+
+    def cmd2(y: str) -> str:
+        return y.upper()
+
+    subcommands = {"multiply": cmd1, "uppercase": cmd2}
+
+    # Test with add_help=False
+    result = tyro.extras.subcommand_cli_from_dict(
+        subcommands, args=["multiply", "--x", "3"], add_help=False
+    )
+    assert result == 6
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.extras.subcommand_cli_from_dict(
+            subcommands, args=["--help"], add_help=False
+        )
+    assert excinfo.value.code == 2
+
+
+def test_overridable_config_cli_add_help():
+    """Test add_help parameter with overridable_config_cli."""
+
+    @dataclasses.dataclass
+    class Config:
+        a: int
+        b: str
+
+    configs = {
+        "small": ("Small config", Config(1, "small")),
+        "big": ("Big config", Config(100, "big")),
+    }
+
+    # Test with add_help=False
+    result = tyro.extras.overridable_config_cli(configs, args=["small"], add_help=False)
+    assert result.a == 1
+    assert result.b == "small"
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.extras.overridable_config_cli(configs, args=["--help"], add_help=False)
+    assert excinfo.value.code == 2
+
+
+def test_return_unknown_args_with_add_help_false():
+    """Test that --help/-h are returned as unknown args when add_help=False and return_unknown_args=True."""
+
+    @dataclasses.dataclass
+    class Config:
+        value: int = 5
+
+    # Test that --help is returned in unknown args
+    result, unknown = tyro.cli(
+        Config, args=["--help"], add_help=False, return_unknown_args=True
+    )
+    assert unknown == ["--help"]
+    assert result.value == 5
+
+    # Test that -h is returned in unknown args
+    result, unknown = tyro.cli(
+        Config, args=["-h"], add_help=False, return_unknown_args=True
+    )
+    assert unknown == ["-h"]
+    assert result.value == 5
+
+    # Test with both --help and other unknown args
+    result, unknown = tyro.cli(
+        Config,
+        args=["--help", "--unknown", "arg"],
+        add_help=False,
+        return_unknown_args=True,
+    )
+    assert "--help" in unknown
+    assert "--unknown" in unknown
+    assert "arg" in unknown
+    assert result.value == 5
+
+    # Test that with add_help=True, --help still shows help (doesn't return unknown args)
+    with pytest.raises(SystemExit) as excinfo:
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            tyro.cli(Config, args=["--help"], add_help=True, return_unknown_args=True)
+        finally:
+            sys.stdout = old_stdout
+    assert excinfo.value.code == 0  # Should exit cleanly after showing help


### PR DESCRIPTION
This is useful especially when we need multiple `tyro.cli()` calls, like in #296.