### PR TITLE
Update docs, tests to clarify current mutex group behavior

### DIFF
--- a/src/tyro/conf/_mutex_group.py
+++ b/src/tyro/conf/_mutex_group.py
@@ -10,7 +10,29 @@ def create_mutex_group(*, required: bool) -> object:
     """Create a mutually exclusive group for command-line arguments.
 
     When multiple arguments are annotated with the same mutex group, they become
-    mutually exclusive - only one can be specified at a time via the CLI.
+    mutually exclusive: only one can be specified at a time via the CLI.
+
+    .. warning::
+        Mutex groups are currently only supported for individual arguments (primitive
+        types, enums, etc.), not for composite types like dataclasses or structs. To
+        make fields within a dataclass mutually exclusive, annotate each field
+        individually rather than the dataclass itself.
+
+        For example, the annotation on ``Config`` will have no effect::
+
+            @dataclass
+            class Config:
+                foo: int
+                bar: str
+
+            MutexGroup = tyro.conf.create_mutex_group(required=True)
+
+            def main(
+                config: Annotated[Config, MutexGroup],  # Has no effect!
+                other: Annotated[int, MutexGroup],
+            ): ...
+
+        Instead, annotate individual fields within the dataclass.
 
     Args:
         required: If True, exactly one argument from the group must be specified.

--- a/tests/test_mutex_groups.py
+++ b/tests/test_mutex_groups.py
@@ -298,6 +298,48 @@ def test_mutex_group_with_defaults_not_none():
         tyro.cli(main, args=["--verbose", "--verbosity-level", "2"])
 
 
+def test_mutex_group_on_dataclass_is_ignored():
+    """Test that applying a mutex group annotation to a dataclass itself is ignored.
+
+    This documents the current limitation where mutex groups can only be applied to
+    individual fields, not to composite types like dataclasses. The MutexGroup
+    annotation is ignored, and the dataclass behaves normally (creating subcommands
+    for Optional[Dataclass] as usual).
+    """
+    MutexGroup = tyro.conf.create_mutex_group(required=True)
+
+    @dataclasses.dataclass
+    class Config:
+        """A configuration dataclass."""
+
+        foo: int = 1
+        bar: str = "hello"
+
+    def main(
+        config: Annotated[
+            Optional[Config], MutexGroup
+        ] = None,  # MutexGroup annotation is ignored.
+        other: Annotated[Optional[int], MutexGroup] = None,
+    ) -> Tuple[Optional[Config], Optional[int]]:
+        return config, other
+
+    # The MutexGroup annotation on the dataclass is ignored for mutual exclusion.
+    # Since config is Optional[Config], it creates subcommands as normal.
+
+    # When only --other is provided, it works.
+    result = tyro.cli(main, args=["--other", "42"])
+    assert result == (None, 42)
+
+    # Both --other and config:config can be used together since the MutexGroup
+    # on config is ignored (they're not actually mutually exclusive).
+    # Note: order matters due to subcommand parsing.
+    result = tyro.cli(main, args=["--other", "42", "config:config"])
+    assert result[0] is not None
+    assert result[0].foo == 1
+    assert result[0].bar == "hello"
+    assert result[1] == 42
+
+
 def test_nested_mutex_groups():
     """Test that mutex groups work correctly across nested dataclasses."""
     SharedGroup = tyro.conf.create_mutex_group(required=False)


### PR DESCRIPTION
Mutex groups are currently only supported for individual arguments, but this wasn't clear from the docs. It's possible that we'll expand the features here in the future, but in the meantime I added a note to clarify the existing behavior.

cc #129, thanks @jungerm2 for raising this!