### PR TITLE
Add test for nesting `is_default` in subcommands

### DIFF
--- a/src/tyro/_backends/_argparse_backend.py
+++ b/src/tyro/_backends/_argparse_backend.py
@@ -27,8 +27,10 @@ def _spec_has_is_default(spec: _parsers.ParserSpecification) -> bool:
             return True
         for parser in subparser_spec.parser_from_name.values():
             evaluated = parser.evaluate()
-            if isinstance(evaluated, UnsupportedTypeAnnotationError):
-                continue
+            # Error should have been caught earlier.
+            assert not isinstance(evaluated, UnsupportedTypeAnnotationError), (
+                "Unexpected UnsupportedTypeAnnotationError in argparse backend"
+            )
             if _spec_has_is_default(evaluated):
                 return True
     return False

--- a/src/tyro/_backends/_argparse_backend.py
+++ b/src/tyro/_backends/_argparse_backend.py
@@ -16,13 +16,21 @@ from ._base import ParserBackend
 
 
 def _spec_has_is_default(spec: _parsers.ParserSpecification) -> bool:
-    """Quick check: any subparser group at this level uses is_default
-    (signaled by default_name being set with no field default instance)?"""
+    """Quick check: any subparser group at this level *or nested below it*
+    uses is_default (signaled by default_name being set with no field
+    default instance)? Recurses into nested subparsers so that a default
+    set only on a deeper branch is still detected."""
     for subparser_spec in spec.subparsers_from_intern_prefix.values():
         if subparser_spec.default_name is not None and isinstance(
             subparser_spec.default_instance, NonpropagatingMissingType
         ):
             return True
+        for parser in subparser_spec.parser_from_name.values():
+            evaluated = parser.evaluate()
+            if isinstance(evaluated, UnsupportedTypeAnnotationError):
+                continue
+            if _spec_has_is_default(evaluated):
+                return True
     return False
 
 

--- a/tests/test_py311_generated/test_subcommand_aliases_and_default_generated.py
+++ b/tests/test_py311_generated/test_subcommand_aliases_and_default_generated.py
@@ -324,6 +324,46 @@ def test_subcommandapp_nested_with_aliases(capsys):
     assert capsys.readouterr().out.strip() == "migrating to 1"
 
 
+def test_subcommandapp_nested_is_default(capsys):
+    """is_default set only on a *nested* command must be honored when the
+    nested subcommand is omitted. Regression test: the argparse backend's
+    is_default detection previously only inspected the top-level parser
+    spec, so a default set on a deeper branch was silently ignored (the
+    call returned MISSING_NONPROP / errored)."""
+    db = SubcommandApp()
+
+    @db.command(is_default=True)
+    def status(verbose: bool = False) -> None:
+        print(f"status:{verbose}")
+
+    @db.command
+    def migrate(version: int = 1) -> None:
+        print(f"migrating to {version}")
+
+    app = SubcommandApp()
+    app.command(db, name="db")
+
+    @app.command
+    def hello(name: str = "world") -> None:
+        print(f"hello {name}")
+
+    # Omitting the nested subcommand should fall through to the default.
+    app.cli(args=["db"])
+    assert capsys.readouterr().out.strip() == "status:False"
+
+    # The default can still be selected explicitly and take flags.
+    app.cli(args=["db", "status", "--verbose"])
+    assert capsys.readouterr().out.strip() == "status:True"
+
+    # A non-default nested subcommand still routes normally.
+    app.cli(args=["db", "migrate", "--version", "7"])
+    assert capsys.readouterr().out.strip() == "migrating to 7"
+
+    # Sibling at the outer level is unaffected.
+    app.cli(args=["hello", "--name", "tyro"])
+    assert capsys.readouterr().out.strip() == "hello tyro"
+
+
 def test_sort_subcommands_does_not_persist_across_cli_calls(capsys):
     """Calling cli(sort_subcommands=True) must not mutate the registration order."""
     app = SubcommandApp()

--- a/tests/test_subcommand_aliases_and_default.py
+++ b/tests/test_subcommand_aliases_and_default.py
@@ -339,6 +339,46 @@ def test_subcommandapp_nested_with_aliases(capsys):
     assert capsys.readouterr().out.strip() == "migrating to 1"
 
 
+def test_subcommandapp_nested_is_default(capsys):
+    """is_default set only on a *nested* command must be honored when the
+    nested subcommand is omitted. Regression test: the argparse backend's
+    is_default detection previously only inspected the top-level parser
+    spec, so a default set on a deeper branch was silently ignored (the
+    call returned MISSING_NONPROP / errored)."""
+    db = SubcommandApp()
+
+    @db.command(is_default=True)
+    def status(verbose: bool = False) -> None:
+        print(f"status:{verbose}")
+
+    @db.command
+    def migrate(version: int = 1) -> None:
+        print(f"migrating to {version}")
+
+    app = SubcommandApp()
+    app.command(db, name="db")
+
+    @app.command
+    def hello(name: str = "world") -> None:
+        print(f"hello {name}")
+
+    # Omitting the nested subcommand should fall through to the default.
+    app.cli(args=["db"])
+    assert capsys.readouterr().out.strip() == "status:False"
+
+    # The default can still be selected explicitly and take flags.
+    app.cli(args=["db", "status", "--verbose"])
+    assert capsys.readouterr().out.strip() == "status:True"
+
+    # A non-default nested subcommand still routes normally.
+    app.cli(args=["db", "migrate", "--version", "7"])
+    assert capsys.readouterr().out.strip() == "migrating to 7"
+
+    # Sibling at the outer level is unaffected.
+    app.cli(args=["hello", "--name", "tyro"])
+    assert capsys.readouterr().out.strip() == "hello tyro"
+
+
 def test_sort_subcommands_does_not_persist_across_cli_calls(capsys):
     """Calling cli(sort_subcommands=True) must not mutate the registration order."""
     app = SubcommandApp()


### PR DESCRIPTION
Also fixed in argparse backend, which is used for tests (doesn't impact users).