### PR TITLE
Add docs link to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ dev-nn = [
 ]
 
 [project.urls]
-"GitHub" = "https://github.com/brentyi/tyro"
+Repository = "https://github.com/brentyi/tyro"
+Documentation = "https://brentyi.github.io/tyro/"
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
Useful so that it shows up on the PyPI page.

I also renamed the "GitHub" link to "Repository", as that's the standard name for that link/url.