### PR TITLE
Subcommand edge case: `TypedDict` with `total=False`, `typing.NotRequired[]`

### DIFF
--- a/src/tyro/_backends/_tyro_backend.py
+++ b/src/tyro/_backends/_tyro_backend.py
@@ -635,7 +635,13 @@ class TyroBackend(ParserBackend):
 
                 # No subcommand was selected for this group.
                 if subparser_spec.default_name is None:
-                    # No default available; this is an error.
+                    # If the subparser is not required (e.g., field has EXCLUDE_FROM_CALL
+                    # as default from TypedDict total=False), skip it entirely. The field
+                    # will be excluded from the result via EXCLUDE_FROM_CALL handling in
+                    # _calling.py.
+                    if not subparser_spec.required:
+                        continue
+                    # No default available and required; this is an error.
                     _tyro_help_formatting.error_and_exit(
                         "Missing subcommand",
                         *[

--- a/src/tyro/_backends/_tyro_help_formatting.py
+++ b/src/tyro/_backends/_tyro_help_formatting.py
@@ -292,7 +292,10 @@ def format_help(
                 if subparser_spec.extern_prefix == ""
                 else subparser_spec.extern_prefix.upper()
             )
-        if default_name is not None:
+        # Wrap in brackets if optional. This includes:
+        # - Subparsers with a default subcommand
+        # - Subparsers marked as not required (e.g., from EXCLUDE_FROM_CALL)
+        if default_name is not None or not subparser_spec.required:
             usage_metavar = f"[{usage_metavar}]"
         subcommand_metavars.append(usage_metavar)
 

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -38,7 +38,7 @@ from typing_extensions import (
 )
 
 from . import _unsafe_cache, conf
-from ._singleton import MISSING_AND_MISSING_NONPROP
+from ._singleton import DEFAULT_SENTINEL_SINGLETONS, MISSING_AND_MISSING_NONPROP
 from ._typing import TypeForm
 from ._typing_compat import (
     is_typing_annotated,
@@ -587,7 +587,10 @@ def expand_union_types(typ: TypeOrCallable, default_instance: Any) -> TypeOrCall
     options_unwrapped = [unwrap_origin_strip_extras(o) for o in options]
 
     try:
-        if default_instance not in MISSING_AND_MISSING_NONPROP and not any(
+        # Skip expansion for sentinel values like EXCLUDE_FROM_CALL (from TypedDict
+        # total=False), MISSING, and MISSING_NONPROP. These are not actual default
+        # values and should not be added to the union type.
+        if default_instance not in DEFAULT_SENTINEL_SINGLETONS and not any(
             isinstance_with_fuzzy_numeric_tower(default_instance, o) is not False
             for o in options_unwrapped
         ):

--- a/src/tyro/constructors/_struct_spec.py
+++ b/src/tyro/constructors/_struct_spec.py
@@ -229,7 +229,11 @@ def apply_default_struct_rules(registry: ConstructorRegistry) -> None:
             else:
                 default = MISSING
 
-            # Nested types need to be populated / can't be excluded from the call.
+            # Nested struct types need to be populated / can't be excluded from the call.
+            # Note: Union types are NOT converted here - they create subparsers that
+            # can be optional. When a union field has EXCLUDE_FROM_CALL as its default
+            # (from TypedDict total=False or NotRequired[]), no subcommand needs to be
+            # selected, and the field will be excluded from the result.
             if default is EXCLUDE_FROM_CALL and is_struct_type(
                 inner_typ, MISSING_NONPROP, in_union_context=False
             ):

--- a/tests/test_dict_namedtuple.py
+++ b/tests/test_dict_namedtuple.py
@@ -203,6 +203,96 @@ def test_total_false_typeddict_with_tuple() -> None:
     ) == dict(i=5, s=("5", "5"))
 
 
+def test_total_false_typeddict_with_union() -> None:
+    """Test that total=False TypedDict with union field creates optional subparser.
+
+    This tests the fix for EXCLUDE_FROM_CALL handling in union types.
+    When a TypedDict field is optional and has a union type, EXCLUDE_FROM_CALL
+    is used as the default, making the subparser optional. When no subcommand
+    is selected, the field is excluded from the result.
+    """
+
+    @dataclasses.dataclass
+    class StructA:
+        a: int = 1
+
+    @dataclasses.dataclass
+    class StructB:
+        b: int = 2
+
+    class ConfigDict(TypedDict, total=False):
+        choice: Union[StructA, StructB]
+        other: int
+
+    # Test 1: No arguments - should return empty dict (both fields excluded).
+    assert tyro.cli(ConfigDict, args=[]) == {}
+
+    # Test 2: Only 'other' argument - choice is excluded.
+    assert tyro.cli(ConfigDict, args=["--other", "42"]) == {"other": 42}
+
+    # Test 3: Only 'choice' subcommand - other is excluded.
+    assert tyro.cli(ConfigDict, args=["choice:struct-a"]) == {"choice": StructA(a=1)}
+
+    # Test 4: Both arguments.
+    assert tyro.cli(ConfigDict, args=["--other", "99", "choice:struct-b"]) == {
+        "choice": StructB(b=2),
+        "other": 99,
+    }
+
+
+def test_not_required_with_union() -> None:
+    """Test that NotRequired[] with union field creates optional subparser."""
+    from typing_extensions import NotRequired
+
+    @dataclasses.dataclass
+    class StructA:
+        a: int = 1
+
+    @dataclasses.dataclass
+    class StructB:
+        b: int = 2
+
+    class ConfigDict(TypedDict):
+        choice: NotRequired[Union[StructA, StructB]]
+        other: int
+
+    # Test 1: Only required field.
+    assert tyro.cli(ConfigDict, args=["--other", "42"]) == {"other": 42}
+
+    # Test 2: Both fields.
+    assert tyro.cli(ConfigDict, args=["--other", "99", "choice:struct-a"]) == {
+        "choice": StructA(a=1),
+        "other": 99,
+    }
+
+
+def test_required_vs_optional_union() -> None:
+    """Test the difference between required and optional union subparsers."""
+
+    @dataclasses.dataclass
+    class StructA:
+        a: int = 1
+
+    @dataclasses.dataclass
+    class StructB:
+        b: int = 2
+
+    # Required union (total=True by default).
+    class RequiredConfig(TypedDict):
+        choice: Union[StructA, StructB]
+
+    # Optional union (total=False).
+    class OptionalConfig(TypedDict, total=False):
+        choice: Union[StructA, StructB]
+
+    # Required: Must provide subcommand.
+    with pytest.raises(SystemExit):
+        tyro.cli(RequiredConfig, args=[])
+
+    # Optional: Can omit subcommand.
+    assert tyro.cli(OptionalConfig, args=[]) == {}
+
+
 def test_nested_typeddict() -> None:
     class ChildTypedDict(TypedDict):
         y: int

--- a/tests/test_py311_generated/test_helptext_generated.py
+++ b/tests/test_py311_generated/test_helptext_generated.py
@@ -1478,3 +1478,73 @@ def test_literal_invalid_choice_error_message() -> None:
     assert "invalid choice" in error_message.lower() or "c" in error_message
     # But it should NOT expose internal implementation details.
     assert "__tyro-dummy-inner__" not in error_message
+
+
+def test_optional_union_subparser_helptext() -> None:
+    """Test that optional union subparsers are marked as optional in help text."""
+
+    @dataclasses.dataclass
+    class StructA:
+        """First option."""
+
+        a: int = 1
+
+    @dataclasses.dataclass
+    class StructB:
+        """Second option."""
+
+        b: int = 2
+
+    # Optional union (total=False).
+    class OptionalConfig(TypedDict, total=False):
+        """Config with optional union field."""
+
+        choice: StructA | StructB
+        other: int
+
+    helptext_optional = get_helptext_with_checks(OptionalConfig)
+
+    # Check that "(required)" is NOT shown for optional subparser.
+    lines = helptext_optional.split("\n")
+    in_subcommands_section = False
+    for line in lines:
+        if "subcommands" in line.lower():
+            in_subcommands_section = True
+        if in_subcommands_section and "choice:struct-a" in line:
+            # The section header before the subcommand list should not say "(required)".
+            assert (
+                "(required)"
+                not in helptext_optional.split("choice:struct-a")[0].split(
+                    "subcommands"
+                )[-1]
+            )
+            break
+
+    # For tyro backend, check usage line shows optional subparser in brackets.
+    # For argparse backend, the brackets may not show up in the usage line due to
+    # argparse limitations, but "optional" should appear in the section title.
+    if "[{choice:struct-a,choice:struct-b}]" not in helptext_optional:
+        # Argparse backend - check for "optional" in section title.
+        assert (
+            "optional" in helptext_optional.lower()
+            or "choice subcommands" in helptext_optional
+        )
+
+    # Required union (total=True by default).
+    class RequiredConfig(TypedDict):
+        """Config with required union field."""
+
+        choice: StructA | StructB
+        other: int
+
+    helptext_required = get_helptext_with_checks(RequiredConfig)
+
+    # Check usage line shows required subparser.
+    assert "{choice:struct-a,choice:struct-b}" in helptext_required
+
+    # Check that "(required)" IS shown for required subparser (tyro backend).
+    # Argparse backend doesn't show "(required)" but doesn't mark subcommands as optional.
+    if "(required)" not in helptext_required:
+        # Argparse backend - ensure "optional subcommands" is NOT in the help text.
+        # (The word "optional" may appear elsewhere, like in field descriptions)
+        assert "optional subcommands" not in helptext_required.lower()


### PR DESCRIPTION
Previous behavior for fields that are not required:
- Raising a warning
- Exposing the internal `EXCLUDE_FROM_CALL_TYPE` as an `exclude-from-call-type` subcommand

Fixed behavior for fields that are not required:
- No more warning
- Subcommand is optional