### PR TITLE
Mutually exclusive arguments (`tyro.conf.create_mutex_group()`, `tyro.conf.DisallowNone`)

### DIFF
--- a/docs/source/examples/basics.rst
+++ b/docs/source/examples/basics.rst
@@ -1042,6 +1042,19 @@ argument groups, where either exactly one (required=True) or at most one
 .. raw:: html
 
     <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py</strong>
+    <span style="color: #e60000">╭─</span><span style="color: #e60000"> </span><span style="font-weight: bold; color: #e60000">Parsing error</span><span style="color: #e60000"> </span><span style="color: #e60000">───────────────────────────────────────────────</span><span style="color: #e60000">─╮</span>
+    <span style="color: #e60000">│</span> One of the arguments --target-stream --target-file is required <span style="color: #e60000">│</span>
+    <span style="color: #e60000">│</span> <span style="color: #800000">──────────────────────────────────────────────────────────────</span> <span style="color: #e60000">│</span>
+    <span style="color: #e60000">│</span> For full helptext, run <span style="font-weight: bold">14_mutex.py --help</span>                      <span style="color: #e60000">│</span>
+    <span style="color: #e60000">╰────────────────────────────────────────────────────────────────╯</span>
+    </pre>
+
+
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
     <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --help</strong>
     <span style="font-weight: bold">usage</span>: 14_mutex.py [-h] [OPTIONS]
     

--- a/docs/source/examples/basics.rst
+++ b/docs/source/examples/basics.rst
@@ -989,3 +989,143 @@ constructors of standard Python classes.
     <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./13_classes.py --field1 hello --field2 7</strong>
     ['hello', 7, False]
     </pre>
+.. _example-14_mutex:
+
+Mutually Exclusive Groups
+-------------------------
+
+:func:`tyro.conf.create_mutex_group()` can be used to create mutually exclusive
+argument groups, where either exactly one (required=True) or at most one
+(required=False) argument from the group can be specified.
+
+
+.. code-block:: python
+    :linenos:
+
+    # 14_mutex.py
+    from pathlib import Path
+    from typing import Annotated, Literal
+
+    import tyro
+
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        target_stream: Annotated[Literal["stdout", "stderr"] | None, RequiredGroup] = None,
+        target_file: Annotated[Path | None, RequiredGroup] = None,
+        verbose: Annotated[bool, OptionalGroup] = False,
+        very_verbose: Annotated[bool, OptionalGroup] = False,
+    ) -> None:
+        """Demonstrate mutually exclusive argument groups.
+
+        Either --target-stream or --target-file must be specified (but not both).
+        Optionally, either --verbose or --very-verbose can be specified (but not both).
+        """
+        if very_verbose or verbose:
+            print(f"{target_stream=} {target_file=}")
+        if very_verbose:
+            print(f"{target_stream=} {target_file=}")
+
+    if __name__ == "__main__":
+        tyro.cli(
+            main,
+            # `DisallowNone` prevents `None` from being a valid choice for
+            # `--target-stream` and `--target-file`.
+            #
+            # `FlagCreatePairsOff` prevents `--no-verbose` and `--no-very-verbose` from
+            # being created.
+            config=(tyro.conf.DisallowNone, tyro.conf.FlagCreatePairsOff),
+        )
+
+
+Show the help message:
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --help</strong>
+    <span style="font-weight: bold">usage</span>: 14_mutex.py [-h] [OPTIONS]
+    
+    Demonstrate mutually exclusive argument groups. Either --target-stream or 
+    --target-file must be specified (but not both). Optionally, either --verbose 
+    or --very-verbose can be specified (but not both).
+    
+    <span style="font-weight: lighter">╭─</span><span style="font-weight: lighter"> options </span><span style="font-weight: lighter">──────────────────────────────────────────────</span><span style="font-weight: lighter">─╮</span>
+    <span style="font-weight: lighter">│</span> -h, --help              <span style="font-weight: lighter">show this help message and exit</span> <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">╰─────────────────────────────────────────────────────────╯</span>
+    <span style="font-weight: lighter">╭─</span><span style="font-weight: lighter"> mutually exclusive </span><span style="font-weight: lighter">───────────────────────────────────</span><span style="font-weight: lighter">─╮</span>
+    <span style="font-weight: lighter">│</span> <span style="font-weight: bold">Exactly one argument must be passed in. </span><span style="font-weight: bold; color: #800000">(required)</span><span style="font-weight: bold">     </span> <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> <span style="font-weight: lighter">──────────────────────────────────────────────────     </span> <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> --target-stream <span style="font-weight: bold">{stdout,stderr}</span>                         <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span>                         <span style="color: #008080">(default: None)</span>                 <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> --target-file <span style="font-weight: bold">PATH</span>      <span style="color: #008080">(default: None)</span>                 <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">╰─────────────────────────────────────────────────────────╯</span>
+    <span style="font-weight: lighter">╭─</span><span style="font-weight: lighter"> mutually exclusive </span><span style="font-weight: lighter">───────────────────────────────────</span><span style="font-weight: lighter">─╮</span>
+    <span style="font-weight: lighter">│</span> <span style="font-weight: bold">At most one argument can overridden.                   </span> <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> <span style="font-weight: lighter">──────────────────────────────────────────────────     </span> <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> --verbose               <span style="color: #008080">(default: False)</span>                <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> --very-verbose          <span style="color: #008080">(default: False)</span>                <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">╰─────────────────────────────────────────────────────────╯</span>
+    </pre>
+
+Valid: choosing one required argument.
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --target-stream stdout</strong>
+    </pre>
+
+
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --target-file /tmp/output.txt</strong>
+    </pre>
+
+Valid: optional mutex arguments.
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --target-stream stdout --verbose</strong>
+    target_stream='stdout' target_file=None
+    </pre>
+
+
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --target-file /tmp/output.txt --very-verbose</strong>
+    target_stream=None target_file=PosixPath('/tmp/output.txt')
+    target_stream=None target_file=PosixPath('/tmp/output.txt')
+    </pre>
+
+Invalid: both required arguments specified.
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --target-stream stdout --target-file /tmp/output.txt</strong>
+    <span style="color: #e60000">╭─</span><span style="color: #e60000"> </span><span style="font-weight: bold; color: #e60000">Parsing error</span><span style="color: #e60000"> </span><span style="color: #e60000">──────────────────────────────────────────────────</span><span style="color: #e60000">─╮</span>
+    <span style="color: #e60000">│</span> Argument --target-file: not allowed with argument --target-stream <span style="color: #e60000">│</span>
+    <span style="color: #e60000">│</span> <span style="color: #800000">─────────────────────────────────────────────────────────────────</span> <span style="color: #e60000">│</span>
+    <span style="color: #e60000">│</span> For full helptext, run <span style="font-weight: bold">14_mutex.py --help</span>                         <span style="color: #e60000">│</span>
+    <span style="color: #e60000">╰───────────────────────────────────────────────────────────────────╯</span>
+    </pre>
+
+Invalid: both optional arguments specified.
+
+.. raw:: html
+
+    <pre class="highlight" style="padding: 1em; box-sizing: border-box; font-size: 0.85em; line-height: 1.2em;">
+    <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --target-stream stdout --verbose --very-verbose</strong>
+    <span style="color: #e60000">╭─</span><span style="color: #e60000"> </span><span style="font-weight: bold; color: #e60000">Parsing error</span><span style="color: #e60000"> </span><span style="color: #e60000">─────────────────────────────────────────────</span><span style="color: #e60000">─╮</span>
+    <span style="color: #e60000">│</span> Argument --very-verbose: not allowed with argument --verbose <span style="color: #e60000">│</span>
+    <span style="color: #e60000">│</span> <span style="color: #800000">────────────────────────────────────────────────────────────</span> <span style="color: #e60000">│</span>
+    <span style="color: #e60000">│</span> For full helptext, run <span style="font-weight: bold">14_mutex.py --help</span>                    <span style="color: #e60000">│</span>
+    <span style="color: #e60000">╰──────────────────────────────────────────────────────────────╯</span>
+    </pre>

--- a/docs/source/examples/basics.rst
+++ b/docs/source/examples/basics.rst
@@ -1012,16 +1012,14 @@ argument groups, where either exactly one (required=True) or at most one
     OptionalGroup = tyro.conf.create_mutex_group(required=False)
 
     def main(
+        # Exactly one of --target-stream or --target-file must be specified.
         target_stream: Annotated[Literal["stdout", "stderr"] | None, RequiredGroup] = None,
         target_file: Annotated[Path | None, RequiredGroup] = None,
+        # Either --verbose or --very-verbose can be specified (but not both).
         verbose: Annotated[bool, OptionalGroup] = False,
         very_verbose: Annotated[bool, OptionalGroup] = False,
     ) -> None:
-        """Demonstrate mutually exclusive argument groups.
-
-        Either --target-stream or --target-file must be specified (but not both).
-        Optionally, either --verbose or --very-verbose can be specified (but not both).
-        """
+        """Demonstrate mutually exclusive argument groups."""
         if very_verbose or verbose:
             print(f"{target_stream=} {target_file=}")
         if very_verbose:
@@ -1039,7 +1037,7 @@ argument groups, where either exactly one (required=True) or at most one
         )
 
 
-Show the help message:
+
 
 .. raw:: html
 
@@ -1047,15 +1045,13 @@ Show the help message:
     <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --help</strong>
     <span style="font-weight: bold">usage</span>: 14_mutex.py [-h] [OPTIONS]
     
-    Demonstrate mutually exclusive argument groups. Either --target-stream or 
-    --target-file must be specified (but not both). Optionally, either --verbose 
-    or --very-verbose can be specified (but not both).
+    Demonstrate mutually exclusive argument groups.
     
     <span style="font-weight: lighter">╭─</span><span style="font-weight: lighter"> options </span><span style="font-weight: lighter">──────────────────────────────────────────────</span><span style="font-weight: lighter">─╮</span>
     <span style="font-weight: lighter">│</span> -h, --help              <span style="font-weight: lighter">show this help message and exit</span> <span style="font-weight: lighter">│</span>
     <span style="font-weight: lighter">╰─────────────────────────────────────────────────────────╯</span>
     <span style="font-weight: lighter">╭─</span><span style="font-weight: lighter"> mutually exclusive </span><span style="font-weight: lighter">───────────────────────────────────</span><span style="font-weight: lighter">─╮</span>
-    <span style="font-weight: lighter">│</span> <span style="font-weight: bold">Exactly one argument must be passed in. </span><span style="font-weight: bold; color: #800000">(required)</span><span style="font-weight: bold">     </span> <span style="font-weight: lighter">│</span>
+    <span style="font-weight: lighter">│</span> <span style="font-weight: bold">Exactly one argument must be passed in. </span><span style="font-weight: bold; color: #e60000">(required)</span><span style="font-weight: bold">     </span> <span style="font-weight: lighter">│</span>
     <span style="font-weight: lighter">│</span> <span style="font-weight: lighter">──────────────────────────────────────────────────     </span> <span style="font-weight: lighter">│</span>
     <span style="font-weight: lighter">│</span> --target-stream <span style="font-weight: bold">{stdout,stderr}</span>                         <span style="font-weight: lighter">│</span>
     <span style="font-weight: lighter">│</span>                         <span style="color: #008080">(default: None)</span>                 <span style="font-weight: lighter">│</span>
@@ -1069,7 +1065,7 @@ Show the help message:
     <span style="font-weight: lighter">╰─────────────────────────────────────────────────────────╯</span>
     </pre>
 
-Valid: choosing one required argument.
+
 
 .. raw:: html
 
@@ -1085,7 +1081,7 @@ Valid: choosing one required argument.
     <strong style="opacity: 0.7; padding-bottom: 0.5em; display: inline-block"><span style="user-select: none">$ </span>python ./14_mutex.py --target-file /tmp/output.txt</strong>
     </pre>
 
-Valid: optional mutex arguments.
+
 
 .. raw:: html
 
@@ -1104,7 +1100,7 @@ Valid: optional mutex arguments.
     target_stream=None target_file=PosixPath('/tmp/output.txt')
     </pre>
 
-Invalid: both required arguments specified.
+
 
 .. raw:: html
 
@@ -1117,7 +1113,7 @@ Invalid: both required arguments specified.
     <span style="color: #e60000">╰───────────────────────────────────────────────────────────────────╯</span>
     </pre>
 
-Invalid: both optional arguments specified.
+
 
 .. raw:: html
 

--- a/examples/01_basics/14_mutex.py
+++ b/examples/01_basics/14_mutex.py
@@ -1,0 +1,51 @@
+"""Mutually Exclusive Groups
+
+:func:`tyro.conf.create_mutex_group()` can be used to create mutually exclusive
+argument groups, where either exactly one (required=True) or at most one
+(required=False) argument from the group can be specified.
+
+Usage:
+
+    python ./14_mutex.py --help
+    python ./14_mutex.py --target-stream stdout
+    python ./14_mutex.py --target-file /tmp/output.txt
+    python ./14_mutex.py --target-stream stdout --verbose
+    python ./14_mutex.py --target-file /tmp/output.txt --very-verbose
+    python ./14_mutex.py --target-stream stdout --target-file /tmp/output.txt
+    python ./14_mutex.py --target-stream stdout --verbose --very-verbose
+"""
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+import tyro
+
+RequiredGroup = tyro.conf.create_mutex_group(required=True)
+OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+
+def main(
+    # Exactly one of --target-stream or --target-file must be specified.
+    target_stream: Annotated[Literal["stdout", "stderr"] | None, RequiredGroup] = None,
+    target_file: Annotated[Path | None, RequiredGroup] = None,
+    # Either --verbose or --very-verbose can be specified (but not both).
+    verbose: Annotated[bool, OptionalGroup] = False,
+    very_verbose: Annotated[bool, OptionalGroup] = False,
+) -> None:
+    """Demonstrate mutually exclusive argument groups."""
+    if very_verbose or verbose:
+        print(f"{target_stream=} {target_file=}")
+    if very_verbose:
+        print(f"{target_stream=} {target_file=}")
+
+
+if __name__ == "__main__":
+    tyro.cli(
+        main,
+        # `DisallowNone` prevents `None` from being a valid choice for
+        # `--target-stream` and `--target-file`.
+        #
+        # `FlagCreatePairsOff` prevents `--no-verbose` and `--no-very-verbose` from
+        # being created.
+        config=(tyro.conf.DisallowNone, tyro.conf.FlagCreatePairsOff),
+    )

--- a/examples/01_basics/14_mutex.py
+++ b/examples/01_basics/14_mutex.py
@@ -6,6 +6,7 @@ argument groups, where either exactly one (required=True) or at most one
 
 Usage:
 
+    python ./14_mutex.py
     python ./14_mutex.py --help
     python ./14_mutex.py --target-stream stdout
     python ./14_mutex.py --target-file /tmp/output.txt

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -7,6 +7,7 @@ import numbers
 import warnings
 from typing import Any, Callable, Dict, List, Set, Tuple, Type, TypeVar, Union, cast
 
+from rich.text import Text
 from typing_extensions import Annotated, get_args, get_origin
 
 from tyro.constructors._registry import ConstructorRegistry
@@ -26,6 +27,7 @@ from . import (
 from ._typing import TypeForm
 from ._typing_compat import is_typing_union
 from .conf import _confstruct, _markers
+from .conf._mutex_group import _MutexGroupConfig
 from .constructors._primitive_spec import (
     PrimitiveConstructorSpec,
     UnsupportedTypeAnnotationError,
@@ -266,46 +268,64 @@ class ParserSpecification:
         positional_group = parser._action_groups[0]
         assert positional_group.title == "positional arguments"
 
+        exclusive_group_from_group_conf: Dict[
+            _MutexGroupConfig, argparse._MutuallyExclusiveGroup
+        ] = {}
+
         # Add each argument group. Groups with only suppressed arguments won't
         # be added.
         for arg in self.args:
             # Don't add suppressed arguments to the parser.
             if arg.is_suppressed():
                 continue
-
-            group_name = (
-                arg.extern_prefix
-                if arg.field.argconf.name != ""
-                # If the field name is "erased", we'll place the argument in
-                # the parent's group.
-                #
-                # This is to avoid "issue 1" in:
-                # https://github.com/brentyi/tyro/issues/183
-                #
-                # Setting `tyro.conf.arg(name="")` should generally be
-                # discouraged, so this will rarely matter.
-                else arg.extern_prefix.rpartition(".")[0]
-            )
-            if group_name not in group_from_group_name:
-                description = (
-                    parent.helptext_from_intern_prefixed_field_name.get(
-                        arg.intern_prefix
-                    )
-                    if parent is not None
-                    else None
-                )
-                group_from_group_name[group_name] = parser.add_argument_group(
-                    format_group_name(group_name),
-                    description=description,
-                )
-
-            # Add each argument.
-            if arg.field.is_positional():
+            elif arg.field.is_positional():
                 arg.add_argument(positional_group)
                 continue
-
-            assert group_name in group_from_group_name
-            arg.add_argument(group_from_group_name[group_name])
+            elif arg.field.mutex_group is not None:
+                group_conf = arg.field.mutex_group
+                if group_conf not in exclusive_group_from_group_conf:
+                    exclusive_group_from_group_conf[group_conf] = (
+                        parser.add_argument_group(
+                            "mutually exclusive",
+                            description=_argparse_formatter.str_from_rich(
+                                Text.from_markup(
+                                    "Exactly one argument must be passed in. [red](required)[/red]"
+                                )
+                            )
+                            if group_conf.required
+                            else "At most one argument can overridden.",
+                        ).add_mutually_exclusive_group(required=group_conf.required)
+                    )
+                group = exclusive_group_from_group_conf[group_conf]
+                arg.add_argument(group)
+            else:
+                group_name = (
+                    arg.extern_prefix
+                    if arg.field.argconf.name != ""
+                    # If the field name is "erased", we'll place the argument in
+                    # the parent's group.
+                    #
+                    # This is to avoid "issue 1" in:
+                    # https://github.com/brentyi/tyro/issues/183
+                    #
+                    # Setting `tyro.conf.arg(name="")` should generally be
+                    # discouraged, so this will rarely matter.
+                    else arg.extern_prefix.rpartition(".")[0]
+                )
+                if group_name not in group_from_group_name:
+                    description = (
+                        parent.helptext_from_intern_prefixed_field_name.get(
+                            arg.intern_prefix
+                        )
+                        if parent is not None
+                        else None
+                    )
+                    group_from_group_name[group_name] = parser.add_argument_group(
+                        format_group_name(group_name),
+                        description=description,
+                    )
+                group = group_from_group_name[group_name]
+                arg.add_argument(group)
 
         for child in self.child_from_prefix.values():
             child.apply_args(parser, parent=self)

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -251,6 +251,10 @@ class ParserSpecification:
         self,
         parser: argparse.ArgumentParser,
         parent: ParserSpecification | None = None,
+        exclusive_group_from_group_conf: Dict[
+            _MutexGroupConfig, argparse._MutuallyExclusiveGroup
+        ]
+        | None = None,
     ) -> None:
         """Create defined arguments and subparsers."""
 
@@ -268,9 +272,9 @@ class ParserSpecification:
         positional_group = parser._action_groups[0]
         assert positional_group.title == "positional arguments"
 
-        exclusive_group_from_group_conf: Dict[
-            _MutexGroupConfig, argparse._MutuallyExclusiveGroup
-        ] = {}
+        # Inherit mutex groups from parent or create new dict
+        if exclusive_group_from_group_conf is None:
+            exclusive_group_from_group_conf = {}
 
         # Add each argument group. Groups with only suppressed arguments won't
         # be added.
@@ -328,7 +332,11 @@ class ParserSpecification:
                 arg.add_argument(group)
 
         for child in self.child_from_prefix.values():
-            child.apply_args(parser, parent=self)
+            child.apply_args(
+                parser,
+                parent=self,
+                exclusive_group_from_group_conf=exclusive_group_from_group_conf,
+            )
 
 
 def handle_field(

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -289,7 +289,7 @@ class ParserSpecification:
                             "mutually exclusive",
                             description=_argparse_formatter.str_from_rich(
                                 Text.from_markup(
-                                    "Exactly one argument must be passed in. [red](required)[/red]"
+                                    "Exactly one argument must be passed in. [bright_red](required)[/bright_red]"
                                 )
                             )
                             if group_conf.required

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -23,6 +23,7 @@ from ._confstruct import arg as arg
 from ._confstruct import subcommand as subcommand
 from ._markers import AvoidSubcommands as AvoidSubcommands
 from ._markers import ConsolidateSubcommandArgs as ConsolidateSubcommandArgs
+from ._markers import DisallowNone as DisallowNone
 from ._markers import EnumChoicesFromValues as EnumChoicesFromValues
 from ._markers import Fixed as Fixed
 from ._markers import FlagConversionOff as FlagConversionOff
@@ -37,3 +38,4 @@ from ._markers import SuppressFixed as SuppressFixed
 from ._markers import UseAppendAction as UseAppendAction
 from ._markers import UseCounterAction as UseCounterAction
 from ._markers import configure as configure
+from ._mutex_group import create_mutex_group as create_mutex_group

--- a/src/tyro/conf/_confstruct.py
+++ b/src/tyro/conf/_confstruct.py
@@ -29,7 +29,7 @@ def subcommand(
     prefix_name: bool = True,
     constructor: None = None,
     constructor_factory: Callable[[], type | Callable[..., Any]] | None = None,
-) -> Any: ...
+) -> object: ...
 
 
 @overload
@@ -41,7 +41,7 @@ def subcommand(
     prefix_name: bool = True,
     constructor: type | Callable[..., Any] | None = None,
     constructor_factory: None = None,
-) -> Any: ...
+) -> object: ...
 
 
 def subcommand(
@@ -52,7 +52,7 @@ def subcommand(
     prefix_name: bool = True,
     constructor: type | Callable[..., Any] | None = None,
     constructor_factory: Callable[[], type | Callable[..., Any]] | None = None,
-) -> Any:
+) -> object:
     """Configure subcommand behavior for Union types in the CLI.
 
     When tyro encounters a Union type over structures, it creates subcommands in the
@@ -137,7 +137,7 @@ def arg(
     constructor: None = None,
     constructor_factory: Callable[[], type | Callable[..., Any]] | None = None,
     default: Any = MISSING_NONPROP,
-) -> Any: ...
+) -> object: ...
 
 
 @overload
@@ -152,7 +152,7 @@ def arg(
     constructor: type | Callable[..., Any] | None = None,
     constructor_factory: None = None,
     default: Any = MISSING_NONPROP,
-) -> Any: ...
+) -> object: ...
 
 
 def arg(
@@ -166,7 +166,7 @@ def arg(
     constructor: type | Callable[..., Any] | None = None,
     constructor_factory: Callable[[], type | Callable[..., Any]] | None = None,
     default: Any = MISSING_NONPROP,
-) -> Any:
+) -> object:
     """Provides fine-grained control over individual CLI argument properties.
 
     The `arg()` function allows you to customize how individual arguments appear and

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -357,6 +357,24 @@ Triple-quoted docstrings on fields are still used for helptext
 even when this marker is applied.
 """
 
+DisallowNone = Annotated[T, None]
+"""Disallow passing `None` in via the command-line interface for union types
+containing ``None``.
+
+Example::
+
+    @dataclass
+    class Config:
+        field: DisallowNone[int | None] = None
+
+In this case, `None` can still be used as a default value. However, ``--field
+None`` will raise an error. This can be useful when used in conjunction with
+:func:`tyro.conf.mutually_exclusive_group`.
+
+This only impacts union types. For cases like ``field: None`` where only
+``None`` is allowed, we still accept ``--field None``.
+"""
+
 
 CallableType = TypeVar("CallableType", bound=Callable)
 

--- a/src/tyro/conf/_mutex_group.py
+++ b/src/tyro/conf/_mutex_group.py
@@ -6,7 +6,7 @@ class _MutexGroupConfig:
     required: bool = False
 
 
-def create_mutex_group(*, required: bool) -> _MutexGroupConfig:
+def create_mutex_group(*, required: bool) -> object:
     """Create a mutually exclusive group for command-line arguments.
 
     When multiple arguments are annotated with the same mutex group, they become

--- a/src/tyro/conf/_mutex_group.py
+++ b/src/tyro/conf/_mutex_group.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, eq=False)
+class _MutexGroupConfig:
+    required: bool = False
+
+
+def create_mutex_group(*, required: bool) -> _MutexGroupConfig:
+    """Create a mutually exclusive group.
+
+    # TODO: add example. note that `tyro.conf.DisallowNone` may be useful.
+    """
+    return _MutexGroupConfig(required=required)

--- a/src/tyro/conf/_mutex_group.py
+++ b/src/tyro/conf/_mutex_group.py
@@ -7,8 +7,43 @@ class _MutexGroupConfig:
 
 
 def create_mutex_group(*, required: bool) -> _MutexGroupConfig:
-    """Create a mutually exclusive group.
+    """Create a mutually exclusive group for command-line arguments.
 
-    # TODO: add example. note that `tyro.conf.DisallowNone` may be useful.
+    When multiple arguments are annotated with the same mutex group, they become
+    mutually exclusive - only one can be specified at a time via the CLI.
+
+    Args:
+        required: If True, exactly one argument from the group must be specified.
+                  If False, at most one argument from the group can be specified.
+
+    Returns:
+        A configuration object to be used with :py:data:`typing.Annotated`.
+
+    Example::
+
+        import tyro
+        from typing import Annotated
+
+        # Create mutex groups.
+        RequiredGroup = tyro.conf.create_mutex_group(required=True)
+        OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+        def main(
+            # Exactly one of these must be specified.
+            option_a: Annotated[str | None, RequiredGroup] = None,
+            option_b: Annotated[int | None, RequiredGroup] = None,
+            # At most one of these can be specified.
+            verbose: Annotated[bool, OptionalGroup] = False,
+            quiet: Annotated[bool, OptionalGroup] = False,
+        ) -> None:
+            print(f"{option_a=}, {option_b=}, {verbose=}, {quiet=}")
+
+        # DisallowNone prevents None from being a valid CLI choice.
+        tyro.cli(main, config=(tyro.conf.DisallowNone,))
+
+    In this example:
+    - The user must specify either ``--option-a`` or ``--option-b``, but not both.
+    - The user can optionally specify either ``--verbose`` or ``--quiet``, but not both.
+    - Using :data:`DisallowNone` ensures that ``--option-a None`` is not accepted.
     """
     return _MutexGroupConfig(required=required)

--- a/tests/test_mutex_groups.py
+++ b/tests/test_mutex_groups.py
@@ -296,3 +296,58 @@ def test_mutex_group_with_defaults_not_none():
     # Should fail when both are overridden.
     with pytest.raises(SystemExit):
         tyro.cli(main, args=["--verbose", "--verbosity-level", "2"])
+
+
+def test_nested_mutex_groups():
+    """Test that mutex groups work correctly across nested dataclasses."""
+    SharedGroup = tyro.conf.create_mutex_group(required=False)
+
+    @dataclasses.dataclass
+    class Inner:
+        """Inner config."""
+
+        option_a: Annotated[int, SharedGroup] = 1
+        option_b: Annotated[int, SharedGroup] = 2
+
+    @dataclasses.dataclass
+    class Outer:
+        """Outer config."""
+
+        inner: Inner = dataclasses.field(default_factory=Inner)
+        option_c: Annotated[int, SharedGroup] = 3
+        option_d: Annotated[int, SharedGroup] = 4
+
+    # Should use defaults when nothing is specified.
+    config = tyro.cli(Outer, args=[])
+    assert config.inner.option_a == 1
+    assert config.inner.option_b == 2
+    assert config.option_c == 3
+    assert config.option_d == 4
+
+    # Should allow overriding a single option.
+    config = tyro.cli(Outer, args=["--option-c", "10"])
+    assert config.option_c == 10
+    assert config.option_d == 4
+    assert config.inner.option_a == 1
+    assert config.inner.option_b == 2
+
+    # Should allow overriding a nested option.
+    config = tyro.cli(Outer, args=["--inner.option-a", "20"])
+    assert config.inner.option_a == 20
+    assert config.inner.option_b == 2
+    assert config.option_c == 3
+    assert config.option_d == 4
+
+    # Should fail when options from the same group are overridden, even across nesting levels.
+    with pytest.raises(SystemExit):
+        tyro.cli(Outer, args=["--option-c", "10", "--option-d", "20"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Outer, args=["--inner.option-a", "10", "--inner.option-b", "20"])
+
+    # Crucially, should fail when mixing options from different nesting levels.
+    with pytest.raises(SystemExit):
+        tyro.cli(Outer, args=["--option-c", "10", "--inner.option-a", "20"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Outer, args=["--option-d", "10", "--inner.option-b", "20"])

--- a/tests/test_mutex_groups.py
+++ b/tests/test_mutex_groups.py
@@ -1,0 +1,298 @@
+"""Tests for mutually exclusive argument groups."""
+
+import dataclasses
+from pathlib import Path
+from typing import Literal, Optional, Tuple, Union
+
+import pytest
+from helptext_utils import get_helptext_with_checks
+from typing_extensions import Annotated
+
+import tyro
+
+
+def test_required_mutex_group_basic():
+    """Test basic required mutex group functionality."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        option_a: Annotated[Union[str, None], RequiredGroup] = None,
+        option_b: Annotated[Union[int, None], RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int]]:
+        return option_a, option_b
+
+    # Should work with just option_a.
+    assert tyro.cli(main, args=["--option-a", "hello"]) == ("hello", None)
+
+    # Should work with just option_b.
+    assert tyro.cli(main, args=["--option-b", "42"]) == (None, 42)
+
+    # Should fail when both are provided.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "hello", "--option-b", "42"])
+
+    # Should fail when neither is provided.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=[])
+
+
+def test_optional_mutex_group_basic():
+    """Test basic optional mutex group functionality."""
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        verbose: Annotated[bool, OptionalGroup] = False,
+        quiet: Annotated[bool, OptionalGroup] = False,
+    ) -> Tuple[bool, bool]:
+        return verbose, quiet
+
+    # Should work with neither option.
+    assert tyro.cli(main, args=[]) == (False, False)
+
+    # Should work with just verbose.
+    assert tyro.cli(main, args=["--verbose"]) == (True, False)
+
+    # Should work with just quiet.
+    assert tyro.cli(main, args=["--quiet"]) == (False, True)
+
+    # Should fail when both are provided.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--verbose", "--quiet"])
+
+
+def test_multiple_mutex_groups():
+    """Test multiple independent mutex groups in the same function."""
+    GroupA = tyro.conf.create_mutex_group(required=True)
+    GroupB = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        option_a1: Annotated[Union[str, None], GroupA] = None,
+        option_a2: Annotated[Union[str, None], GroupA] = None,
+        option_b1: Annotated[bool, GroupB] = False,
+        option_b2: Annotated[bool, GroupB] = False,
+    ) -> Tuple[Optional[str], Optional[str], bool, bool]:
+        return option_a1, option_a2, option_b1, option_b2
+
+    # Should work with one from group A and one from group B.
+    assert tyro.cli(main, args=["--option-a1", "test", "--option-b1"]) == (
+        "test",
+        None,
+        True,
+        False,
+    )
+
+    # Should work with one from group A and none from group B.
+    assert tyro.cli(main, args=["--option-a2", "hello"]) == (
+        None,
+        "hello",
+        False,
+        False,
+    )
+
+    # Should fail with both from group A.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a1", "a", "--option-a2", "b"])
+
+    # Should fail with both from group B.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a1", "test", "--option-b1", "--option-b2"])
+
+
+def test_mutex_group_with_disallow_none():
+    """Test mutex groups with DisallowNone configuration."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        option_a: Annotated[Union[str, None], RequiredGroup] = None,
+        option_b: Annotated[Union[int, None], RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int]]:
+        return option_a, option_b
+
+    # Regular values should work both with and without DisallowNone.
+    assert tyro.cli(main, args=["--option-a", "hello"]) == ("hello", None)
+    assert tyro.cli(
+        main, args=["--option-a", "hello"], config=(tyro.conf.DisallowNone,)
+    ) == ("hello", None)
+
+    # DisallowNone prevents None from being passed via CLI.
+    # Note: For string types, "None" is treated as the string "None", not the None value.
+    # So this test validates that DisallowNone works with the mutex group feature.
+
+
+def test_mutex_group_with_literal_types():
+    """Test mutex groups with Literal types."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        mode: Annotated[Optional[Literal["fast", "slow"]], RequiredGroup] = None,
+        threads: Annotated[Union[int, None], RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int]]:
+        return mode, threads
+
+    # Should work with literal choices.
+    assert tyro.cli(main, args=["--mode", "fast"]) == ("fast", None)
+    assert tyro.cli(main, args=["--mode", "slow"]) == ("slow", None)
+
+    # Should fail with invalid literal value.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--mode", "medium"])
+
+    # Should work with the other option.
+    assert tyro.cli(main, args=["--threads", "4"]) == (None, 4)
+
+
+def test_mutex_group_with_path_types():
+    """Test mutex groups with Path types."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        input_file: Annotated[Optional[Path], RequiredGroup] = None,
+        input_dir: Annotated[Optional[Path], RequiredGroup] = None,
+    ) -> Tuple[Optional[Path], Optional[Path]]:
+        return input_file, input_dir
+
+    # Should work with file path.
+    result = tyro.cli(main, args=["--input-file", "/tmp/test.txt"])
+    assert result == (Path("/tmp/test.txt"), None)
+
+    # Should work with directory path.
+    result = tyro.cli(main, args=["--input-dir", "/home/user"])
+    assert result == (None, Path("/home/user"))
+
+
+def test_mutex_group_in_dataclass():
+    """Test mutex groups within dataclass fields."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    @dataclasses.dataclass
+    class Config:
+        # Required mutex group.
+        option_a: Annotated[Union[str, None], RequiredGroup] = None
+        option_b: Annotated[Union[int, None], RequiredGroup] = None
+        # Optional mutex group.
+        verbose: Annotated[bool, OptionalGroup] = False
+        quiet: Annotated[bool, OptionalGroup] = False
+
+    # Should work with valid combinations.
+    config = tyro.cli(Config, args=["--option-a", "test", "--verbose"])
+    assert config.option_a == "test"
+    assert config.option_b is None
+    assert config.verbose is True
+    assert config.quiet is False
+
+    # Should fail with invalid combinations.
+    with pytest.raises(SystemExit):
+        tyro.cli(Config, args=["--option-a", "a", "--option-b", "1"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Config, args=["--option-a", "test", "--verbose", "--quiet"])
+
+
+def test_mutex_group_helptext():
+    """Test that mutex groups appear correctly in helptext."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        option_a: Annotated[Union[str, None], RequiredGroup] = None,
+        option_b: Annotated[Union[int, None], RequiredGroup] = None,
+        verbose: Annotated[bool, OptionalGroup] = False,
+        quiet: Annotated[bool, OptionalGroup] = False,
+    ) -> None:
+        """Test function with mutex groups."""
+        pass
+
+    helptext = get_helptext_with_checks(main)
+
+    # Check for mutually exclusive section markers.
+    assert "mutually exclusive" in helptext.lower()
+
+    # Check that required group is marked as required.
+    assert "required" in helptext.lower()
+
+    # Check that options are listed.
+    assert "--option-a" in helptext
+    assert "--option-b" in helptext
+    assert "--verbose" in helptext
+    assert "--quiet" in helptext
+
+
+def test_mutex_group_with_flag_create_pairs_off():
+    """Test mutex groups with FlagCreatePairsOff configuration."""
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        verbose: Annotated[bool, OptionalGroup] = False,
+        quiet: Annotated[bool, OptionalGroup] = False,
+    ) -> Tuple[bool, bool]:
+        return verbose, quiet
+
+    # With FlagCreatePairsOff, only positive flags should be created.
+    helptext = get_helptext_with_checks(main, config=(tyro.conf.FlagCreatePairsOff,))
+
+    # Should have positive flags.
+    assert "--verbose" in helptext
+    assert "--quiet" in helptext
+
+    # Should not have negative flags.
+    assert "--no-verbose" not in helptext
+    assert "--no-quiet" not in helptext
+
+    # Functionality should still work.
+    assert tyro.cli(
+        main, args=["--verbose"], config=(tyro.conf.FlagCreatePairsOff,)
+    ) == (True, False)
+
+
+def test_three_way_mutex_group():
+    """Test mutex group with three options."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        option_a: Annotated[Union[str, None], RequiredGroup] = None,
+        option_b: Annotated[Union[int, None], RequiredGroup] = None,
+        option_c: Annotated[Union[float, None], RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int], Optional[float]]:
+        return option_a, option_b, option_c
+
+    # Should work with any single option.
+    assert tyro.cli(main, args=["--option-a", "test"]) == ("test", None, None)
+    assert tyro.cli(main, args=["--option-b", "42"]) == (None, 42, None)
+    assert tyro.cli(main, args=["--option-c", "3.14"]) == (None, None, 3.14)
+
+    # Should fail with any two options.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "a", "--option-b", "1"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-b", "1", "--option-c", "2.0"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "a", "--option-c", "2.0"])
+
+    # Should fail with all three options.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "a", "--option-b", "1", "--option-c", "2.0"])
+
+
+def test_mutex_group_with_defaults_not_none():
+    """Test mutex groups where defaults are not None."""
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        verbose: Annotated[bool, OptionalGroup] = False,
+        verbosity_level: Annotated[int, OptionalGroup] = 0,
+    ) -> Tuple[bool, int]:
+        return verbose, verbosity_level
+
+    # Should use defaults when neither is specified.
+    assert tyro.cli(main, args=[]) == (False, 0)
+
+    # Should override one default.
+    assert tyro.cli(main, args=["--verbose"]) == (True, 0)
+    assert tyro.cli(main, args=["--verbosity-level", "2"]) == (False, 2)
+
+    # Should fail when both are overridden.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--verbose", "--verbosity-level", "2"])

--- a/tests/test_py311_generated/test_add_help_generated.py
+++ b/tests/test_py311_generated/test_add_help_generated.py
@@ -1,0 +1,243 @@
+"""Tests for add_help parameter functionality."""
+
+import dataclasses
+import io
+import sys
+
+import pytest
+
+import tyro
+
+
+@dataclasses.dataclass
+class SimpleConfig:
+    """A simple configuration class."""
+
+    value: int
+    name: str = "default"
+
+
+def simple_function(x: int, y: str = "hello") -> str:
+    """A simple function for testing."""
+    return f"{x}:{y}"
+
+
+def test_cli_add_help_false():
+    """Test that add_help=False prevents help from being added."""
+    # Should raise an error when --help is provided with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.cli(SimpleConfig, args=["--help"], add_help=False)
+    assert excinfo.value.code == 2  # Should fail with parsing error, not help display
+
+
+def test_cli_add_help_true():
+    """Test that add_help=True (default) allows help."""
+    # Should show help and exit with code 0
+    with pytest.raises(SystemExit) as excinfo:
+        # Redirect stdout to capture help output
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            tyro.cli(SimpleConfig, args=["--help"], add_help=True)
+        finally:
+            sys.stdout = old_stdout
+    assert excinfo.value.code == 0  # Should exit cleanly after showing help
+
+
+def test_cli_default_add_help():
+    """Test that add_help defaults to True."""
+    # Should show help and exit with code 0
+    with pytest.raises(SystemExit) as excinfo:
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            tyro.cli(SimpleConfig, args=["--help"])
+        finally:
+            sys.stdout = old_stdout
+    assert excinfo.value.code == 0
+
+
+def test_get_parser_add_help_false():
+    """Test that get_parser with add_help=False doesn't add help option."""
+    parser = tyro.extras.get_parser(SimpleConfig, add_help=False)
+    assert "-h" not in parser._option_string_actions
+    assert "--help" not in parser._option_string_actions
+
+
+def test_get_parser_add_help_true():
+    """Test that get_parser with add_help=True adds help option."""
+    parser = tyro.extras.get_parser(SimpleConfig, add_help=True)
+    assert (
+        "-h" in parser._option_string_actions
+        or "--help" in parser._option_string_actions
+    )
+
+
+def test_get_parser_default_add_help():
+    """Test that get_parser defaults to add_help=True."""
+    parser = tyro.extras.get_parser(SimpleConfig)
+    assert (
+        "-h" in parser._option_string_actions
+        or "--help" in parser._option_string_actions
+    )
+
+
+def test_function_cli_add_help():
+    """Test add_help works with function targets."""
+    # Test with add_help=False
+    result = tyro.cli(simple_function, args=["--x", "42"], add_help=False)
+    assert result == "42:hello"
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.cli(simple_function, args=["--help"], add_help=False)
+    assert excinfo.value.code == 2
+
+
+def test_subcommand_app_add_help():
+    """Test add_help parameter with SubcommandApp."""
+    from tyro.extras import SubcommandApp
+
+    app = SubcommandApp()
+
+    @app.command
+    def cmd1(x: int) -> int:
+        return x
+
+    @app.command
+    def cmd2(y: str) -> str:
+        return y
+
+    # Test with add_help=False
+    result = app.cli(args=["cmd1", "--x", "5"], add_help=False)
+    assert result == 5
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        app.cli(args=["--help"], add_help=False)
+    assert excinfo.value.code == 2
+
+
+def test_subcommand_cli_from_dict_add_help():
+    """Test add_help parameter with subcommand_cli_from_dict."""
+
+    def cmd1(x: int) -> int:
+        return x * 2
+
+    def cmd2(y: str) -> str:
+        return y.upper()
+
+    subcommands = {"multiply": cmd1, "uppercase": cmd2}
+
+    # Test with add_help=False
+    result = tyro.extras.subcommand_cli_from_dict(
+        subcommands, args=["multiply", "--x", "3"], add_help=False
+    )
+    assert result == 6
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.extras.subcommand_cli_from_dict(
+            subcommands, args=["--help"], add_help=False
+        )
+    assert excinfo.value.code == 2
+
+
+def test_overridable_config_cli_add_help():
+    """Test add_help parameter with overridable_config_cli."""
+
+    @dataclasses.dataclass
+    class Config:
+        a: int
+        b: str
+
+    configs = {
+        "small": ("Small config", Config(1, "small")),
+        "big": ("Big config", Config(100, "big")),
+    }
+
+    # Test with add_help=False
+    result = tyro.extras.overridable_config_cli(configs, args=["small"], add_help=False)
+    assert result.a == 1
+    assert result.b == "small"
+
+    # Test that --help fails with add_help=False
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.extras.overridable_config_cli(configs, args=["--help"], add_help=False)
+    assert excinfo.value.code == 2
+
+
+def test_subparsers_respect_add_help():
+    """Test that subparsers inherit the add_help setting from parent parser."""
+
+    @dataclasses.dataclass
+    class ConfigA:
+        value_a: int = 1
+
+    @dataclasses.dataclass
+    class ConfigB:
+        value_b: str = "test"
+
+    # Test with add_help=False - subparsers should also not have help
+    with pytest.raises(SystemExit) as excinfo:
+        tyro.cli(ConfigA | ConfigB, args=["config-a", "--help"], add_help=False)
+    assert excinfo.value.code == 2  # Should fail, not show help
+
+    # Test with add_help=True - subparsers should have help
+    with pytest.raises(SystemExit) as excinfo:
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            tyro.cli(ConfigA | ConfigB, args=["config-a", "--help"], add_help=True)
+        finally:
+            sys.stdout = old_stdout
+    assert excinfo.value.code == 0  # Should show help
+
+    # Test that subparser works normally with add_help=False
+    result = tyro.cli(ConfigA | ConfigB, args=["config-a"], add_help=False)
+    assert isinstance(result, ConfigA)
+    assert result.value_a == 1
+
+
+def test_return_unknown_args_with_add_help_false():
+    """Test that --help/-h are returned as unknown args when add_help=False and return_unknown_args=True."""
+
+    @dataclasses.dataclass
+    class Config:
+        value: int = 5
+
+    # Test that --help is returned in unknown args
+    result, unknown = tyro.cli(
+        Config, args=["--help"], add_help=False, return_unknown_args=True
+    )
+    assert unknown == ["--help"]
+    assert result.value == 5
+
+    # Test that -h is returned in unknown args
+    result, unknown = tyro.cli(
+        Config, args=["-h"], add_help=False, return_unknown_args=True
+    )
+    assert unknown == ["-h"]
+    assert result.value == 5
+
+    # Test with both --help and other unknown args
+    result, unknown = tyro.cli(
+        Config,
+        args=["--help", "--unknown", "arg"],
+        add_help=False,
+        return_unknown_args=True,
+    )
+    assert "--help" in unknown
+    assert "--unknown" in unknown
+    assert "arg" in unknown
+    assert result.value == 5
+
+    # Test that with add_help=True, --help still shows help (doesn't return unknown args)
+    with pytest.raises(SystemExit) as excinfo:
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            tyro.cli(Config, args=["--help"], add_help=True, return_unknown_args=True)
+        finally:
+            sys.stdout = old_stdout
+    assert excinfo.value.code == 0  # Should exit cleanly after showing help

--- a/tests/test_py311_generated/test_mutex_groups_generated.py
+++ b/tests/test_py311_generated/test_mutex_groups_generated.py
@@ -1,0 +1,297 @@
+"""Tests for mutually exclusive argument groups."""
+
+import dataclasses
+from pathlib import Path
+from typing import Annotated, Literal, Optional, Tuple
+
+import pytest
+from helptext_utils import get_helptext_with_checks
+
+import tyro
+
+
+def test_required_mutex_group_basic():
+    """Test basic required mutex group functionality."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        option_a: Annotated[str | None, RequiredGroup] = None,
+        option_b: Annotated[int | None, RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int]]:
+        return option_a, option_b
+
+    # Should work with just option_a.
+    assert tyro.cli(main, args=["--option-a", "hello"]) == ("hello", None)
+
+    # Should work with just option_b.
+    assert tyro.cli(main, args=["--option-b", "42"]) == (None, 42)
+
+    # Should fail when both are provided.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "hello", "--option-b", "42"])
+
+    # Should fail when neither is provided.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=[])
+
+
+def test_optional_mutex_group_basic():
+    """Test basic optional mutex group functionality."""
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        verbose: Annotated[bool, OptionalGroup] = False,
+        quiet: Annotated[bool, OptionalGroup] = False,
+    ) -> Tuple[bool, bool]:
+        return verbose, quiet
+
+    # Should work with neither option.
+    assert tyro.cli(main, args=[]) == (False, False)
+
+    # Should work with just verbose.
+    assert tyro.cli(main, args=["--verbose"]) == (True, False)
+
+    # Should work with just quiet.
+    assert tyro.cli(main, args=["--quiet"]) == (False, True)
+
+    # Should fail when both are provided.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--verbose", "--quiet"])
+
+
+def test_multiple_mutex_groups():
+    """Test multiple independent mutex groups in the same function."""
+    GroupA = tyro.conf.create_mutex_group(required=True)
+    GroupB = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        option_a1: Annotated[str | None, GroupA] = None,
+        option_a2: Annotated[str | None, GroupA] = None,
+        option_b1: Annotated[bool, GroupB] = False,
+        option_b2: Annotated[bool, GroupB] = False,
+    ) -> Tuple[Optional[str], Optional[str], bool, bool]:
+        return option_a1, option_a2, option_b1, option_b2
+
+    # Should work with one from group A and one from group B.
+    assert tyro.cli(main, args=["--option-a1", "test", "--option-b1"]) == (
+        "test",
+        None,
+        True,
+        False,
+    )
+
+    # Should work with one from group A and none from group B.
+    assert tyro.cli(main, args=["--option-a2", "hello"]) == (
+        None,
+        "hello",
+        False,
+        False,
+    )
+
+    # Should fail with both from group A.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a1", "a", "--option-a2", "b"])
+
+    # Should fail with both from group B.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a1", "test", "--option-b1", "--option-b2"])
+
+
+def test_mutex_group_with_disallow_none():
+    """Test mutex groups with DisallowNone configuration."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        option_a: Annotated[str | None, RequiredGroup] = None,
+        option_b: Annotated[int | None, RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int]]:
+        return option_a, option_b
+
+    # Regular values should work both with and without DisallowNone.
+    assert tyro.cli(main, args=["--option-a", "hello"]) == ("hello", None)
+    assert tyro.cli(
+        main, args=["--option-a", "hello"], config=(tyro.conf.DisallowNone,)
+    ) == ("hello", None)
+
+    # DisallowNone prevents None from being passed via CLI.
+    # Note: For string types, "None" is treated as the string "None", not the None value.
+    # So this test validates that DisallowNone works with the mutex group feature.
+
+
+def test_mutex_group_with_literal_types():
+    """Test mutex groups with Literal types."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        mode: Annotated[Optional[Literal["fast", "slow"]], RequiredGroup] = None,
+        threads: Annotated[int | None, RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int]]:
+        return mode, threads
+
+    # Should work with literal choices.
+    assert tyro.cli(main, args=["--mode", "fast"]) == ("fast", None)
+    assert tyro.cli(main, args=["--mode", "slow"]) == ("slow", None)
+
+    # Should fail with invalid literal value.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--mode", "medium"])
+
+    # Should work with the other option.
+    assert tyro.cli(main, args=["--threads", "4"]) == (None, 4)
+
+
+def test_mutex_group_with_path_types():
+    """Test mutex groups with Path types."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        input_file: Annotated[Optional[Path], RequiredGroup] = None,
+        input_dir: Annotated[Optional[Path], RequiredGroup] = None,
+    ) -> Tuple[Optional[Path], Optional[Path]]:
+        return input_file, input_dir
+
+    # Should work with file path.
+    result = tyro.cli(main, args=["--input-file", "/tmp/test.txt"])
+    assert result == (Path("/tmp/test.txt"), None)
+
+    # Should work with directory path.
+    result = tyro.cli(main, args=["--input-dir", "/home/user"])
+    assert result == (None, Path("/home/user"))
+
+
+def test_mutex_group_in_dataclass():
+    """Test mutex groups within dataclass fields."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    @dataclasses.dataclass
+    class Config:
+        # Required mutex group.
+        option_a: Annotated[str | None, RequiredGroup] = None
+        option_b: Annotated[int | None, RequiredGroup] = None
+        # Optional mutex group.
+        verbose: Annotated[bool, OptionalGroup] = False
+        quiet: Annotated[bool, OptionalGroup] = False
+
+    # Should work with valid combinations.
+    config = tyro.cli(Config, args=["--option-a", "test", "--verbose"])
+    assert config.option_a == "test"
+    assert config.option_b is None
+    assert config.verbose is True
+    assert config.quiet is False
+
+    # Should fail with invalid combinations.
+    with pytest.raises(SystemExit):
+        tyro.cli(Config, args=["--option-a", "a", "--option-b", "1"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Config, args=["--option-a", "test", "--verbose", "--quiet"])
+
+
+def test_mutex_group_helptext():
+    """Test that mutex groups appear correctly in helptext."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        option_a: Annotated[str | None, RequiredGroup] = None,
+        option_b: Annotated[int | None, RequiredGroup] = None,
+        verbose: Annotated[bool, OptionalGroup] = False,
+        quiet: Annotated[bool, OptionalGroup] = False,
+    ) -> None:
+        """Test function with mutex groups."""
+        pass
+
+    helptext = get_helptext_with_checks(main)
+
+    # Check for mutually exclusive section markers.
+    assert "mutually exclusive" in helptext.lower()
+
+    # Check that required group is marked as required.
+    assert "required" in helptext.lower()
+
+    # Check that options are listed.
+    assert "--option-a" in helptext
+    assert "--option-b" in helptext
+    assert "--verbose" in helptext
+    assert "--quiet" in helptext
+
+
+def test_mutex_group_with_flag_create_pairs_off():
+    """Test mutex groups with FlagCreatePairsOff configuration."""
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        verbose: Annotated[bool, OptionalGroup] = False,
+        quiet: Annotated[bool, OptionalGroup] = False,
+    ) -> Tuple[bool, bool]:
+        return verbose, quiet
+
+    # With FlagCreatePairsOff, only positive flags should be created.
+    helptext = get_helptext_with_checks(main, config=(tyro.conf.FlagCreatePairsOff,))
+
+    # Should have positive flags.
+    assert "--verbose" in helptext
+    assert "--quiet" in helptext
+
+    # Should not have negative flags.
+    assert "--no-verbose" not in helptext
+    assert "--no-quiet" not in helptext
+
+    # Functionality should still work.
+    assert tyro.cli(
+        main, args=["--verbose"], config=(tyro.conf.FlagCreatePairsOff,)
+    ) == (True, False)
+
+
+def test_three_way_mutex_group():
+    """Test mutex group with three options."""
+    RequiredGroup = tyro.conf.create_mutex_group(required=True)
+
+    def main(
+        option_a: Annotated[str | None, RequiredGroup] = None,
+        option_b: Annotated[int | None, RequiredGroup] = None,
+        option_c: Annotated[float | None, RequiredGroup] = None,
+    ) -> Tuple[Optional[str], Optional[int], Optional[float]]:
+        return option_a, option_b, option_c
+
+    # Should work with any single option.
+    assert tyro.cli(main, args=["--option-a", "test"]) == ("test", None, None)
+    assert tyro.cli(main, args=["--option-b", "42"]) == (None, 42, None)
+    assert tyro.cli(main, args=["--option-c", "3.14"]) == (None, None, 3.14)
+
+    # Should fail with any two options.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "a", "--option-b", "1"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-b", "1", "--option-c", "2.0"])
+
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "a", "--option-c", "2.0"])
+
+    # Should fail with all three options.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--option-a", "a", "--option-b", "1", "--option-c", "2.0"])
+
+
+def test_mutex_group_with_defaults_not_none():
+    """Test mutex groups where defaults are not None."""
+    OptionalGroup = tyro.conf.create_mutex_group(required=False)
+
+    def main(
+        verbose: Annotated[bool, OptionalGroup] = False,
+        verbosity_level: Annotated[int, OptionalGroup] = 0,
+    ) -> Tuple[bool, int]:
+        return verbose, verbosity_level
+
+    # Should use defaults when neither is specified.
+    assert tyro.cli(main, args=[]) == (False, 0)
+
+    # Should override one default.
+    assert tyro.cli(main, args=["--verbose"]) == (True, 0)
+    assert tyro.cli(main, args=["--verbosity-level", "2"]) == (False, 2)
+
+    # Should fail when both are overridden.
+    with pytest.raises(SystemExit):
+        tyro.cli(main, args=["--verbose", "--verbosity-level", "2"])


### PR DESCRIPTION
Adds an API for configuring mutually exclusive arguments (#129), with an example adapted from @emcd.

Introduces two helpers that can be used with `typing.Annotated`:
- `tyro.conf.create_mutex_group()` creates an object that marks an argument as part of a mutually exclusive gorup
- `tyro.conf.DisallowNone` prevents `"None"` from appearing in the helptext or being passed into the CLI (related to #331, cc @e3rd)

Later, we'll also want to put effort into supporting these in our helptext generation and parsing rewrites (#333, #334).

Example usage:

```python
# 14_mutex.py
from pathlib import Path
from typing import Annotated, Literal

import tyro

RequiredGroup = tyro.conf.create_mutex_group(required=True)
OptionalGroup = tyro.conf.create_mutex_group(required=False)

def main(
    # Exactly one of --target-stream or --target-file must be specified.
    target_stream: Annotated[Literal["stdout", "stderr"] | None, RequiredGroup] = None,
    target_file: Annotated[Path | None, RequiredGroup] = None,
    # Either --verbose or --very-verbose can be specified (but not both).
    verbose: Annotated[bool, OptionalGroup] = False,
    very_verbose: Annotated[bool, OptionalGroup] = False,
) -> None:
    """Demonstrate mutually exclusive argument groups."""
    if very_verbose or verbose:
        print(f"{target_stream=} {target_file=}")
    if very_verbose:
        print(f"{target_stream=} {target_file=}")

if __name__ == "__main__":
    tyro.cli(
        main,
        # `DisallowNone` prevents `None` from being a valid choice for
        # `--target-stream` and `--target-file`.
        #
        # `FlagCreatePairsOff` prevents `--no-verbose` and `--no-very-verbose` from
        # being created.
        config=(tyro.conf.DisallowNone, tyro.conf.FlagCreatePairsOff),
    )
```

Usage and helptext; this is a screenshot from the updated docs:

<img width="480" height="761" alt="image" src="https://github.com/user-attachments/assets/68f8b2ad-a2f2-4a71-852e-f4822b5021d0" />
