### PR TITLE
Add `tyro.conf.ShowSourcePath`, `PYTHON_TYRO_GLOBAL_MARKERS` env variable

### DIFF
--- a/docs/source/helptext_generation.rst
+++ b/docs/source/helptext_generation.rst
@@ -136,3 +136,19 @@ following order of precedence:
 2. PEP 727 ``Doc``
 3. Docstrings
 4. Comments
+
+Source paths in help
+--------------------
+
+When configs are spread across many files, it can be helpful to know where each
+one is defined—for example, to quickly update a default value in code. The
+:data:`tyro.conf.ShowSourcePath` marker appends the source file path and line
+number of each struct's definition to its help group description.
+
+.. code-block:: python
+
+    tyro.cli(Config, config=(tyro.conf.ShowSourcePath,))
+
+Each group description will then end with a line like ``(source:
+configs/train.py:42)``. The marker can also be applied to a single field with
+``ShowSourcePath[SomeConfig]`` to scope it to one subtree.

--- a/src/tyro/_backends/_argparse_help_formatting.py
+++ b/src/tyro/_backends/_argparse_help_formatting.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import dataclasses
 import difflib
+import inspect
+import os
 import shlex
 import shutil
 import sys
-from typing import TYPE_CHECKING, NoReturn
+from typing import TYPE_CHECKING, Callable, NoReturn
 
-from tyro.conf._markers import CascadeSubcommandArgs
+from tyro.conf._markers import CascadeSubcommandArgs, ShowSourcePath
 from tyro.conf._mutex_group import _MutexGroupConfig
 
 from .. import _fmtlib as fmt
@@ -21,13 +23,38 @@ if TYPE_CHECKING:
     from .._parsers import ParserSpecification, SubparsersSpecification
 
 
+def _get_source_location(f: Callable) -> str | None:
+    """Return a "(source: <path>:<line>)" string for a struct/callable, or None
+    if the source location can't be determined. Used by the
+    :data:`tyro.conf.ShowSourcePath` marker."""
+    try:
+        path = inspect.getsourcefile(f)
+        line = inspect.getsourcelines(f)[1]
+    except (TypeError, OSError):
+        # TypeError: built-in or otherwise has no Python source.
+        # OSError: source file can't be located (e.g. dynamically created).
+        return None
+    if path is None:
+        return None
+    # Prefer a path relative to the working directory when the file lives under
+    # it; otherwise fall back to the absolute path.
+    try:
+        relative = os.path.relpath(path)
+        if not relative.startswith(os.pardir + os.sep):
+            path = relative
+    except ValueError:
+        # relpath can raise on Windows when paths are on different drives.
+        pass
+    return f"(source: {path}:{line})"
+
+
 def format_help(
     prog: str,
     parser_specs: list[ParserSpecification],
     subparser_frontier: dict[str, SubparsersSpecification],
 ) -> list[str]:
     usage_strings = []
-    group_description: dict[str, str] = {}
+    group_description: dict[str, str | fmt._Text] = {}
     groups: dict[str | _MutexGroupConfig, list[tuple[str | fmt._Text, fmt._Text]]] = {
         "positional arguments": [],
         "options": [("-h, --help", fmt.text["dim"]("show this help message and exit"))],
@@ -43,7 +70,23 @@ def format_help(
         groups.setdefault(group_label, [])
         if parser.extern_prefix != "":
             # Ignore root, since we'll show description above.
-            group_description[group_label] = parser.description
+            description: str | fmt._Text = parser.description
+            if ShowSourcePath in parser.markers:
+                source_location = _get_source_location(parser.f)
+                if source_location is not None:
+                    # Match the color of the "(default: ...)" hint, but dim.
+                    source_text = fmt.text[
+                        _settings.ACCENT_COLOR
+                        if _settings.ACCENT_COLOR != "white"
+                        else "cyan",
+                        "dim",
+                    ](source_location)
+                    description = (
+                        fmt.text(description, "\n", source_text)
+                        if description
+                        else source_text
+                    )
+            group_description[group_label] = description
 
         for arg in parser.args:
             # Update usage.

--- a/src/tyro/_backends/_argparse_help_formatting.py
+++ b/src/tyro/_backends/_argparse_help_formatting.py
@@ -74,12 +74,11 @@ def format_help(
             if ShowSourcePath in parser.markers:
                 source_location = _get_source_location(parser.f)
                 if source_location is not None:
-                    # Match the color of the "(default: ...)" hint, but dim.
+                    # Match the color of the "(default: ...)" hint.
                     source_text = fmt.text[
                         _settings.ACCENT_COLOR
                         if _settings.ACCENT_COLOR != "white"
-                        else "cyan",
-                        "dim",
+                        else "cyan"
                     ](source_location)
                     description = (
                         fmt.text(description, "\n", source_text)

--- a/src/tyro/_backends/_tyro_help_formatting.py
+++ b/src/tyro/_backends/_tyro_help_formatting.py
@@ -9,12 +9,13 @@ import shutil
 import sys
 from typing import TYPE_CHECKING, NoReturn
 
-from tyro.conf._markers import CascadeSubcommandArgs
+from tyro.conf._markers import CascadeSubcommandArgs, ShowSourcePath
 from tyro.conf._mutex_group import _MutexGroupConfig
 
 from .. import _fmtlib as fmt
 from .. import _settings, conf
 from ..constructors._primitive_spec import UnsupportedTypeAnnotationError
+from ._argparse_help_formatting import _get_source_location
 
 
 @dataclasses.dataclass(frozen=True)
@@ -39,7 +40,7 @@ def format_help(
     verbose: bool = False,
 ) -> list[str]:
     usage_strings = []
-    group_description: dict[str, str] = {}
+    group_description: dict[str, str | fmt._Text] = {}
 
     # Compact mode is the inverse of verbose mode.
     compact_mode = not verbose
@@ -140,7 +141,23 @@ def format_help(
                 arg_group not in group_description
                 and arg_ctx.source_parser.extern_prefix != ""
             ):
-                group_description[arg_group] = arg_ctx.source_parser.description
+                description: str | fmt._Text = arg_ctx.source_parser.description
+                if ShowSourcePath in arg_ctx.source_parser.markers:
+                    source_location = _get_source_location(arg_ctx.source_parser.f)
+                    if source_location is not None:
+                        # Match the color of the "(default: ...)" hint, but dim.
+                        source_text = fmt.text[
+                            _settings.ACCENT_COLOR
+                            if _settings.ACCENT_COLOR != "white"
+                            else "cyan",
+                            "dim",
+                        ](source_location)
+                        description = (
+                            fmt.text(description, "\n", source_text)
+                            if description
+                            else source_text
+                        )
+                group_description[arg_group] = description
             # Default subcommand args use a separate group key so they get
             # their own box with a source label, even if a regular arg shares
             # the same extern_prefix.

--- a/src/tyro/_backends/_tyro_help_formatting.py
+++ b/src/tyro/_backends/_tyro_help_formatting.py
@@ -145,12 +145,11 @@ def format_help(
                 if ShowSourcePath in arg_ctx.source_parser.markers:
                     source_location = _get_source_location(arg_ctx.source_parser.f)
                     if source_location is not None:
-                        # Match the color of the "(default: ...)" hint, but dim.
+                        # Match the color of the "(default: ...)" hint.
                         source_text = fmt.text[
                             _settings.ACCENT_COLOR
                             if _settings.ACCENT_COLOR != "white"
-                            else "cyan",
-                            "dim",
+                            else "cyan"
                         ](source_location)
                         description = (
                             fmt.text(description, "\n", source_text)

--- a/src/tyro/_cli.py
+++ b/src/tyro/_cli.py
@@ -451,7 +451,10 @@ def _cli_impl(
 ):
     """Helper for stitching the `tyro` pipeline together."""
 
-    if config is not None and len(config) > 0:
+    # Combine markers passed via `config=` with any applied globally through the
+    # `global_markers` experimental option (PYTHON_TYRO_GLOBAL_MARKERS).
+    config = tuple(config or ()) + _settings.get_global_markers()
+    if len(config) > 0:
         f = Annotated[(f, *config)]  # type: ignore
 
     if "default_instance" in deprecated_kwargs:

--- a/src/tyro/_settings.py
+++ b/src/tyro/_settings.py
@@ -28,12 +28,17 @@ class ExperimentalOptionsDict(TypedDict):
         backend: Backend to use for parsing ("argparse" or "tyro").
         utf8_boxes: Enable UTF-8 box drawing characters in formatted output.
         ansi_codes: Enable ANSI color codes in formatted output.
+        global_markers: Comma-separated names of :mod:`tyro.conf` markers to
+            apply globally to every :func:`tyro.cli` call, in addition to any
+            markers passed via ``config=``. Primarily useful for debugging, for
+            example ``PYTHON_TYRO_GLOBAL_MARKERS=FlagConversionOff,ShowSourcePath``.
     """
 
     enable_timing: bool
     backend: Literal["argparse", "tyro"]
     utf8_boxes: bool
     ansi_codes: bool
+    global_markers: str
 
 
 @contextlib.contextmanager
@@ -77,7 +82,43 @@ _experimental_options: ExperimentalOptionsDict = {
     "backend": _read_option("PYTHON_TYRO_BACKEND", Literal["argparse", "tyro"], "tyro"),
     "utf8_boxes": _read_option("PYTHON_TYRO_UTF8_BOXES", bool, True),
     "ansi_codes": _read_option("PYTHON_TYRO_ANSI_CODES", bool, True),
+    "global_markers": _read_option("PYTHON_TYRO_GLOBAL_MARKERS", str, ""),
 }
+
+
+def get_global_markers() -> tuple[Any, ...]:
+    """Resolve the ``global_markers`` experimental option into marker objects.
+
+    The option is a comma-separated string of marker names that exist in
+    :mod:`tyro.conf` (e.g. ``"FlagConversionOff,ShowSourcePath"``). Each name is
+    looked up via :func:`getattr` on the :mod:`tyro.conf` module. Returns an
+    empty tuple when the option is unset.
+    """
+    markers_str = _experimental_options["global_markers"]
+    if not markers_str:
+        return ()
+
+    # Imported lazily to avoid a circular import at module load time.
+    from . import conf
+    from .conf import _markers
+
+    markers = []
+    for name in markers_str.split(","):
+        name = name.strip()
+        if name == "":
+            continue
+        marker = getattr(conf, name, None)
+        # Reject both unknown names and names that resolve to non-marker members
+        # of `tyro.conf` (e.g. `arg`, `configure`), which would otherwise be
+        # silently ignored.
+        if not isinstance(marker, _markers._Marker):
+            raise ValueError(
+                f"Unknown marker {name!r} in the `global_markers` option "
+                "(PYTHON_TYRO_GLOBAL_MARKERS). Expected the name of a marker in "
+                "`tyro.conf`."
+            )
+        markers.append(marker)
+    return tuple(markers)
 
 
 # TODO: revisit global.

--- a/src/tyro/conf/__init__.py
+++ b/src/tyro/conf/__init__.py
@@ -35,6 +35,7 @@ from ._markers import OmitArgPrefixes as OmitArgPrefixes
 from ._markers import OmitSubcommandPrefixes as OmitSubcommandPrefixes
 from ._markers import Positional as Positional
 from ._markers import PositionalRequiredArgs as PositionalRequiredArgs
+from ._markers import ShowSourcePath as ShowSourcePath
 from ._markers import Suppress as Suppress
 from ._markers import SuppressFixed as SuppressFixed
 from ._markers import UseAppendAction as UseAppendAction

--- a/src/tyro/conf/_markers.py
+++ b/src/tyro/conf/_markers.py
@@ -385,6 +385,26 @@ When :data:`EnumChoicesFromValues` is used, enum aliases aren't considered. The 
 matching value will be selected.
 """
 
+ShowSourcePath = Annotated[T, None]
+"""Append the source file path and line number of each struct's definition to its
+help group description.
+
+This is useful for quickly locating where configs are defined in code, for
+example to update default values. The location points to where the struct
+(dataclass, attrs class, etc.) is defined.
+
+Example::
+
+    tyro.cli(Config, config=(tyro.conf.ShowSourcePath,))
+
+This produces help output where each group description ends with a line like::
+
+    (source: configs/train.py:42)
+
+The marker can also be applied to a single field to scope the annotation to one
+subtree, for example ``ShowSourcePath[SomeConfig]``.
+"""
+
 HelptextFromCommentsOff = Annotated[T, None]
 """Disable automatic helptext generation from code comments.
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2120,6 +2120,45 @@ def test_helptext_from_contents_off() -> None:
     )
 
 
+@dataclasses.dataclass
+class ShowSourcePathInner:
+    z: int = 0
+
+
+@dataclasses.dataclass
+class ShowSourcePathOuter:
+    inner: ShowSourcePathInner = dataclasses.field(default_factory=ShowSourcePathInner)
+
+
+def test_show_source_path() -> None:
+    # Without the marker, no source path is shown.
+    assert "(source:" not in get_helptext_with_checks(ShowSourcePathOuter)
+
+    # With the marker, the source path of each nested struct is appended to its
+    # help group description.
+    helptext = get_helptext_with_checks(
+        ShowSourcePathOuter, config=(tyro.conf.ShowSourcePath,)
+    )
+    assert "(source:" in helptext
+    # The path points at this test module (matches both the source and the
+    # auto-generated `test_conf_generated.py`).
+    assert "test_conf" in helptext
+
+
+def test_show_source_path_scoped() -> None:
+    # The marker can be scoped to a single field/subtree via Annotated.
+    @dataclasses.dataclass
+    class Scoped:
+        a: tyro.conf.ShowSourcePath[ShowSourcePathInner] = dataclasses.field(
+            default_factory=ShowSourcePathInner
+        )
+        b: ShowSourcePathInner = dataclasses.field(default_factory=ShowSourcePathInner)
+
+    # Only the annotated subtree should get a source path.
+    helptext = get_helptext_with_checks(Scoped)
+    assert helptext.count("(source:") == 1
+
+
 # Tests for union types with config parameters (fix for union + config bug)
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -2159,6 +2159,42 @@ def test_show_source_path_scoped() -> None:
     assert helptext.count("(source:") == 1
 
 
+def test_show_source_path_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import inspect
+
+    from tyro._backends._argparse_help_formatting import _get_source_location
+
+    # Built-in callables have no Python source.
+    assert _get_source_location(dict) is None
+
+    # Dynamically created functions have no retrievable source file.
+    namespace: Dict[str, Any] = {}
+    exec("def dynamic_fn(): pass", namespace)
+    assert _get_source_location(namespace["dynamic_fn"]) is None
+
+    # inspect.getsourcefile() can also return None without raising.
+    monkeypatch.setattr(inspect, "getsourcefile", lambda f: None)
+    monkeypatch.setattr(inspect, "getsourcelines", lambda f: ([], 1))
+    assert _get_source_location(ShowSourcePathInner) is None
+
+
+def test_show_source_path_relpath_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import os.path
+
+    from tyro._backends._argparse_help_formatting import _get_source_location
+
+    # os.path.relpath() raises ValueError on Windows when the source file and
+    # working directory are on different drives; we fall back to the absolute
+    # path.
+    def relpath_error(path: str) -> str:
+        raise ValueError
+
+    monkeypatch.setattr(os.path, "relpath", relpath_error)
+    location = _get_source_location(ShowSourcePathInner)
+    assert location is not None
+    assert "test_conf" in location
+
+
 # Tests for union types with config parameters (fix for union + config bug)
 
 

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -4,7 +4,10 @@ import dataclasses
 import sys
 from io import StringIO
 
+import pytest
+
 import tyro
+from tyro import _settings
 
 
 def test_enable_timing() -> None:
@@ -33,3 +36,51 @@ def test_enable_timing() -> None:
         # Restore stderr and disable timing.
         sys.stderr = old_stderr
         tyro._experimental_options["enable_timing"] = False
+
+
+def test_global_markers_helper() -> None:
+    """`global_markers` is parsed into marker objects from `tyro.conf`."""
+    try:
+        # Unset -> no markers.
+        tyro._experimental_options["global_markers"] = ""
+        assert _settings.get_global_markers() == ()
+
+        # Comma-separated names resolve to markers; whitespace is tolerated.
+        tyro._experimental_options["global_markers"] = (
+            "FlagConversionOff, ShowSourcePath"
+        )
+        assert _settings.get_global_markers() == (
+            tyro.conf.FlagConversionOff,
+            tyro.conf.ShowSourcePath,
+        )
+
+        # Unknown names raise.
+        tyro._experimental_options["global_markers"] = "NotARealMarker"
+        with pytest.raises(ValueError):
+            _settings.get_global_markers()
+
+        # Names that exist in `tyro.conf` but aren't markers (e.g. `arg`) also
+        # raise, rather than being silently ignored.
+        tyro._experimental_options["global_markers"] = "arg"
+        with pytest.raises(ValueError):
+            _settings.get_global_markers()
+    finally:
+        tyro._experimental_options["global_markers"] = ""
+
+
+def test_global_markers_applied() -> None:
+    """Markers from `global_markers` are applied to every `tyro.cli` call."""
+
+    @dataclasses.dataclass
+    class Args:
+        flag: bool = False
+
+    try:
+        tyro._experimental_options["global_markers"] = "FlagConversionOff"
+        # With FlagConversionOff, the flag takes an explicit value and the
+        # `--no-flag` form is not generated.
+        assert tyro.cli(Args, args=["--flag", "True"]).flag is True
+        with pytest.raises(SystemExit):
+            tyro.cli(Args, args=["--no-flag"], console_outputs=False)
+    finally:
+        tyro._experimental_options["global_markers"] = ""

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -2166,6 +2166,42 @@ def test_show_source_path_scoped() -> None:
     assert helptext.count("(source:") == 1
 
 
+def test_show_source_path_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import inspect
+
+    from tyro._backends._argparse_help_formatting import _get_source_location
+
+    # Built-in callables have no Python source.
+    assert _get_source_location(dict) is None
+
+    # Dynamically created functions have no retrievable source file.
+    namespace: Dict[str, Any] = {}
+    exec("def dynamic_fn(): pass", namespace)
+    assert _get_source_location(namespace["dynamic_fn"]) is None
+
+    # inspect.getsourcefile() can also return None without raising.
+    monkeypatch.setattr(inspect, "getsourcefile", lambda f: None)
+    monkeypatch.setattr(inspect, "getsourcelines", lambda f: ([], 1))
+    assert _get_source_location(ShowSourcePathInner) is None
+
+
+def test_show_source_path_relpath_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import os.path
+
+    from tyro._backends._argparse_help_formatting import _get_source_location
+
+    # os.path.relpath() raises ValueError on Windows when the source file and
+    # working directory are on different drives; we fall back to the absolute
+    # path.
+    def relpath_error(path: str) -> str:
+        raise ValueError
+
+    monkeypatch.setattr(os.path, "relpath", relpath_error)
+    location = _get_source_location(ShowSourcePathInner)
+    assert location is not None
+    assert "test_conf" in location
+
+
 # Tests for union types with config parameters (fix for union + config bug)
 
 

--- a/tests/test_py311_generated/test_conf_generated.py
+++ b/tests/test_py311_generated/test_conf_generated.py
@@ -2127,6 +2127,45 @@ def test_helptext_from_contents_off() -> None:
     )
 
 
+@dataclasses.dataclass
+class ShowSourcePathInner:
+    z: int = 0
+
+
+@dataclasses.dataclass
+class ShowSourcePathOuter:
+    inner: ShowSourcePathInner = dataclasses.field(default_factory=ShowSourcePathInner)
+
+
+def test_show_source_path() -> None:
+    # Without the marker, no source path is shown.
+    assert "(source:" not in get_helptext_with_checks(ShowSourcePathOuter)
+
+    # With the marker, the source path of each nested struct is appended to its
+    # help group description.
+    helptext = get_helptext_with_checks(
+        ShowSourcePathOuter, config=(tyro.conf.ShowSourcePath,)
+    )
+    assert "(source:" in helptext
+    # The path points at this test module (matches both the source and the
+    # auto-generated `test_conf_generated.py`).
+    assert "test_conf" in helptext
+
+
+def test_show_source_path_scoped() -> None:
+    # The marker can be scoped to a single field/subtree via Annotated.
+    @dataclasses.dataclass
+    class Scoped:
+        a: tyro.conf.ShowSourcePath[ShowSourcePathInner] = dataclasses.field(
+            default_factory=ShowSourcePathInner
+        )
+        b: ShowSourcePathInner = dataclasses.field(default_factory=ShowSourcePathInner)
+
+    # Only the annotated subtree should get a source path.
+    helptext = get_helptext_with_checks(Scoped)
+    assert helptext.count("(source:") == 1
+
+
 # Tests for union types with config parameters (fix for union + config bug)
 
 

--- a/tests/test_py311_generated/test_experimental_generated.py
+++ b/tests/test_py311_generated/test_experimental_generated.py
@@ -4,7 +4,10 @@ import dataclasses
 import sys
 from io import StringIO
 
+import pytest
+
 import tyro
+from tyro import _settings
 
 
 def test_enable_timing() -> None:
@@ -33,3 +36,51 @@ def test_enable_timing() -> None:
         # Restore stderr and disable timing.
         sys.stderr = old_stderr
         tyro._experimental_options["enable_timing"] = False
+
+
+def test_global_markers_helper() -> None:
+    """`global_markers` is parsed into marker objects from `tyro.conf`."""
+    try:
+        # Unset -> no markers.
+        tyro._experimental_options["global_markers"] = ""
+        assert _settings.get_global_markers() == ()
+
+        # Comma-separated names resolve to markers; whitespace is tolerated.
+        tyro._experimental_options["global_markers"] = (
+            "FlagConversionOff, ShowSourcePath"
+        )
+        assert _settings.get_global_markers() == (
+            tyro.conf.FlagConversionOff,
+            tyro.conf.ShowSourcePath,
+        )
+
+        # Unknown names raise.
+        tyro._experimental_options["global_markers"] = "NotARealMarker"
+        with pytest.raises(ValueError):
+            _settings.get_global_markers()
+
+        # Names that exist in `tyro.conf` but aren't markers (e.g. `arg`) also
+        # raise, rather than being silently ignored.
+        tyro._experimental_options["global_markers"] = "arg"
+        with pytest.raises(ValueError):
+            _settings.get_global_markers()
+    finally:
+        tyro._experimental_options["global_markers"] = ""
+
+
+def test_global_markers_applied() -> None:
+    """Markers from `global_markers` are applied to every `tyro.cli` call."""
+
+    @dataclasses.dataclass
+    class Args:
+        flag: bool = False
+
+    try:
+        tyro._experimental_options["global_markers"] = "FlagConversionOff"
+        # With FlagConversionOff, the flag takes an explicit value and the
+        # `--no-flag` form is not generated.
+        assert tyro.cli(Args, args=["--flag", "True"]).flag is True
+        with pytest.raises(SystemExit):
+            tyro.cli(Args, args=["--no-flag"], console_outputs=False)
+    finally:
+        tyro._experimental_options["global_markers"] = ""


### PR DESCRIPTION
Adds two things:
- `tyro.conf.ShowSourcePath`. This addresses #464.
- A `PYTHON_TYRO_GLOBAL_MARKERS` env variable for debugging 

`PYTHON_TYRO_GLOBAL_MARKERS=ShowSourcePath uv run 01_nesting.py --help`:

<img width="470" height="254" alt="image" src="https://github.com/user-attachments/assets/ae946772-6768-42b2-aa99-5a2f9b8798b1" />
