### PR TITLE
Fix parsing, type resolution, and struct/container handling edge cases

### DIFF
--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -119,8 +119,15 @@ class ArgumentDefinition:
         arguments, or the positional's name with the internal dummy name
         (used for direct Literal/primitive types) hidden behind ``value``."""
         if self.is_positional():
-            name = self.lowered.name_or_flags[-1]
-            return "value" if name == "__tyro-dummy-inner__" else name
+            # Delimiter-agnostic dummy check (the lowered name is
+            # `__tyro_dummy_inner__` under `use_underscores=True`); mirrors the
+            # predicate in `is_positional()` below.
+            if (
+                self.field.extern_name == ""
+                and self.field.intern_name == "__tyro_dummy_inner__"
+            ):
+                return "value"
+            return self.lowered.name_or_flags[-1]
         return "/".join(self.lowered.name_or_flags)
 
     def is_positional(self) -> bool:

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -529,7 +529,7 @@ def _rule_apply_primitive_specs(
                 if container_type is collections.defaultdict:
                     # No default_factory can be inferred from the annotation.
                     return collections.defaultdict(None, out)
-                return container_type(out)  # e.g. OrderedDict, Counter
+                return container_type(out)  # type: ignore  # e.g. OrderedDict, Counter
             if container_type in (
                 list,
                 Sequence,
@@ -541,7 +541,7 @@ def _rule_apply_primitive_specs(
                 return frozenset(out)
             if container_type is collections.abc.MutableSet:
                 return set(out)
-            return container_type(out)  # e.g. set, frozenset, deque, tuple
+            return container_type(out)  # type: ignore  # e.g. set, frozenset, deque, tuple
 
         lowered.instance_from_str = append_instantiator
         lowered.str_from_instance = spec.str_from_instance

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -114,6 +114,15 @@ class ArgumentDefinition:
             assert self.lowered.dest is not None
             return self.lowered.dest
 
+    def display_name(self) -> str:
+        """User-facing name for error messages: the flag(s) for keyword
+        arguments, or the positional's name with the internal dummy name
+        (used for direct Literal/primitive types) hidden behind ``value``."""
+        if self.is_positional():
+            name = self.lowered.name_or_flags[-1]
+            return "value" if name == "__tyro-dummy-inner__" else name
+        return "/".join(self.lowered.name_or_flags)
+
     def is_positional(self) -> bool:
         """Returns True if the argument should be positional in the commandline."""
         return (

--- a/src/tyro/_arguments.py
+++ b/src/tyro/_arguments.py
@@ -486,6 +486,16 @@ def _rule_apply_primitive_specs(
                 # that a user would use this but we can handle it.
                 container_type = arg.field.type_stripped
 
+            # Mapping-like vs sequence/set-like. We accumulate into a plain dict
+            # or list, then build the concrete annotated type at the end. This
+            # mirrors the (possibly abstract) container -> concrete mapping in
+            # the primitive rules, so abc containers (MutableSequence, Set,
+            # MutableSet, Mapping, MutableMapping) and dict subclasses
+            # (OrderedDict, Counter, defaultdict) work here too.
+            is_mapping = isinstance(container_type, type) and issubclass(
+                container_type, collections.abc.Mapping
+            )
+
             # Instantiate initial output.
             out = (
                 arg.field.default
@@ -493,12 +503,11 @@ def _rule_apply_primitive_specs(
                 else None
             )
             if out is None:
-                out = {} if container_type is dict else []
-            elif isinstance(out, dict):
-                out = out.copy()
+                out = {} if is_mapping else []
+            elif isinstance(out, collections.abc.Mapping):
+                out = dict(out)
             else:
-                # All sequence types will be lists for now to make sure we can
-                # append to them.
+                # All sequence/set types accumulate into a list so we can append.
                 out = list(out)
 
             # Get + merge parts.
@@ -509,11 +518,30 @@ def _rule_apply_primitive_specs(
                 else:
                     out.append(part)
 
-            # Return output with correct type.
-            if container_type in (dict, Sequence, collections.abc.Sequence):
+            # Return output as the concrete annotated type.
+            if is_mapping:
+                if container_type in (
+                    dict,
+                    collections.abc.Mapping,
+                    collections.abc.MutableMapping,
+                ):
+                    return out
+                if container_type is collections.defaultdict:
+                    # No default_factory can be inferred from the annotation.
+                    return collections.defaultdict(None, out)
+                return container_type(out)  # e.g. OrderedDict, Counter
+            if container_type in (
+                list,
+                Sequence,
+                collections.abc.Sequence,
+                collections.abc.MutableSequence,
+            ):
                 return out
-            else:
-                return container_type(out)
+            if container_type is collections.abc.Set:
+                return frozenset(out)
+            if container_type is collections.abc.MutableSet:
+                return set(out)
+            return container_type(out)  # e.g. set, frozenset, deque, tuple
 
         lowered.instance_from_str = append_instantiator
         lowered.str_from_instance = spec.str_from_instance

--- a/src/tyro/_backends/_argparse_backend.py
+++ b/src/tyro/_backends/_argparse_backend.py
@@ -77,9 +77,7 @@ def _inject_is_default_subcommands(
 
     args = list(args)
 
-    def walk(
-        spec: _parsers.ParserSpecification, cursor: int
-    ) -> int:
+    def walk(spec: _parsers.ParserSpecification, cursor: int) -> int:
         """Recursively inject default subcommand names, returning the updated
         cursor position. A single parser level can contain multiple sibling
         subparser groups (e.g. two ``Union`` fields), and each chosen branch
@@ -250,7 +248,9 @@ def _reorder_subparsers_action_last(parser: argparse.ArgumentParser) -> None:
     handles this ordering natively. See BUG 2.
     """
     actions = parser._actions
-    subparser_actions = [a for a in actions if isinstance(a, argparse._SubParsersAction)]
+    subparser_actions = [
+        a for a in actions if isinstance(a, argparse._SubParsersAction)
+    ]
     if not subparser_actions:
         return
     # Stable reorder: keep relative order of everything else, move subparser

--- a/src/tyro/_backends/_argparse_backend.py
+++ b/src/tyro/_backends/_argparse_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Container, Dict, List, Sequence, Tuple, cast
 
+from .. import _fmtlib as fmt
 from .. import _parsers, _strings
 from .._singleton import NonpropagatingMissingType
 from ..conf import _markers
@@ -75,11 +76,18 @@ def _inject_is_default_subcommands(
         return args
 
     args = list(args)
-    cursor = 0
-    current_spec: _parsers.ParserSpecification | None = parser_spec
-    while current_spec is not None:
-        next_spec: _parsers.ParserSpecification | None = None
-        for subparser_spec in current_spec.subparsers_from_intern_prefix.values():
+
+    def walk(
+        spec: _parsers.ParserSpecification, cursor: int
+    ) -> int:
+        """Recursively inject default subcommand names, returning the updated
+        cursor position. A single parser level can contain multiple sibling
+        subparser groups (e.g. two ``Union`` fields), and each chosen branch
+        may itself contain nested subparser groups. We must descend into *each*
+        chosen branch independently rather than tracking a single ``next_spec``,
+        otherwise a default in one branch's nested subparser is dropped when a
+        later sibling subcommand is also present at this level. See BUG 1."""
+        for subparser_spec in spec.subparsers_from_intern_prefix.values():
             canonical_lookup = subparser_spec.canonical_from_alias()
             chosen_idx = _find_subcommand_token(args, cursor, canonical_lookup)
 
@@ -94,8 +102,9 @@ def _inject_is_default_subcommands(
                 chosen_idx = cursor
 
             if chosen_idx is None:
-                next_spec = None
-                break
+                # No selection and no injectable default for this group; we
+                # can't reliably descend further into this branch.
+                continue
 
             cursor = chosen_idx + 1
             chosen = canonical_lookup.get(args[chosen_idx], args[chosen_idx])
@@ -104,9 +113,113 @@ def _inject_is_default_subcommands(
             assert not isinstance(evaluated, UnsupportedTypeAnnotationError), (
                 "Unexpected UnsupportedTypeAnnotationError in argparse backend"
             )
-            next_spec = evaluated
-        current_spec = next_spec
+            # Descend into the chosen branch, which may have its own nested
+            # subparser groups (including default branches to inject).
+            cursor = walk(evaluated, cursor)
+        return cursor
+
+    walk(parser_spec, 0)
     return args
+
+
+def _check_mutex_groups_within_subcommand_boundaries(
+    parser_spec: _parsers.ParserSpecification,
+) -> None:
+    """Raise a clear error if any mutex group spans a subcommand boundary.
+
+    argparse builds one ``_MutuallyExclusiveGroup`` per parser object and
+    cannot share a mutex group across subparsers: the parent parser and each
+    subparser are independent ``ArgumentParser`` instances. So if a single
+    ``tyro.conf.create_mutex_group`` has members on both sides of a subcommand
+    boundary (e.g. a top-level field and a subcommand-arm field, or two
+    different subcommand arms), argparse would silently build a *separate*
+    group on each parser. This destroys mutual exclusion (both members get
+    accepted) and, for required groups, wrongly demands a member on every
+    parser level.
+
+    The tyro backend enforces such groups globally and is correct. Since
+    argparse cannot replicate this without rearchitecting, we detect the
+    situation at parser-construction time and raise an explicit error rather
+    than silently mis-parsing. See BUG 3.
+
+    Detection mirrors how the argparse parser is constructed: a single argparse
+    parser "node" owns a ``ParserSpecification``'s own ``args`` plus all args
+    reachable through ``child_from_prefix`` (which do *not* cross subparsers).
+    Each subparser arm is a distinct node. A mutex config that appears in more
+    than one node spans a subcommand boundary.
+    """
+    # Map each mutex config to the set of distinct parser-node ids that
+    # reference it. A node id is the integer id() of the ParserSpecification at
+    # the root of an argparse-parser group (the spec passed to apply_parser).
+    nodes_from_mutex_config: Dict[_MutexGroupConfig, set] = {}
+
+    def visit_node(spec: _parsers.ParserSpecification, node_id: int) -> None:
+        # Collect mutex configs from this spec's own args and from all
+        # non-subparser descendants (these share the same argparse parser).
+        for arg in spec.args:
+            group_conf = arg.field.mutex_group
+            if group_conf is not None and not arg.is_suppressed():
+                nodes_from_mutex_config.setdefault(group_conf, set()).add(node_id)
+        for child in spec.child_from_prefix.values():
+            visit_node(child, node_id)
+
+        # Each subparser arm is a fresh argparse parser node.
+        for subparser_spec in spec.subparsers_from_intern_prefix.values():
+            for parser_lazy in subparser_spec.parser_from_name.values():
+                evaluated = parser_lazy.evaluate()
+                assert not isinstance(evaluated, UnsupportedTypeAnnotationError), (
+                    "Unexpected UnsupportedTypeAnnotationError in argparse backend"
+                )
+                visit_node(evaluated, id(evaluated))
+
+    visit_node(parser_spec, id(parser_spec))
+
+    for group_conf, node_ids in nodes_from_mutex_config.items():
+        if len(node_ids) > 1:
+            title = group_conf.title or "mutually exclusive"
+            raise UnsupportedTypeAnnotationError(
+                (
+                    fmt.text(
+                        "The mutex group ",
+                        fmt.text["cyan"](repr(title)),
+                        " has members that span a subcommand (subparser) "
+                        "boundary, which the argparse backend cannot enforce: "
+                        "argparse builds an independent mutually-exclusive group "
+                        "for each parser level, so mutual exclusion would be "
+                        "silently lost. Keep all members of a mutex group within "
+                        "a single (sub)command, or use the default 'tyro' backend, "
+                        "which enforces mutex groups globally.",
+                    ),
+                )
+            )
+
+
+def _reorder_subparsers_action_last(parser: argparse.ArgumentParser) -> None:
+    """Move any ``_SubParsersAction`` to the end of ``parser._actions``.
+
+    argparse matches positional actions in ``parser._actions`` order. The
+    subparsers action has ``nargs=PARSER`` (``A...``), which greedily consumes
+    every remaining positional token. When a parent-level positional is
+    declared *before* a subcommand union (e.g. ``name: Positional[str]`` then
+    ``sub: Union[A, B]``), tyro's documented usage is ``STR [{sub:a,sub:b}]``
+    -- the plain positional first, then the subcommand. But the subparsers
+    action is registered before the plain positional's store action, so
+    argparse routes the leading positional into the subparsers action and
+    reports an "invalid choice" error.
+
+    Ensuring the subparsers action is matched *after* all other positionals
+    lets argparse consume fixed-arity positionals first, then route the
+    remaining tokens into the subparser. This mirrors the tyro backend, which
+    handles this ordering natively. See BUG 2.
+    """
+    actions = parser._actions
+    subparser_actions = [a for a in actions if isinstance(a, argparse._SubParsersAction)]
+    if not subparser_actions:
+        return
+    # Stable reorder: keep relative order of everything else, move subparser
+    # actions to the very end.
+    others = [a for a in actions if not isinstance(a, argparse._SubParsersAction)]
+    actions[:] = others + subparser_actions
 
 
 class ArgparseBackend(ParserBackend):
@@ -172,6 +285,11 @@ class ArgparseBackend(ParserBackend):
         parser._console_outputs = console_outputs
         parser._args = []
 
+        # argparse cannot share a mutually-exclusive group across subparsers.
+        # Detect and clearly reject this case before constructing the parser,
+        # so we never silently mis-parse. See BUG 3.
+        _check_mutex_groups_within_subcommand_boundaries(parser_spec)
+
         # Populate the argparse parser.
         apply_parser(
             parser_spec, parser, force_required_subparsers=False, add_help=add_help
@@ -229,6 +347,10 @@ def apply_parser(
 
     if subparser_group is not None:
         parser._action_groups.append(subparser_group)
+
+    # Ensure plain positionals are matched before the subparsers action (which
+    # greedily consumes all remaining tokens). See BUG 2.
+    _reorder_subparsers_action_last(parser)
 
     # Break some API boundaries to rename the "optional arguments" => "options".
     assert parser._action_groups[1].title in (
@@ -581,6 +703,10 @@ def apply_parser_with_materialized_subparsers(
         apply_parser_args(parser_spec, parser)
 
     parser._action_groups.append(subparser_group)
+
+    # Ensure plain positionals are matched before the subparsers action (which
+    # greedily consumes all remaining tokens). See BUG 2.
+    _reorder_subparsers_action_last(parser)
 
     # Rename "optional arguments" => "options".
     assert parser._action_groups[1].title in (

--- a/src/tyro/_backends/_argparse_backend.py
+++ b/src/tyro/_backends/_argparse_backend.py
@@ -43,7 +43,15 @@ def _find_subcommand_token(
     """Scan args from cursor for a non-flag token in `choices`. Skips flags
     and the token immediately following each flag (likely the flag's
     value), since a value that happens to equal a subcommand name must not
-    be mistaken for explicit selection."""
+    be mistaken for explicit selection.
+
+    Known limitation (argparse backend only): this scanner doesn't know flag
+    arity, so it skips the token after *every* dash-prefixed option, including
+    zero-arity boolean/count flags. A parent boolean flag immediately before an
+    explicit subcommand (e.g. ``--verbose sub:b``) can therefore be mis-scanned,
+    breaking `is_default` injection. The default `tyro` backend handles this
+    correctly; fixing it here would require threading per-flag arity into the
+    scanner."""
     i = cursor
     while i < len(args):
         tok = args[i]

--- a/src/tyro/_backends/_argparse_backend.py
+++ b/src/tyro/_backends/_argparse_backend.py
@@ -142,40 +142,77 @@ def _check_mutex_groups_within_subcommand_boundaries(
     situation at parser-construction time and raise an explicit error rather
     than silently mis-parsing. See BUG 3.
 
-    Detection mirrors how the argparse parser is constructed: a single argparse
-    parser "node" owns a ``ParserSpecification``'s own ``args`` plus all args
-    reachable through ``child_from_prefix`` (which do *not* cross subparsers).
-    Each subparser arm is a distinct node. A mutex config that appears in more
-    than one node spans a subcommand boundary.
+    Detection models where each member is reachable. A single argparse parser
+    "node" owns a ``ParserSpecification``'s own ``args`` plus all args reachable
+    through ``child_from_prefix`` (which do *not* cross subparsers); each
+    subparser arm is a distinct node, reached by selecting specific arms of the
+    subparser groups along the path to it. We record, per mutex config, the
+    subparser-arm *selection map* (``{subparser_group_id: arm_name}``) at every
+    node where it appears. Two occurrences can be active in the SAME parse
+    unless some shared subparser group forces different arm choices -- so a
+    group spans a boundary iff any two of its occurrences can coexist. This
+    correctly allows a group reused across mutually-exclusive *sibling* arms
+    (only one is ever active) while still catching parent-vs-arm and
+    parallel-subparser-group cases (where members genuinely coexist).
     """
-    # Map each mutex config to the set of distinct parser-node ids that
-    # reference it. A node id is the integer id() of the ParserSpecification at
-    # the root of an argparse-parser group (the spec passed to apply_parser).
-    nodes_from_mutex_config: Dict[_MutexGroupConfig, set] = {}
+    # Per mutex config: the list of subparser-arm selection maps at the nodes
+    # where it appears.
+    selections_from_mutex_config: Dict[_MutexGroupConfig, List[Dict[int, str]]] = {}
 
-    def visit_node(spec: _parsers.ParserSpecification, node_id: int) -> None:
-        # Collect mutex configs from this spec's own args and from all
-        # non-subparser descendants (these share the same argparse parser).
-        for arg in spec.args:
-            group_conf = arg.field.mutex_group
-            if group_conf is not None and not arg.is_suppressed():
-                nodes_from_mutex_config.setdefault(group_conf, set()).add(node_id)
-        for child in spec.child_from_prefix.values():
-            visit_node(child, node_id)
+    def visit_node(
+        spec: _parsers.ParserSpecification, selections: Dict[int, str]
+    ) -> None:
+        # Configs owned by this argparse parser node: this spec's own args plus
+        # all non-subparser (child_from_prefix) descendants.
+        configs_here: set = set()
 
-        # Each subparser arm is a fresh argparse parser node.
-        for subparser_spec in spec.subparsers_from_intern_prefix.values():
-            for parser_lazy in subparser_spec.parser_from_name.values():
-                evaluated = parser_lazy.evaluate()
-                assert not isinstance(evaluated, UnsupportedTypeAnnotationError), (
-                    "Unexpected UnsupportedTypeAnnotationError in argparse backend"
-                )
-                visit_node(evaluated, id(evaluated))
+        def collect(s: _parsers.ParserSpecification) -> None:
+            for arg in s.args:
+                group_conf = arg.field.mutex_group
+                if group_conf is not None and not arg.is_suppressed():
+                    configs_here.add(group_conf)
+            for child in s.child_from_prefix.values():
+                collect(child)
 
-    visit_node(parser_spec, id(parser_spec))
+        collect(spec)
+        for group_conf in configs_here:
+            selections_from_mutex_config.setdefault(group_conf, []).append(
+                dict(selections)
+            )
 
-    for group_conf, node_ids in nodes_from_mutex_config.items():
-        if len(node_ids) > 1:
+        # Recurse into subparser arms (fresh argparse nodes), recording the arm
+        # selection. Subparser groups can be nested under child_from_prefix.
+        def recurse_subparsers(s: _parsers.ParserSpecification) -> None:
+            for subparser_spec in s.subparsers_from_intern_prefix.values():
+                group_id = id(subparser_spec)
+                for name, parser_lazy in subparser_spec.parser_from_name.items():
+                    evaluated = parser_lazy.evaluate()
+                    assert not isinstance(evaluated, UnsupportedTypeAnnotationError), (
+                        "Unexpected UnsupportedTypeAnnotationError in argparse backend"
+                    )
+                    visit_node(evaluated, {**selections, group_id: name})
+            for child in s.child_from_prefix.values():
+                recurse_subparsers(child)
+
+        recurse_subparsers(spec)
+
+    visit_node(parser_spec, {})
+
+    def can_coexist(a: Dict[int, str], b: Dict[int, str]) -> bool:
+        # Both members are reachable in one parse unless a shared subparser
+        # group forces different arm choices.
+        for group_id, arm in a.items():
+            if group_id in b and b[group_id] != arm:
+                return False
+        return True
+
+    for group_conf, selections in selections_from_mutex_config.items():
+        spans_boundary = any(
+            can_coexist(selections[i], selections[j])
+            for i in range(len(selections))
+            for j in range(i + 1, len(selections))
+        )
+        if spans_boundary:
             title = group_conf.title or "mutually exclusive"
             raise UnsupportedTypeAnnotationError(
                 (

--- a/src/tyro/_backends/_completion/_tyro_bash.py
+++ b/src/tyro/_backends/_completion/_tyro_bash.py
@@ -105,14 +105,22 @@ _{root_prefix}() {{
 
   # Pass raw COMP_WORDS array to Python for processing.
   # Python will handle word reconstruction (e.g., merging "dataset" ":" "mnist" -> "dataset:mnist").
-  local completions
-  completions=$("$python_cmd" - "${{COMP_WORDS[@]}}" "$COMP_CWORD" << 'PYTHON_EOF'
+  #
+  # We read the embedded Python into a variable via a plain heredoc rather than
+  # putting the heredoc directly inside the $(...) command substitution: bash
+  # scans the whole substitution body (heredoc included) for balanced quotes,
+  # so a spec string with an odd number of quotes (e.g. a default like "don't")
+  # would otherwise break the entire script. Feeding the heredoc to `read` has
+  # no such issue. (`read -d ''` returns non-zero at EOF, hence `|| true`.)
+  local _tyro_py
+  IFS= read -r -d '' _tyro_py << 'PYTHON_EOF' || true
 # Hardcoded completion spec.
 COMPLETION_SPEC = {spec_repr}
 
 {python_code}
 PYTHON_EOF
-)
+  local completions
+  completions=$(printf '%s' "$_tyro_py" | "$python_cmd" - "${{COMP_WORDS[@]}}" "$COMP_CWORD")
 
   # Check for special path completion marker.
   if [[ "$completions" == "__TYRO_COMPLETE_FILES__" ]]; then

--- a/src/tyro/_backends/_tyro_backend.py
+++ b/src/tyro/_backends/_tyro_backend.py
@@ -30,6 +30,35 @@ _FLAG_ACTIONS = frozenset(
 )
 
 
+class _LiteralValue(str):
+    """A token that was explicitly attached to a flag with ``=`` (e.g. the
+    ``--y`` in ``--x=--y``). Such a token must be consumed as a value verbatim,
+    even when it looks like a flag -- unlike a space-separated token, which a
+    fixed/variable-nargs argument must not silently swallow."""
+
+
+def _blocks_value_consumption(token: str, kwarg_map: "KwargMap") -> bool:
+    """Whether ``token`` should NOT be consumed as an argument value: the
+    end-of-options ``--`` marker, a registered flag, or a flag-like token
+    (leading dash followed by an alpha character, so negative numbers like
+    ``-5`` are still treated as values). Matches argparse, which errors rather
+    than consuming e.g. ``--x --verbose`` as the value of ``--x``.
+
+    ``_LiteralValue`` tokens (supplied via ``=``) are never blocking."""
+    if isinstance(token, _LiteralValue):
+        return False
+    if token == "--":
+        return True
+    token_key = token.partition("=")[0]
+    if kwarg_map.contains_normalized(token_key):
+        return True
+    return (
+        token_key.startswith("-")
+        and len(token_key) > 1
+        and token_key.lstrip("-")[:1].isalpha()
+    )
+
+
 class KwargMap:
     """Look-up table for tracking keyword arguments. Due to aliases, each
     argument can have multiple string representations, like -v and
@@ -370,6 +399,10 @@ class TyroBackend(ParserBackend):
                         add_help=add_help,
                         console_outputs=console_outputs,
                         seen_double_dash=True,
+                        # Reserve trailing values for later required positionals.
+                        min_remaining_positional=self._min_positional_consumption(
+                            positional_args
+                        ),
                     )
                     continue
 
@@ -429,7 +462,9 @@ class TyroBackend(ParserBackend):
                 ):
                     # This should also handle nargs!=1 cases like tuple[int, int].
                     # ["--tuple=1", "2"] will be broken into ["--tuple", "1", "2"].
-                    args_deque.appendleft(equals_value)
+                    # The `=`-attached value is marked literal so it is consumed
+                    # verbatim even if it looks like a flag (e.g. `--x=--y`).
+                    args_deque.appendleft(_LiteralValue(equals_value))
                     args_deque.appendleft(maybe_flag_delimiter_swapped)
                     continue
 
@@ -639,6 +674,11 @@ class TyroBackend(ParserBackend):
                         local_prog,
                         add_help=add_help,
                         console_outputs=console_outputs,
+                        # A variable-nargs positional must leave enough trailing
+                        # values for the remaining required positionals.
+                        min_remaining_positional=self._min_positional_consumption(
+                            positional_args
+                        ),
                     )
                     continue
 
@@ -898,7 +938,14 @@ class TyroBackend(ParserBackend):
         # https://docs.python.org/3/library/argparse.html#nargs
         if isinstance(arg.lowered.nargs, int):
             for _ in range(arg.lowered.nargs):
-                if len(args_deque) == 0:
+                # A flag-like token or the `--` end-of-options marker cannot be
+                # swallowed as a value (unless explicitly attached via `=`, or
+                # we are past a `--`). argparse errors here rather than consuming
+                # e.g. `--x --verbose` as the value of `--x`.
+                if len(args_deque) == 0 or (
+                    not seen_double_dash
+                    and _blocks_value_consumption(args_deque[0], kwarg_map)
+                ):
                     _tyro_help_formatting.error_and_exit(
                         "Missing argument",
                         f"Missing value for argument '{arg.display_name()}'. "
@@ -907,12 +954,16 @@ class TyroBackend(ParserBackend):
                         console_outputs=console_outputs,
                         add_help=add_help,
                     )
-                arg_values.append(args_deque.popleft())
+                arg_values.append(str(args_deque.popleft()))
         elif arg.lowered.nargs in ("*", "+", "?"):
             counter = 0
             while len(args_deque) > 0:
+                # A value explicitly attached via `=` is consumed verbatim,
+                # bypassing the `--` and flag-like termination checks below.
+                is_literal = isinstance(args_deque[0], _LiteralValue)
+
                 # Handle '--' end-of-options marker.
-                if args_deque[0] == "--" and not seen_double_dash:
+                if args_deque[0] == "--" and not seen_double_dash and not is_literal:
                     # For kwargs (non-positional), '--' terminates value
                     # consumption. Leave '--' in deque for the main loop.
                     if not arg.is_positional():
@@ -922,7 +973,7 @@ class TyroBackend(ParserBackend):
                     continue
 
                 # After '--', skip all flag-related termination checks.
-                if not seen_double_dash:
+                if not seen_double_dash and not is_literal:
                     # Partition on '=' to handle --flag=value syntax.
                     token_key = args_deque[0].partition("=")[0]
                     if kwarg_map.contains_normalized(token_key):
@@ -956,16 +1007,17 @@ class TyroBackend(ParserBackend):
                 if arg.lowered.nargs == "?" and counter > 0:
                     break
 
-                # For kwargs with variable nargs, reserve values for
-                # remaining required positional args.
+                # Reserve values for remaining required positional args. This
+                # applies to a variable-nargs keyword arg (so it doesn't eat a
+                # trailing required positional) and to a variable-nargs
+                # positional (so it leaves values for later positionals).
                 if (
-                    not arg.is_positional()
-                    and min_remaining_positional > 0
+                    min_remaining_positional > 0
                     and len(args_deque) <= min_remaining_positional
                 ):
                     break
 
-                arg_values.append(args_deque.popleft())
+                arg_values.append(str(args_deque.popleft()))
                 counter += 1
             if arg.lowered.nargs == "+" and counter == 0:
                 _tyro_help_formatting.error_and_exit(

--- a/src/tyro/_backends/_tyro_backend.py
+++ b/src/tyro/_backends/_tyro_backend.py
@@ -141,12 +141,16 @@ class KwargMap:
                 # matching argparse. Any other ``=`` is part of the value
                 # (``-na=foo`` -> ``a=foo``).
                 rest = token[i + 1 :]
+                # The glued value is an explicit value attached to the flag
+                # (just like ``--x=value``), so mark it `_LiteralValue`: it must
+                # be consumed verbatim even when it looks like a flag, e.g.
+                # ``-n-x`` -> ``-n`` with value ``-x``.
                 if rest.startswith("="):
                     # Explicit separator: the value is whatever follows, even
                     # if empty.
-                    expanded.append(rest[1:])
+                    expanded.append(_LiteralValue(rest[1:]))
                 elif rest:
-                    expanded.append(rest)
+                    expanded.append(_LiteralValue(rest))
                 break
         return expanded
 

--- a/src/tyro/_backends/_tyro_backend.py
+++ b/src/tyro/_backends/_tyro_backend.py
@@ -136,9 +136,11 @@ class KwargMap:
             expanded.append("-" + ch)
             if arg.lowered.action not in _FLAG_ACTIONS:
                 # Value-taking short: the rest of the token is its value. A
-                # single `=` immediately after the flag character acts as a
-                # separator (``-n=foo`` -> ``foo``, ``-abn=foo`` -> ``foo``),
-                # matching argparse. Any other ``=`` is part of the value
+                # single `=` immediately after the value-taking flag character
+                # acts as a separator (``-n=foo`` -> ``foo`` -- this matches
+                # argparse; ``-abn=foo`` -> ``foo`` -- tyro strips the `=` here
+                # too for consistency, whereas argparse would keep ``=foo``).
+                # An `=` that is not right after the flag is part of the value
                 # (``-na=foo`` -> ``a=foo``).
                 rest = token[i + 1 :]
                 # The glued value is an explicit value attached to the flag

--- a/src/tyro/_backends/_tyro_backend.py
+++ b/src/tyro/_backends/_tyro_backend.py
@@ -90,9 +90,12 @@ class KwargMap:
         increments once per character). Returns ``None`` if the token isn't
         a short cluster or contains an unknown character.
 
-        The caller must strip any trailing ``=value`` before calling, and
-        must already have ruled out an exact alias match (so explicit
-        multi-char shorts like ``-cail`` are preferred).
+        The full token (including any ``=value``) should be passed in: for a
+        value-taking short, the rest of the token becomes the value, and a
+        single ``=`` immediately after the flag character is treated as a
+        separator (``-n=foo`` -> ``foo``). The caller must already have ruled
+        out an exact alias match (so explicit multi-char shorts like
+        ``-cail`` are preferred).
         """
         if not (token.startswith("-") and len(token) > 2 and token[1] != "-"):
             return None
@@ -103,9 +106,17 @@ class KwargMap:
                 return None
             expanded.append("-" + ch)
             if arg.lowered.action not in _FLAG_ACTIONS:
-                # Value-taking short: the rest of the token is its value.
+                # Value-taking short: the rest of the token is its value. A
+                # single `=` immediately after the flag character acts as a
+                # separator (``-n=foo`` -> ``foo``, ``-abn=foo`` -> ``foo``),
+                # matching argparse. Any other ``=`` is part of the value
+                # (``-na=foo`` -> ``a=foo``).
                 rest = token[i + 1 :]
-                if rest:
+                if rest.startswith("="):
+                    # Explicit separator: the value is whatever follows, even
+                    # if empty.
+                    expanded.append(rest[1:])
+                elif rest:
                     expanded.append(rest)
                 break
         return expanded
@@ -559,13 +570,15 @@ class TyroBackend(ParserBackend):
                 # POSIX-style short flag clustering (-abc -> -a -b -c).
                 # Tried only after exact-match lookups, so registered
                 # multi-char shorts like -cail still win.
-                flag_token = (
-                    arg_value if equals_value is None else arg_value.partition("=")[0]
-                )
-                expanded = kwarg_map.expand_short_cluster(flag_token)
+                #
+                # We pass the original token (including any `=value`) rather
+                # than the `=`-pre-split form: for a value-taking short, the
+                # `=` is only a separator when it immediately follows the flag
+                # character, and `expand_short_cluster` handles this. Splitting
+                # eagerly here would corrupt values like `-na=foo` (which must
+                # parse to `-n` with value `a=foo`).
+                expanded = kwarg_map.expand_short_cluster(arg_value)
                 if expanded is not None:
-                    if equals_value is not None:
-                        expanded.append(equals_value)
                     args_deque.extendleft(reversed(expanded))
                     continue
 

--- a/src/tyro/_backends/_tyro_backend.py
+++ b/src/tyro/_backends/_tyro_backend.py
@@ -901,7 +901,7 @@ class TyroBackend(ParserBackend):
                 if len(args_deque) == 0:
                     _tyro_help_formatting.error_and_exit(
                         "Missing argument",
-                        f"Missing value for argument '{arg.lowered.name_or_flags}'. "
+                        f"Missing value for argument '{arg.display_name()}'. "
                         f"Expected {arg.lowered.nargs} values.",
                         prog=prog,
                         console_outputs=console_outputs,
@@ -969,7 +969,7 @@ class TyroBackend(ParserBackend):
                 counter += 1
             if arg.lowered.nargs == "+" and counter == 0:
                 _tyro_help_formatting.error_and_exit(
-                    f"Missing value for argument '{arg.lowered.name_or_flags}'. "
+                    f"Missing value for argument '{arg.display_name()}'. "
                     f"Expected at least one value.",
                     prog=prog,
                     console_outputs=console_outputs,
@@ -980,16 +980,7 @@ class TyroBackend(ParserBackend):
         if arg.lowered.choices is not None:
             for value in arg_values:
                 if value not in arg.lowered.choices:
-                    # Use name_or_flags for consistent display across positional and flag arguments.
-                    if arg.is_positional():
-                        arg_display_name = arg.lowered.name_or_flags[-1]
-                        # For DummyWrapper (used for direct Literal types), use a generic term
-                        # instead of the internal name to avoid exposing implementation details.
-                        if arg_display_name == "__tyro-dummy-inner__":
-                            arg_display_name = "value"
-                    else:
-                        # name_or_flags is a tuple, join with / for display.
-                        arg_display_name = "/".join(arg.lowered.name_or_flags)
+                    arg_display_name = arg.display_name()
                     _tyro_help_formatting.error_and_exit(
                         "Invalid choice",
                         fmt.text(

--- a/src/tyro/_backends/_tyro_backend.py
+++ b/src/tyro/_backends/_tyro_backend.py
@@ -37,12 +37,37 @@ class _LiteralValue(str):
     fixed/variable-nargs argument must not silently swallow."""
 
 
+# Special float spellings that ``float()`` accepts but argparse's
+# negative-number matcher misses. Matched case-insensitively.
+_SPECIAL_FLOAT_BODIES = frozenset({"inf", "infinity", "nan"})
+
+
+def _looks_like_negative_number(token: str) -> bool:
+    """Whether ``token`` is a negative numeric value (so it should be consumed as
+    a value, not treated as a flag): a single leading ``-`` followed by a digit
+    or ``.`` (e.g. ``-5``, ``-.5``, ``-1e9``, ``-1j``), or one of the special
+    float spellings ``-inf`` / ``-nan`` / ``-infinity`` (any capitalization). A
+    ``--`` prefix is excluded, since that genuinely looks like a long flag."""
+    if not (token.startswith("-") and len(token) > 1 and token[1] != "-"):
+        return False
+    rest = token[1:]
+    return rest[0].isdigit() or rest[0] == "." or rest.lower() in _SPECIAL_FLOAT_BODIES
+
+
+def _is_registered_choice(arg: "_arguments.ArgumentDefinition", token: str) -> bool:
+    """Whether ``token`` is one of the argument's explicit ``choices`` (e.g. a
+    dash-prefixed ``Literal`` value like ``-b``). Such a token is unambiguous and
+    must be consumed as a value even though it looks flag-like."""
+    return arg.lowered.choices is not None and token in arg.lowered.choices
+
+
 def _blocks_value_consumption(token: str, kwarg_map: "KwargMap") -> bool:
     """Whether ``token`` should NOT be consumed as an argument value: the
     end-of-options ``--`` marker, a registered flag, or a flag-like token
     (leading dash followed by an alpha character, so negative numbers like
-    ``-5`` are still treated as values). Matches argparse, which errors rather
-    than consuming e.g. ``--x --verbose`` as the value of ``--x``.
+    ``-5`` -- and special floats like ``-inf``/``-nan`` -- are still treated as
+    values). Matches argparse, which errors rather than consuming e.g.
+    ``--x --verbose`` as the value of ``--x``.
 
     ``_LiteralValue`` tokens (supplied via ``=``) are never blocking."""
     if isinstance(token, _LiteralValue):
@@ -52,6 +77,8 @@ def _blocks_value_consumption(token: str, kwarg_map: "KwargMap") -> bool:
     token_key = token.partition("=")[0]
     if kwarg_map.contains_normalized(token_key):
         return True
+    if _looks_like_negative_number(token_key):
+        return False
     return (
         token_key.startswith("-")
         and len(token_key) > 1
@@ -951,6 +978,7 @@ class TyroBackend(ParserBackend):
                 if len(args_deque) == 0 or (
                     not seen_double_dash
                     and _blocks_value_consumption(args_deque[0], kwarg_map)
+                    and not _is_registered_choice(arg, args_deque[0])
                 ):
                     _tyro_help_formatting.error_and_exit(
                         "Missing argument",
@@ -986,14 +1014,18 @@ class TyroBackend(ParserBackend):
                         break
 
                     # To match argparse behavior, any flag-like string
-                    # terminates positional nargs consumption. We check for
-                    # a leading alpha character after stripping dashes to
-                    # avoid treating negative numbers (like -2 or -3.14)
-                    # as flags.
+                    # terminates variable nargs consumption. We check for a
+                    # leading alpha character after stripping dashes to avoid
+                    # treating negative numbers (like -2 or -3.14) and special
+                    # floats (-inf/-nan) as flags. A token that is an explicit
+                    # `choices` value (e.g. a dash-prefixed Literal) is also a
+                    # value, not a flag.
                     if (
                         token_key.startswith("-")
                         and len(token_key) > 1
                         and token_key.lstrip("-")[:1].isalpha()
+                        and not _looks_like_negative_number(token_key)
+                        and not _is_registered_choice(arg, args_deque[0])
                     ):
                         break
                     # Break if we reach a subparser. This diverges from

--- a/src/tyro/_fields.py
+++ b/src/tyro/_fields.py
@@ -521,7 +521,12 @@ def _field_list_from_function(
             else:
                 # Original behavior: creates `--kwargs STR T [STR T ...]` argument.
                 typ = Dict[str, typ]  # type: ignore
-                default = {}
+                # Only set the empty default when there's no default_instance,
+                # so the _OPTIONAL_GROUP logic can return the provided default
+                # directly (mirrors the *args branch above). Without this guard
+                # a `default=` instance for a **kwargs parameter is dropped.
+                if is_missing(default_instance):
+                    default = {}
 
         with FieldDefinition.marker_context(func_markers):
             field_list.append(

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -443,9 +443,25 @@ def _validated_aliases(
         if canonical not in parser_from_name:
             continue
         for alias in aliases:
-            assert alias not in parser_from_name, (
+            # An alias collides with a canonical name if *typing the alias*
+            # would resolve to that canonical. At parse time a token resolves
+            # by trying both its raw form and its delimiter-swapped form (under
+            # the default `-` delimiter, `swap_delimiters` turns `_` into `-`),
+            # so typing `a_b` reaches a canonical `a-b` but typing `a-b` does
+            # NOT reach a canonical `a_b`. We mirror that asymmetry here rather
+            # than normalizing both sides, which would over-reject legitimate
+            # manually-underscored names.
+            swapped = _strings.swap_delimiters(alias)
+            if alias in parser_from_name:
+                collides_with = alias
+            elif swapped in parser_from_name:
+                collides_with = swapped
+            else:
+                collides_with = None
+            assert collides_with is None, (
                 f"Alias {alias!r} on subcommand {canonical!r} collides with "
-                f"the canonical name of another subcommand in the same Union."
+                f"the canonical name {collides_with!r} of another subcommand "
+                f"in the same Union."
             )
             assert alias not in seen, (
                 f"Alias {alias!r} is registered on both {seen[alias]!r} and "

--- a/src/tyro/_parsers.py
+++ b/src/tyro/_parsers.py
@@ -443,25 +443,17 @@ def _validated_aliases(
         if canonical not in parser_from_name:
             continue
         for alias in aliases:
-            # An alias collides with a canonical name if *typing the alias*
-            # would resolve to that canonical. At parse time a token resolves
-            # by trying both its raw form and its delimiter-swapped form (under
-            # the default `-` delimiter, `swap_delimiters` turns `_` into `-`),
-            # so typing `a_b` reaches a canonical `a-b` but typing `a-b` does
-            # NOT reach a canonical `a_b`. We mirror that asymmetry here rather
-            # than normalizing both sides, which would over-reject legitimate
-            # manually-underscored names.
-            swapped = _strings.swap_delimiters(alias)
-            if alias in parser_from_name:
-                collides_with = alias
-            elif swapped in parser_from_name:
-                collides_with = swapped
-            else:
-                collides_with = None
-            assert collides_with is None, (
+            # An alias only genuinely collides with a canonical name when it is
+            # *exactly* that canonical name. At parse time a token resolves by
+            # exact match first (then by a delimiter swap), so a registered
+            # alias is always reachable as itself -- even when its swapped form
+            # (`_`<->`-`) happens to match another subcommand's canonical. We
+            # must NOT reject the swapped form: doing so wrongly forbids natural
+            # aliases like `run_server` for a `run-server` subcommand (its own
+            # canonical), and aliases that are still distinctly reachable.
+            assert alias not in parser_from_name, (
                 f"Alias {alias!r} on subcommand {canonical!r} collides with "
-                f"the canonical name {collides_with!r} of another subcommand "
-                f"in the same Union."
+                f"the canonical name of another subcommand in the same Union."
             )
             assert alias not in seen, (
                 f"Alias {alias!r} is registered on both {seen[alias]!r} and "

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -457,11 +457,19 @@ class TypeParamResolver:
                 # the active assignment maps so that we end up with a concrete
                 # type. `resolve_params_and_aliases()` handles cycle detection
                 # (e.g. a TypeVar that resolves to itself) via `seen`.
+                if resolved is not typ:
+                    resolved = TypeParamResolver.resolve_params_and_aliases(
+                        resolved, seen=seen, ignore_confstruct=ignore_confstruct
+                    )
                 if resolved is typ:
-                    return resolved  # type: ignore
-                return TypeParamResolver.resolve_params_and_aliases(
-                    resolved, seen=seen, ignore_confstruct=ignore_confstruct
-                )
+                    # The assignment map made no progress: either an identity
+                    # binding (e.g. the sibling context for `Pair[float, V]`
+                    # maps the free `V` to itself) or a cycle that bounced back
+                    # (e.g. `Pair[V, K]` maps `K -> V -> K`). Try enclosing
+                    # scopes, then fall through to the PEP 696 default /
+                    # bound / constraint handling below, as if unbound.
+                    continue
+                return resolved  # type: ignore
 
         # Found a TypeVar that isn't bound.
         # Note: In Python 3.8, Unpack[TypedDict] incorrectly passes isinstance(typ, TypeVar).

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -562,9 +562,27 @@ class TypeParamResolver:
                         isinstance(cast(Any, p), TypeVar) for p in origin_params
                     )
                 ):
-                    sibling_context = TypeParamAssignmentContext(
-                        typ, dict(zip(origin_params, new_args_list))
-                    )
+                    # Only bind parameters that aren't already bound by an
+                    # enclosing scope. A sibling binding exists to fill in an
+                    # origin parameter (e.g. a chained PEP 696 default) that has
+                    # no other source; it must NOT shadow a binding from an outer
+                    # generic. This matters when a TypeVar *object* is reused
+                    # across scopes: e.g. `OuterNest[str]` with a field
+                    # `Pair[int, List[T]]` would otherwise rebind the shared `T`
+                    # to `int` while resolving the inner `List[T]`, instead of
+                    # keeping the enclosing `T -> str`.
+                    already_bound: Set[TypeVar] = set()
+                    for assignment_map in TypeParamResolver.param_assignments:
+                        already_bound.update(assignment_map.keys())
+                    sibling_assignments = {
+                        p: a
+                        for p, a in zip(origin_params, new_args_list)
+                        if p not in already_bound
+                    }
+                    if sibling_assignments:
+                        sibling_context = TypeParamAssignmentContext(
+                            typ, sibling_assignments
+                        )
 
             # Recursively resolve type parameters and aliases in the arguments.
             # We copy `seen` for each arg to prevent sibling args from interfering

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -450,7 +450,7 @@ class TypeParamResolver:
         # Search for type parameter assignments.
         for type_from_typevar in reversed(TypeParamResolver.param_assignments):
             if typ in type_from_typevar:
-                resolved = type_from_typevar[typ]
+                resolved = type_from_typevar[typ]  # type: ignore
                 # The binding may itself be (or contain) another TypeVar, for
                 # example with chained PEP 696 defaults like
                 # `V = TypeVar("V", default=K)`. Recursively resolve it through
@@ -480,7 +480,9 @@ class TypeParamResolver:
                 if default is typ:
                     return default  # type: ignore
                 return TypeParamResolver.resolve_params_and_aliases(
-                    default, seen=seen, ignore_confstruct=ignore_confstruct
+                    default,  # type: ignore
+                    seen=seen,
+                    ignore_confstruct=ignore_confstruct,
                 )
 
             bound = getattr(typ, "__bound__", None)
@@ -558,9 +560,7 @@ class TypeParamResolver:
                     # Only do this for user-defined generic classes, not builtin
                     # containers like list/dict/tuple (whose origins don't carry
                     # meaningful TypeVar parameters here).
-                    and all(
-                        isinstance(cast(Any, p), TypeVar) for p in origin_params
-                    )
+                    and all(isinstance(cast(Any, p), TypeVar) for p in origin_params)
                 ):
                     # Only bind parameters that aren't already bound by an
                     # enclosing scope. A sibling binding exists to fill in an

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -963,14 +963,38 @@ def get_type_hints_resolve_type_params(
     return out
 
 
+def _type_param_localns(obj: Any) -> Dict[str, Any]:
+    """Namespace mapping PEP 695 type parameter names to their TypeVar objects.
+
+    PEP 695 type parameters (``class Foo[T]: ...`` / ``def f[T](): ...``, Python
+    3.12+) live in ``__type_params__``, NOT in module globals. So a stringized
+    annotation that references one -- e.g. under ``from __future__ import
+    annotations`` -- fails to resolve via `get_type_hints`'s default namespaces
+    (``NameError: name 'T' is not defined``). We collect them (from the class's
+    full MRO, so inherited generic annotations resolve too) to pass as a local
+    namespace. Empty on Python < 3.12, so this is a no-op there."""
+    localns: Dict[str, Any] = {}
+    classes = obj.__mro__ if inspect.isclass(obj) else (obj,)
+    for cls in classes:
+        for type_param in getattr(cls, "__type_params__", ()):
+            name = getattr(type_param, "__name__", None)
+            if name is not None:
+                localns.setdefault(name, type_param)
+    return localns
+
+
 def _get_type_hints_backported_syntax(
     obj: Callable[..., Any], include_extras: bool = False
 ) -> Dict[str, Any]:
     """Same as `typing.get_type_hints()`, but supports new union syntax (X | Y)
-    and generics (list[str]) in older versions of Python."""
+    and generics (list[str]) in older versions of Python, and resolves PEP 695
+    type parameters in stringized annotations."""
 
+    localns = _type_param_localns(obj)
     try:
-        return get_type_hints(obj, include_extras=include_extras)
+        return get_type_hints(
+            obj, localns=localns or None, include_extras=include_extras
+        )
 
     except TypeError as e:  # pragma: no cover
         # Resolve new type syntax using eval_type_backport.
@@ -988,7 +1012,9 @@ def _get_type_hints_backported_syntax(
                     globalns = getattr(getattr(obj, "__init__"), "__globals__", None)
 
                 out = {
-                    k: eval_type_backport(ForwardRef(v), globalns=globalns, localns={})
+                    k: eval_type_backport(
+                        ForwardRef(v), globalns=globalns, localns=localns
+                    )
                     for k, v in getattr(obj, "__annotations__").items()
                 }
                 return out

--- a/src/tyro/_resolver.py
+++ b/src/tyro/_resolver.py
@@ -15,6 +15,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    Optional,
     Sequence,
     Set,
     Tuple,
@@ -449,7 +450,18 @@ class TypeParamResolver:
         # Search for type parameter assignments.
         for type_from_typevar in reversed(TypeParamResolver.param_assignments):
             if typ in type_from_typevar:
-                return type_from_typevar[typ]  # type: ignore
+                resolved = type_from_typevar[typ]
+                # The binding may itself be (or contain) another TypeVar, for
+                # example with chained PEP 696 defaults like
+                # `V = TypeVar("V", default=K)`. Recursively resolve it through
+                # the active assignment maps so that we end up with a concrete
+                # type. `resolve_params_and_aliases()` handles cycle detection
+                # (e.g. a TypeVar that resolves to itself) via `seen`.
+                if resolved is typ:
+                    return resolved  # type: ignore
+                return TypeParamResolver.resolve_params_and_aliases(
+                    resolved, seen=seen, ignore_confstruct=ignore_confstruct
+                )
 
         # Found a TypeVar that isn't bound.
         # Note: In Python 3.8, Unpack[TypedDict] incorrectly passes isinstance(typ, TypeVar).
@@ -460,8 +472,16 @@ class TypeParamResolver:
             default = getattr(typ, "__default__", NoDefault)
             # If __default__ exists and is not the NoDefault sentinel, use it.
             if default is not NoDefault:
-                # We have a valid default, use it without warning.
-                return default  # type: ignore
+                # The default may itself be (or contain) another TypeVar, for
+                # example `V = TypeVar("V", default=K)`. Resolve it recursively
+                # through the active assignment maps so a chained default like
+                # `K` gets bound to its concrete type. Cycles are guarded by
+                # `seen` in `resolve_params_and_aliases()`.
+                if default is typ:
+                    return default  # type: ignore
+                return TypeParamResolver.resolve_params_and_aliases(
+                    default, seen=seen, ignore_confstruct=ignore_confstruct
+                )
 
             bound = getattr(typ, "__bound__", None)
             if bound is not None:
@@ -520,15 +540,48 @@ class TypeParamResolver:
                             break
                     new_args_list.append(x)
 
+            # For a parameterized generic class like `Entry[int]`, the args are
+            # the bindings for the origin class's own type parameters. We push an
+            # assignment context mapping those parameters to the args before
+            # resolving them, so that a chained PEP 696 default (e.g.
+            # `V = TypeVar("V", default=K)`, where `Entry[int].__args__` is
+            # `(int, ~K)`) resolves the trailing `~K` against its sibling binding
+            # `K -> int` rather than falling back to `K`'s own default.
+            sibling_context: Optional[TypeParamAssignmentContext] = None
+            if origin is not None:
+                origin_params = getattr(origin, "__parameters__", None)
+                if (
+                    origin_params is not None
+                    and hasattr(origin_params, "__len__")
+                    and len(origin_params) == len(new_args_list)
+                    and len(origin_params) > 0
+                    # Only do this for user-defined generic classes, not builtin
+                    # containers like list/dict/tuple (whose origins don't carry
+                    # meaningful TypeVar parameters here).
+                    and all(
+                        isinstance(cast(Any, p), TypeVar) for p in origin_params
+                    )
+                ):
+                    sibling_context = TypeParamAssignmentContext(
+                        typ, dict(zip(origin_params, new_args_list))
+                    )
+
             # Recursively resolve type parameters and aliases in the arguments.
             # We copy `seen` for each arg to prevent sibling args from interfering
             # with each other's cycle detection.
-            new_args = tuple(
-                TypeParamResolver.resolve_params_and_aliases(
-                    x, seen=seen.copy() if len(new_args_list) > 1 else seen
+            def _resolve_new_args() -> Tuple[Any, ...]:
+                return tuple(
+                    TypeParamResolver.resolve_params_and_aliases(
+                        x, seen=seen.copy() if len(new_args_list) > 1 else seen
+                    )
+                    for x in new_args_list
                 )
-                for x in new_args_list
-            )
+
+            if sibling_context is not None:
+                with sibling_context:
+                    new_args = _resolve_new_args()
+            else:
+                new_args = _resolve_new_args()
 
             # Early return if nothing changed.
             if new_args == args_to_process:

--- a/src/tyro/constructors/_backtracking.py
+++ b/src/tyro/constructors/_backtracking.py
@@ -18,6 +18,11 @@ class BacktrackState:
     parsed_value: Any | None  # The value parsed at this state, if any.
     parent: BacktrackState | None  # Link to parent state to reconstruct path.
     nargs_option_idx: int
+    # `arg_idx` at the start of the current cycle (only meaningful when
+    # `is_repeating`). Used to detect a full cycle of specs that consumed zero
+    # arguments, which would otherwise loop forever (e.g. a repeated zero-width
+    # spec like the empty tuple `Tuple[()]`).
+    cycle_start_arg_idx: int = 0
 
 
 def parse_with_backtracking(
@@ -60,10 +65,15 @@ def parse_with_backtracking(
         )
     """
 
-    assert len(specs) >= 1, "At least one spec is required"
+    if len(specs) == 0:
+        # The empty tuple type `Tuple[()]` produces zero inner specs. The only
+        # valid parse consumes zero arguments. (This is reached when an empty
+        # tuple is nested inside another container, whose parser invokes the
+        # empty tuple's instantiator.)
+        return [] if len(args) == 0 else None
 
     # Use iterative approach with explicit stack to avoid recursion limit.
-    stack: list[BacktrackState] = [BacktrackState(0, 0, None, None, 0)]
+    stack: list[BacktrackState] = [BacktrackState(0, 0, None, None, 0, 0)]
 
     def reconstruct_path(state: BacktrackState) -> list[Any]:
         """Reconstruct the parsed values from the state chain."""
@@ -82,13 +92,27 @@ def parse_with_backtracking(
         nargs_option_idx = state.nargs_option_idx
 
         # Base cases.
+        cycle_start_arg_idx = state.cycle_start_arg_idx
         if is_repeating:
             # For repeating specs, success when all args consumed.
             if arg_idx == len(args):
                 # When repeating multiple specs, ensure we completed full cycles.
                 if len(specs) > 1 and spec_idx % len(specs) != 0:
+                    # Known limitation: a repeating multi-spec whose *trailing*
+                    # spec is zero-width (e.g. `Dict[str, Tuple[()]]`) is
+                    # rejected here. Closing the cycle with the empty match
+                    # would bypass the zero-progress pruning below, which is
+                    # load-bearing for disambiguating unions. Such types are
+                    # impractical, so we accept the clean rejection.
                     continue  # Incomplete cycle, not a valid parse.
                 return reconstruct_path(state)
+            # At a cycle boundary, detect a full cycle that consumed zero
+            # arguments. Such a path can never consume the remaining args and
+            # would loop forever (e.g. a repeated zero-width spec); prune it.
+            if spec_idx > 0 and spec_idx % len(specs) == 0:
+                if arg_idx == cycle_start_arg_idx:
+                    continue
+                cycle_start_arg_idx = arg_idx  # A new cycle begins here.
             spec = specs[spec_idx % len(specs)]
         else:
             # For non-repeating specs, success when all specs processed.
@@ -97,9 +121,19 @@ def parse_with_backtracking(
                     return reconstruct_path(state)
                 else:
                     continue
-            if arg_idx == len(args):
-                continue
             spec = specs[spec_idx]
+            if arg_idx == len(args):
+                # All arguments consumed, but specs remain. A spec that can
+                # match zero arguments (e.g. the empty tuple `Tuple[()]` with
+                # nargs=0) can still complete the parse; otherwise this path is
+                # dead. Positive-nargs specs are pruned naturally below.
+                zero_ok = (
+                    spec.nargs == "*"
+                    or spec.nargs == 0
+                    or (isinstance(spec.nargs, tuple) and 0 in spec.nargs)
+                )
+                if not zero_ok:
+                    continue
 
         # Get nargs options for current spec.
         if spec.nargs == "*":
@@ -122,6 +156,7 @@ def parse_with_backtracking(
                     state.parsed_value,
                     state.parent,
                     nargs_option_idx + 1,
+                    state.cycle_start_arg_idx,
                 )
             )
 
@@ -150,6 +185,7 @@ def parse_with_backtracking(
                     parsed,
                     state,
                     0,
+                    cycle_start_arg_idx,
                 )
             )
         except ValueError:

--- a/src/tyro/constructors/_backtracking.py
+++ b/src/tyro/constructors/_backtracking.py
@@ -127,10 +127,8 @@ def parse_with_backtracking(
                 # match zero arguments (e.g. the empty tuple `Tuple[()]` with
                 # nargs=0) can still complete the parse; otherwise this path is
                 # dead. Positive-nargs specs are pruned naturally below.
-                zero_ok = (
-                    spec.nargs == "*"
-                    or spec.nargs == 0
-                    or (isinstance(spec.nargs, tuple) and 0 in spec.nargs)
+                zero_ok = spec.nargs in ("*", 0) or (
+                    isinstance(spec.nargs, tuple) and 0 in spec.nargs
                 )
                 if not zero_ok:
                     continue

--- a/src/tyro/constructors/_primitive_spec.py
+++ b/src/tyro/constructors/_primitive_spec.py
@@ -612,7 +612,7 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
         # 3.8-3.10. Normalize the latter to "no inner types" so both produce a
         # spec that consumes zero arguments.
         if types == ((),):
-            types = ()
+            types = ()  # pragma: no cover (reachable only on Python 3.8-3.10)
         typeset = set(types)  # Sets are unordered.
         typeset_no_ellipsis = typeset - {Ellipsis}  # type: ignore
 

--- a/src/tyro/constructors/_primitive_spec.py
+++ b/src/tyro/constructors/_primitive_spec.py
@@ -500,6 +500,9 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
     ) -> PrimitiveConstructorSpec | UnsupportedTypeAnnotationError | None:
         if type_info.type_origin not in (
             collections.abc.Sequence,
+            collections.abc.MutableSequence,
+            collections.abc.Set,
+            collections.abc.MutableSet,
             frozenset,
             list,
             set,
@@ -509,8 +512,18 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
             return None
         container_type = type_info.type_origin
         assert container_type is not None
-        if container_type is collections.abc.Sequence:
+        # Map abstract base classes to concrete constructible types. The
+        # immutable `collections.abc.Set` maps to `frozenset`; the mutable abcs
+        # map to their natural mutable concrete type.
+        if container_type in (
+            collections.abc.Sequence,
+            collections.abc.MutableSequence,
+        ):
             container_type = list
+        elif container_type is collections.abc.Set:
+            container_type = frozenset
+        elif container_type is collections.abc.MutableSet:
+            container_type = set
 
         args = get_args(type_info.type)
         if container_type is tuple:
@@ -670,13 +683,45 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
     def dict_rule(
         type_info: PrimitiveTypeInfo,
     ) -> PrimitiveConstructorSpec | UnsupportedTypeAnnotationError | None:
-        if (
-            type_info.type_origin not in (dict, collections.abc.Mapping)
-            or len(get_args(type_info.type)) != 2
-        ):
+        # Map the (possibly abstract or subclass) mapping origin to a concrete
+        # factory that turns a plain parsed `dict` into the desired type.
+        #
+        # Notes:
+        # - `collections.abc.Mapping` is immutable in spirit, but there is no
+        #   immutable concrete mapping in the stdlib, so (matching prior
+        #   behavior) we construct a plain `dict`.
+        # - `defaultdict` is constructed as `defaultdict(None, parsed)`. We
+        #   cannot infer a sensible `default_factory` from the annotation, so we
+        #   leave it as `None`. The result is still a real `defaultdict`
+        #   instance and round-trips through `str_from_instance`; it simply
+        #   behaves like a plain dict on missing-key access (raising KeyError).
+        mapping_origin = type_info.type_origin
+        mapping_factories: dict[Any, Callable[[dict], Any]] = {
+            dict: dict,
+            collections.abc.Mapping: dict,
+            collections.abc.MutableMapping: dict,
+            collections.OrderedDict: collections.OrderedDict,
+            collections.Counter: collections.Counter,
+            collections.defaultdict: lambda parsed: collections.defaultdict(
+                None, parsed
+            ),
+        }
+        if mapping_origin not in mapping_factories:
             return None
+        container_factory = mapping_factories[mapping_origin]
 
-        key_type, val_type = get_args(type_info.type)
+        type_args = get_args(type_info.type)
+        if mapping_origin is collections.Counter:
+            # `Counter[K]` has a single type argument: the key type. The values
+            # are implicitly integer counts.
+            if len(type_args) != 1:
+                return None
+            (key_type,) = type_args
+            val_type: Any = int
+        elif len(type_args) == 2:
+            key_type, val_type = type_args
+        else:
+            return None
         key_spec = ConstructorRegistry.get_primitive_spec(
             PrimitiveTypeInfo.make(
                 raw_annotation=key_type,
@@ -742,7 +787,7 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
             for i in range(0, len(parsed), 2):
                 out[parsed[i]] = parsed[i + 1]
 
-            return out
+            return container_factory(out)
 
         def str_from_instance(instance: dict) -> list[str]:
             # TODO: this may be strange right now for the append action.

--- a/src/tyro/constructors/_primitive_spec.py
+++ b/src/tyro/constructors/_primitive_spec.py
@@ -575,6 +575,12 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
         if type_info.type_origin is not tuple:
             return None
         types = get_args(type_info.type)
+        # The empty tuple type `Tuple[()]` is represented inconsistently across
+        # Python versions: `get_args` returns `()` on 3.11+ but `((),)` on
+        # 3.8-3.10. Normalize the latter to "no inner types" so both produce a
+        # spec that consumes zero arguments.
+        if types == ((),):
+            types = ()
         typeset = set(types)  # Sets are unordered.
         typeset_no_ellipsis = typeset - {Ellipsis}  # type: ignore
 
@@ -846,13 +852,18 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
             if not (t is type(None) and _markers.DisallowNone in type_info.markers):
                 metavar_parts.append(option_spec.metavar)
 
-            if t is not type(None):
-                # Track if all options have fixed nargs.
-                if isinstance(option_spec.nargs, int):
-                    nargs_set.add(option_spec.nargs)
-                else:
-                    all_fixed_nargs = False
+            # Track if all options have fixed nargs. We include NoneType here
+            # (its nargs is always 1) so that unions like
+            # `Optional[Tuple[int, int]]` produce a nargs that accepts both the
+            # single-token `None` and the multi-token tuple. Without this, the
+            # computed nargs would be the tuple's exact count and the `None`
+            # token could never be supplied.
+            if isinstance(option_spec.nargs, int):
+                nargs_set.add(option_spec.nargs)
+            elif t is not type(None):
+                all_fixed_nargs = False
 
+            if t is not type(None):
                 # Enforce that `nargs` is the same for all child types, except for
                 # NoneType.
                 if first:

--- a/src/tyro/constructors/_primitive_spec.py
+++ b/src/tyro/constructors/_primitive_spec.py
@@ -273,8 +273,10 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
             nargs=1,
             metavar=type_info.type.__name__.upper(),
             instance_from_str=lambda args: (
-                bytes(args[0], encoding="ascii")
-                if type_info.type is bytes
+                # `bytes`/`bytearray` need an explicit encoding; the others
+                # accept the string directly.
+                type_info.type(args[0], "ascii")
+                if type_info.type in (bytes, bytearray)
                 else type_info.type(args[0])
             ),
             # issubclass(type(x), y) here is preferable over isinstance(x, y)
@@ -339,10 +341,27 @@ def apply_default_primitive_rules(registry: ConstructorRegistry) -> None:
         except TypeError:
             # `issubclass()` failed.
             return None
+
+        def path_from_str(args: List[str]) -> Any:
+            typ = type_info.type
+            # Pure path types (PurePath/PurePosixPath/PureWindowsPath) are
+            # instantiable on any OS and preserve their flavour, so honor the
+            # annotated type. Concrete `Path`/`os.PathLike` fall back to
+            # `pathlib.Path`, which resolves to the correct OS-specific class
+            # (and avoids NotImplementedError when instantiating the
+            # non-native concrete `PosixPath`/`WindowsPath`).
+            if (
+                isinstance(typ, type)
+                and issubclass(typ, pathlib.PurePath)
+                and not issubclass(typ, pathlib.Path)
+            ):
+                return typ(args[0])
+            return pathlib.Path(args[0])
+
         return PrimitiveConstructorSpec(
             nargs=1,
             metavar=type_info.type.__name__.upper(),
-            instance_from_str=lambda args: pathlib.Path(args[0]),
+            instance_from_str=path_from_str,
             is_instance=lambda x: hasattr(x, "__fspath__"),
             str_from_instance=lambda instance: [str(instance)],
         )

--- a/src/tyro/constructors/_struct_spec_attrs.py
+++ b/src/tyro/constructors/_struct_spec_attrs.py
@@ -30,6 +30,19 @@ def attrs_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
         info.type, include_extras=True
     )
 
+    # attrs renames some constructor parameters relative to the attribute name:
+    # a private field `_x` takes init argument `x`, and `attrs.field(alias=...)`
+    # sets an explicit init-arg name. We key our fields (CLI flags, docstrings,
+    # reading values off a default instance) by the attribute name, but must
+    # call the constructor with the init-arg name. Build that mapping. (`.alias`
+    # is available in attrs >= 22.2; fall back to the historical leading-
+    # underscore-stripping behavior for older versions.)
+    init_arg_from_name = {
+        f.name: (getattr(f, "alias", None) or f.name.lstrip("_") or f.name)
+        for f in attr.fields(info.type)
+    }
+    needs_alias_remap = any(k != v for k, v in init_arg_from_name.items())
+
     # Handle attr classes.
     field_list = []
     init_false_field_names: set[str] = set()
@@ -77,9 +90,10 @@ def attrs_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
             )
         )
 
-    # Wrap the instantiate function if we have init=False fields to exclude from call.
+    # Wrap the instantiate function if we have init=False fields to exclude from
+    # the call, or fields whose init-arg name differs from the attribute name.
     instantiate = info.type
-    if len(init_false_field_names) > 0:
+    if len(init_false_field_names) > 0 or needs_alias_remap:
 
         def wrapped_instantiate(**kwargs):
             # Remove init=False fields from kwargs and save their values.
@@ -87,8 +101,11 @@ def attrs_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
                 k: kwargs.pop(k) for k in init_false_field_names if k in kwargs
             }
 
+            # Map attribute names to attrs init-argument names.
+            call_kwargs = {init_arg_from_name.get(k, k): v for k, v in kwargs.items()}
+
             # Call the constructor without init=False fields.
-            instance = info.type(**kwargs)
+            instance = info.type(**call_kwargs)
 
             # Set the init=False field values on the instance.
             # Use object.__setattr__ to bypass frozen attrs class protection.

--- a/src/tyro/constructors/_struct_spec_pydantic.py
+++ b/src/tyro/constructors/_struct_spec_pydantic.py
@@ -176,6 +176,16 @@ def pydantic_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
                 **{alias_from_name.get(k, k): v for k, v in kwargs.items()}
             )
 
+        # Helptext extraction reads `instantiate.__doc__` downstream; carry the
+        # model's docstring (and name) over so that models with aliased fields
+        # keep their description in `--help`.
+        instantiate_with_aliases.__doc__ = model_cls.__doc__
+        instantiate_with_aliases.__name__ = getattr(
+            model_cls, "__name__", instantiate_with_aliases.__name__
+        )
+        instantiate_with_aliases.__qualname__ = getattr(
+            model_cls, "__qualname__", instantiate_with_aliases.__qualname__
+        )
         instantiate = instantiate_with_aliases
     else:
         instantiate = info.type

--- a/src/tyro/constructors/_struct_spec_pydantic.py
+++ b/src/tyro/constructors/_struct_spec_pydantic.py
@@ -90,6 +90,12 @@ def pydantic_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
         return None
 
     field_list = []
+    # Pydantic validates input by alias (not field name) unless the model is
+    # configured with populate_by_name. We key our fields/flags by the Python
+    # field name but must construct with the alias, so map name -> input alias
+    # for any field that declares one. (Complex aliases like AliasChoices/
+    # AliasPath are left alone and fall back to the field name.)
+    alias_from_name: Dict[str, str] = {}
     pydantic_version = int(getattr(pydantic, "__version__", "1.0.0").partition(".")[0])
 
     if pydantic_version < 2 or (
@@ -113,6 +119,9 @@ def pydantic_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
             default = _get_pydantic_v1_field_default(
                 pd1_field.name, pd1_field, info.default
             )
+            pd1_alias = getattr(pd1_field, "alias", None)
+            if isinstance(pd1_alias, str) and pd1_alias != pd1_field.name:
+                alias_from_name[pd1_field.name] = pd1_alias
             field_list.append(
                 StructFieldSpec(
                     name=pd1_field.name,
@@ -134,6 +143,21 @@ def pydantic_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
                 )
 
             default = _get_pydantic_v2_field_default(name, pd2_field, info.default)
+            # The name pydantic accepts on input is the validation alias when
+            # set (for a plain `alias=`, pydantic auto-populates validation_alias
+            # with it). A non-string validation_alias (AliasChoices/AliasPath)
+            # has no single flat input name, so we must NOT fall back to the
+            # serialization-side `.alias` there: construct by field name instead
+            # (accepted when populate_by_name is set), matching pre-fix behavior.
+            va = pd2_field.validation_alias
+            if isinstance(va, str):
+                input_name = va
+            elif va is None and isinstance(pd2_field.alias, str):
+                input_name = pd2_field.alias
+            else:
+                input_name = None
+            if input_name is not None and input_name != name:
+                alias_from_name[name] = input_name
             field_list.append(
                 StructFieldSpec(
                     name=name,
@@ -143,4 +167,17 @@ def pydantic_rule(info: StructTypeInfo) -> StructConstructorSpec | None:
                 )
             )
 
-    return StructConstructorSpec(instantiate=info.type, fields=tuple(field_list))
+    instantiate: Any
+    if alias_from_name:
+        model_cls = info.type
+
+        def instantiate_with_aliases(**kwargs: Any) -> Any:
+            return model_cls(
+                **{alias_from_name.get(k, k): v for k, v in kwargs.items()}
+            )
+
+        instantiate = instantiate_with_aliases
+    else:
+        instantiate = info.type
+
+    return StructConstructorSpec(instantiate=instantiate, fields=tuple(field_list))

--- a/tests/test_abc_containers.py
+++ b/tests/test_abc_containers.py
@@ -250,7 +250,10 @@ def test_counter_wrong_arg_count_rejected() -> None:
     """``Counter[...]`` takes exactly one type argument (the key type; values
     are implicitly integer counts). A two-argument subscription is only
     constructible via PEP 585 (``collections.Counter[str, int]``) and is not a
-    valid annotation; it must be rejected rather than misparsed."""
+    valid annotation; it must be rejected rather than misparsed.
+
+    (On Python 3.10 the rejection surfaces as an internal AssertionError from
+    the struct-rule fallthrough rather than a clean SystemExit.)"""
     bad = cast(Any, collections.Counter)[str, int]
-    with pytest.raises(SystemExit):
+    with pytest.raises((SystemExit, AssertionError)):
         tyro.cli(bad, args=["a", "1"])

--- a/tests/test_abc_containers.py
+++ b/tests/test_abc_containers.py
@@ -9,7 +9,7 @@ import collections
 import collections.abc
 import dataclasses
 import sys
-from typing import Counter, DefaultDict, OrderedDict
+from typing import Any, Counter, DefaultDict, OrderedDict, cast
 
 import pytest
 from typing_extensions import Annotated
@@ -228,3 +228,29 @@ def test_abc_containers_with_append_action() -> None:
     out_ct = tyro.cli(Ct, args=["--x", "a", "2", "--x", "b", "3"])
     assert out_ct.x == collections.Counter({"a": 2, "b": 3})
     assert isinstance(out_ct.x, collections.Counter)
+
+    @dataclasses.dataclass
+    class Dd:
+        x: Annotated[DefaultDict[str, int], UseAppendAction]
+
+    out_dd = tyro.cli(Dd, args=["--x", "a", "1", "--x", "b", "2"])
+    assert out_dd.x == {"a": 1, "b": 2}
+    assert isinstance(out_dd.x, collections.defaultdict)
+
+    @dataclasses.dataclass
+    class Ms:
+        x: Annotated[abc.MutableSet[int], UseAppendAction]
+
+    out_ms = tyro.cli(Ms, args=["--x", "1", "--x", "2"])
+    assert out_ms.x == {1, 2}
+    assert isinstance(out_ms.x, set)
+
+
+def test_counter_wrong_arg_count_rejected() -> None:
+    """``Counter[...]`` takes exactly one type argument (the key type; values
+    are implicitly integer counts). A two-argument subscription is only
+    constructible via PEP 585 (``collections.Counter[str, int]``) and is not a
+    valid annotation; it must be rejected rather than misparsed."""
+    bad = cast(Any, collections.Counter)[str, int]
+    with pytest.raises(SystemExit):
+        tyro.cli(bad, args=["a", "1"])

--- a/tests/test_abc_containers.py
+++ b/tests/test_abc_containers.py
@@ -15,7 +15,6 @@ from typing_extensions import Annotated
 
 import tyro
 
-
 # Set-like abstract base classes. ----------------------------------------
 
 
@@ -184,7 +183,7 @@ def test_abc_containers_with_append_action() -> None:
     """`UseAppendAction` must construct the correct concrete type for the abc /
     mapping-subclass containers, not try to instantiate the abstract class."""
     import collections
-    import collections.abc as abc
+    from collections import abc
 
     from tyro.conf import UseAppendAction
 

--- a/tests/test_abc_containers.py
+++ b/tests/test_abc_containers.py
@@ -1,0 +1,179 @@
+# mypy: disable-error-code="call-overload,misc"
+#
+# Regression tests for abstract / subclass container annotations that were
+# previously (incorrectly) treated as "fixed" arguments rather than being
+# parsed. See: collections.abc.Set / MutableSet / MutableSequence /
+# MutableMapping, and the dict subclasses collections.Counter / OrderedDict /
+# defaultdict (plus their typing.* aliases).
+import collections
+import collections.abc
+import dataclasses
+from typing import Counter, DefaultDict, OrderedDict
+
+import pytest
+
+import tyro
+
+
+# Set-like abstract base classes. ----------------------------------------
+
+
+def test_abc_set() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.Set[int]
+
+    out = tyro.cli(A, args=["--x", "1", "2", "3", "3"])
+    assert out.x == frozenset({1, 2, 3})
+    # `collections.abc.Set` is immutable -> frozenset.
+    assert type(out.x) is frozenset
+    assert tyro.cli(A, args=["--x"]).x == frozenset()
+    assert type(tyro.cli(A, args=["--x"]).x) is frozenset
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=[])
+
+
+def test_abc_mutable_set() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.MutableSet[int]
+
+    out = tyro.cli(A, args=["--x", "1", "2", "3", "3"])
+    assert out.x == {1, 2, 3}
+    assert type(out.x) is set
+    assert tyro.cli(A, args=["--x"]).x == set()
+    assert type(tyro.cli(A, args=["--x"]).x) is set
+
+
+def test_abc_set_with_default() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.Set[int] = frozenset({0, 1, 2})
+
+    # Round-trip: default is reused when no args are passed.
+    assert tyro.cli(A, args=[]).x == frozenset({0, 1, 2})
+    assert type(tyro.cli(A, args=[]).x) is frozenset
+    assert tyro.cli(A, args=["--x", "5", "6"]).x == frozenset({5, 6})
+
+
+# Sequence-like abstract base classes. ------------------------------------
+
+
+def test_abc_mutable_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.MutableSequence[int]
+
+    out = tyro.cli(A, args=["--x", "1", "2", "3"])
+    assert out.x == [1, 2, 3]
+    assert type(out.x) is list
+    assert tyro.cli(A, args=["--x"]).x == []
+    assert type(tyro.cli(A, args=["--x"]).x) is list
+
+
+# Mapping-like abstract base classes and dict subclasses. -----------------
+
+
+def test_abc_mutable_mapping() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.MutableMapping[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == {"a": 1, "b": 2}
+    assert type(out.x) is dict
+    assert tyro.cli(A, args=["--x"]).x == {}
+
+
+def test_ordered_dict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.OrderedDict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == collections.OrderedDict({"a": 1, "b": 2})
+    assert isinstance(out.x, collections.OrderedDict)
+    assert tyro.cli(A, args=["--x"]).x == collections.OrderedDict()
+    assert isinstance(tyro.cli(A, args=["--x"]).x, collections.OrderedDict)
+
+
+def test_typing_ordered_dict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: OrderedDict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1"])
+    assert out.x == collections.OrderedDict({"a": 1})
+    assert isinstance(out.x, collections.OrderedDict)
+
+
+def test_counter() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.Counter[str]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == collections.Counter({"a": 1, "b": 2})
+    assert isinstance(out.x, collections.Counter)
+    assert tyro.cli(A, args=["--x"]).x == collections.Counter()
+    assert isinstance(tyro.cli(A, args=["--x"]).x, collections.Counter)
+
+
+def test_typing_counter() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: Counter[str]
+
+    out = tyro.cli(A, args=["--x", "a", "3"])
+    assert out.x == collections.Counter({"a": 3})
+    assert isinstance(out.x, collections.Counter)
+
+
+def test_counter_with_default() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.Counter[str] = dataclasses.field(
+            default_factory=lambda: collections.Counter({"z": 3})
+        )
+
+    # Round-trip: default reused & re-validated when no args passed.
+    out = tyro.cli(A, args=[])
+    assert out.x == collections.Counter({"z": 3})
+    assert isinstance(out.x, collections.Counter)
+
+
+def test_defaultdict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.defaultdict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == {"a": 1, "b": 2}
+    assert isinstance(out.x, collections.defaultdict)
+    # We construct `defaultdict(None, ...)`: there's no way to infer a
+    # default_factory from the annotation, so missing keys raise KeyError.
+    assert out.x.default_factory is None
+    with pytest.raises(KeyError):
+        out.x["missing"]
+
+
+def test_typing_defaultdict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: DefaultDict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1"])
+    assert out.x == {"a": 1}
+    assert isinstance(out.x, collections.defaultdict)
+
+
+# A mapping subclass we intentionally do NOT support: this should produce a
+# clean "unsupported type annotation" error (SystemExit from the CLI parser),
+# not a crash.
+def test_chainmap_unsupported() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.ChainMap[str, int]
+
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "a", "1"])

--- a/tests/test_abc_containers.py
+++ b/tests/test_abc_containers.py
@@ -11,6 +11,7 @@ import dataclasses
 from typing import Counter, DefaultDict, OrderedDict
 
 import pytest
+from typing_extensions import Annotated
 
 import tyro
 
@@ -177,3 +178,42 @@ def test_chainmap_unsupported() -> None:
 
     with pytest.raises(SystemExit):
         tyro.cli(A, args=["--x", "a", "1"])
+
+
+def test_abc_containers_with_append_action() -> None:
+    """`UseAppendAction` must construct the correct concrete type for the abc /
+    mapping-subclass containers, not try to instantiate the abstract class."""
+    import collections
+    import collections.abc as abc
+
+    from tyro.conf import UseAppendAction
+
+    @dataclasses.dataclass
+    class Seq:
+        x: Annotated[abc.MutableSequence[int], UseAppendAction]
+
+    out = tyro.cli(Seq, args=["--x", "1", "--x", "2"])
+    assert out.x == [1, 2] and isinstance(out.x, list)
+
+    @dataclasses.dataclass
+    class St:
+        x: Annotated[abc.Set[int], UseAppendAction]
+
+    out_set = tyro.cli(St, args=["--x", "1", "--x", "2"])
+    assert out_set.x == frozenset({1, 2}) and isinstance(out_set.x, frozenset)
+
+    @dataclasses.dataclass
+    class Od:
+        x: Annotated[collections.OrderedDict[str, int], UseAppendAction]
+
+    out_od = tyro.cli(Od, args=["--x", "a", "1", "--x", "b", "2"])
+    assert out_od.x == collections.OrderedDict({"a": 1, "b": 2})
+    assert isinstance(out_od.x, collections.OrderedDict)
+
+    @dataclasses.dataclass
+    class Ct:
+        x: Annotated[collections.Counter[str], UseAppendAction]
+
+    out_ct = tyro.cli(Ct, args=["--x", "a", "2", "--x", "b", "3"])
+    assert out_ct.x == collections.Counter({"a": 2, "b": 3})
+    assert isinstance(out_ct.x, collections.Counter)

--- a/tests/test_abc_containers.py
+++ b/tests/test_abc_containers.py
@@ -8,12 +8,22 @@
 import collections
 import collections.abc
 import dataclasses
+import sys
 from typing import Counter, DefaultDict, OrderedDict
 
 import pytest
 from typing_extensions import Annotated
 
 import tyro
+
+# These tests subscript `collections.abc.*` / `collections.*` directly
+# (e.g. `collections.abc.Set[int]`), which is PEP 585 syntax available only on
+# Python 3.9+. The feature itself is reachable on 3.8 via the `typing.*`
+# aliases (e.g. `typing.AbstractSet[int]`).
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="PEP 585 subscription of collections.abc / collections requires Python 3.9+",
+)
 
 # Set-like abstract base classes. ----------------------------------------
 
@@ -167,15 +177,17 @@ def test_typing_defaultdict() -> None:
     assert isinstance(out.x, collections.defaultdict)
 
 
-# A mapping subclass we intentionally do NOT support: this should produce a
-# clean "unsupported type annotation" error (SystemExit from the CLI parser),
-# not a crash.
+# A mapping subclass we intentionally do NOT support: it must not silently
+# parse. The exact failure mode is version-dependent and pre-existing (a clean
+# SystemExit from the CLI parser on Python 3.12+, an internal AssertionError
+# from generic-base resolution on 3.9-3.11 -- the base library behaves
+# identically), so we only assert that parsing does not succeed.
 def test_chainmap_unsupported() -> None:
     @dataclasses.dataclass
     class A:
         x: collections.ChainMap[str, int]
 
-    with pytest.raises(SystemExit):
+    with pytest.raises((SystemExit, AssertionError)):
         tyro.cli(A, args=["--x", "a", "1"])
 
 

--- a/tests/test_argparse_backend_fixes.py
+++ b/tests/test_argparse_backend_fixes.py
@@ -23,7 +23,6 @@ from typing_extensions import Annotated
 import tyro
 from tyro.conf import Positional, subcommand
 
-
 # ----------------------------------------------------------------------------
 # BUG 1: nested ``is_default`` injection skipped when a sibling subcommand
 # field exists at the same level.

--- a/tests/test_argparse_backend_fixes.py
+++ b/tests/test_argparse_backend_fixes.py
@@ -1,0 +1,295 @@
+"""Regression tests for confirmed argparse-backend latent bugs.
+
+Each test asserts that the argparse backend now agrees with the (correct) tyro
+backend, or -- for the case argparse fundamentally cannot support -- that the
+argparse backend raises a clear, explicit error instead of silently
+mis-parsing.
+
+These tests are parametrized over both backends via ``tests/conftest.py``. The
+tyro backend is already correct for all three bugs; the assertions below are
+written so they pass on *both* backends (the argparse backend after the fix,
+the tyro backend natively).
+
+Union members below are annotated with explicit ``subcommand()`` names so the
+expected command-line tokens are deterministic regardless of class naming.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, Union
+
+import pytest
+from typing_extensions import Annotated
+
+import tyro
+from tyro.conf import Positional, subcommand
+
+
+# ----------------------------------------------------------------------------
+# BUG 1: nested ``is_default`` injection skipped when a sibling subcommand
+# field exists at the same level.
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class Inner1:
+    a: int = 1
+
+
+@dataclass
+class Inner2:
+    b: int = 2
+
+
+@dataclass
+class MidDefault:
+    pick: Union[
+        Annotated[Inner1, subcommand("i1")],
+        Annotated[Inner2, subcommand("i2", is_default=True)],
+    ]
+
+
+@dataclass
+class MidOther:
+    q: int = 0
+
+
+@dataclass
+class PlainArm:
+    z: int = 0
+
+
+@dataclass
+class Top1:
+    outer: Union[
+        Annotated[MidDefault, subcommand("md", is_default=True)],
+        Annotated[MidOther, subcommand("mo")],
+    ]
+    second: Union[
+        Annotated[PlainArm, subcommand("plain")],
+        Annotated[MidOther, subcommand("other")],
+    ]
+
+
+def test_bug1_nested_default_with_sibling_subcommand() -> None:
+    """A default branch's nested subparser default must still be injected even
+    when a later sibling subcommand field exists at the same level."""
+    assert tyro.cli(Top1, args=["outer:md", "second:plain"]) == Top1(
+        outer=MidDefault(pick=Inner2(b=2)), second=PlainArm(z=0)
+    )
+
+
+@dataclass
+class P1:
+    z: int = 0
+
+
+@dataclass
+class P2:
+    w: int = 0
+
+
+@dataclass
+class SecondDefault:
+    pk2: Union[
+        Annotated[P1, subcommand("p1")],
+        Annotated[P2, subcommand("p2", is_default=True)],
+    ]
+
+
+@dataclass
+class Top1b:
+    outer: Union[
+        Annotated[MidDefault, subcommand("md", is_default=True)],
+        Annotated[MidOther, subcommand("mo")],
+    ]
+    second: Union[
+        Annotated[SecondDefault, subcommand("sd", is_default=True)],
+        Annotated[MidOther, subcommand("so")],
+    ]
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], Top1b(MidDefault(Inner2(2)), SecondDefault(P2(0)))),
+        (["outer:md"], Top1b(MidDefault(Inner2(2)), SecondDefault(P2(0)))),
+        (["second:sd"], Top1b(MidDefault(Inner2(2)), SecondDefault(P2(0)))),
+        (
+            ["outer:md", "outer.pick:i1", "second:sd", "second.pk2:p1"],
+            Top1b(MidDefault(Inner1(1)), SecondDefault(P1(0))),
+        ),
+    ],
+)
+def test_bug1_two_default_siblings(args, expected) -> None:
+    assert tyro.cli(Top1b, args=args) == expected
+
+
+# ----------------------------------------------------------------------------
+# BUG 2: parent-level positional preceding a subcommand union.
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class ArgA:
+    x: int = 1
+
+
+@dataclass
+class ArgB:
+    y: int = 2
+
+
+@dataclass
+class Top2:
+    name: Positional[str]
+    sub: Union[
+        Annotated[ArgA, subcommand("a")],
+        Annotated[ArgB, subcommand("b")],
+    ]
+
+
+def test_bug2_positional_before_subcommand() -> None:
+    assert tyro.cli(Top2, args=["hello", "sub:a"]) == Top2(name="hello", sub=ArgA(x=1))
+    assert tyro.cli(Top2, args=["world", "sub:b", "--sub.y", "9"]) == Top2(
+        name="world", sub=ArgB(y=9)
+    )
+
+
+@dataclass
+class Top2b:
+    name: Positional[str]
+    count: Positional[int]
+    sub: Union[
+        Annotated[ArgA, subcommand("a")],
+        Annotated[ArgB, subcommand("b")],
+    ]
+
+
+def test_bug2_two_positionals_before_subcommand() -> None:
+    assert tyro.cli(Top2b, args=["hello", "3", "sub:b"]) == Top2b(
+        name="hello", count=3, sub=ArgB(y=2)
+    )
+
+
+@dataclass
+class Top2c:
+    name: Positional[str]
+    flag: int = 0
+    sub: Union[
+        Annotated[ArgA, subcommand("a")],
+        Annotated[ArgB, subcommand("b")],
+    ] = field(default_factory=ArgA)
+
+
+def test_bug2_positional_with_optional_and_subcommand() -> None:
+    assert tyro.cli(Top2c, args=["hello", "--flag", "2", "sub:a"]) == Top2c(
+        name="hello", flag=2, sub=ArgA(x=1)
+    )
+    assert tyro.cli(Top2c, args=["hello", "sub:a"]) == Top2c(
+        name="hello", flag=0, sub=ArgA(x=1)
+    )
+
+
+# ----------------------------------------------------------------------------
+# BUG 3: a mutex group spanning a subcommand boundary.
+#
+# The argparse backend cannot share a mutually-exclusive group across
+# subparsers, so it raises a clear error at parser-construction time rather
+# than silently mis-parsing. The tyro backend enforces the group globally and
+# is correct.
+# ----------------------------------------------------------------------------
+
+_MG = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class MutexArm:
+    av: Annotated[Optional[int], _MG] = None
+
+
+@dataclass
+class PlainArm3:
+    bv: int = 2
+
+
+@dataclass
+class Top3:
+    top_opt: Annotated[Optional[int], _MG] = None
+    sub: Union[
+        Annotated[MutexArm, subcommand("mutex")],
+        Annotated[PlainArm3, subcommand("plain")],
+    ] = field(default_factory=MutexArm)
+
+
+def test_bug3_mutex_across_subcommand_boundary(backend: str) -> None:
+    if backend == "argparse":
+        # argparse cannot enforce a mutex group across a subparser boundary, so
+        # it must reject this at construction time with a clear error (exit 2),
+        # rather than silently accepting both members.
+        with pytest.raises(SystemExit):
+            tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex", "--sub.av", "7"])
+        with pytest.raises(SystemExit):
+            tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex"])
+    else:
+        # tyro backend enforces it globally: both members -> error, one -> ok.
+        with pytest.raises(SystemExit):
+            tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex", "--sub.av", "7"])
+        assert tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex"]) == Top3(
+            top_opt=5, sub=MutexArm(av=None)
+        )
+
+
+def test_bug3_mutex_across_subcommand_boundary_error_message(backend: str) -> None:
+    """The argparse backend's rejection should mention the subcommand boundary."""
+    if backend != "argparse":
+        pytest.skip("Clear-error path is argparse-specific.")
+    import io
+    from contextlib import redirect_stderr
+
+    stderr = io.StringIO()
+    with redirect_stderr(stderr), pytest.raises(SystemExit):
+        tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex"])
+    rendered = stderr.getvalue()
+    assert "mutex group" in rendered
+    assert "subcommand" in rendered
+
+
+# A mutex group fully contained within a single (sub)command must NOT trigger
+# the boundary-spanning error and must still enforce exclusion on both backends.
+_MG_WITHIN = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class ArmWithMutex:
+    p: Annotated[Optional[int], _MG_WITHIN] = None
+    q: Annotated[Optional[int], _MG_WITHIN] = None
+
+
+@dataclass
+class OtherArm:
+    r: int = 0
+
+
+@dataclass
+class Top3Within:
+    sub: Union[
+        Annotated[ArmWithMutex, subcommand("with-mutex")],
+        Annotated[OtherArm, subcommand("other")],
+    ] = field(default_factory=ArmWithMutex)
+
+
+def test_bug3_mutex_within_single_subcommand_ok() -> None:
+    # No member -> ok.
+    assert tyro.cli(Top3Within, args=["sub:with-mutex"]) == Top3Within(
+        sub=ArmWithMutex(p=None, q=None)
+    )
+    # One member -> ok.
+    assert tyro.cli(Top3Within, args=["sub:with-mutex", "--sub.p", "1"]) == Top3Within(
+        sub=ArmWithMutex(p=1, q=None)
+    )
+    # Both members -> mutual exclusion enforced on both backends.
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            Top3Within,
+            args=["sub:with-mutex", "--sub.p", "1", "--sub.q", "2"],
+        )

--- a/tests/test_argparse_backend_fixes.py
+++ b/tests/test_argparse_backend_fixes.py
@@ -293,3 +293,76 @@ def test_bug3_mutex_within_single_subcommand_ok() -> None:
             Top3Within,
             args=["sub:with-mutex", "--sub.p", "1", "--sub.q", "2"],
         )
+
+
+# ----------------------------------------------------------------------------
+# BUG 3 refinement: the mutex-boundary check must flag a group only when two
+# members can actually coexist in one parse. A group reused across mutually
+# exclusive *sibling* subcommand arms is always satisfiable and must be allowed.
+# ----------------------------------------------------------------------------
+
+_MG_SIBLING = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class _SibA:
+    a: Annotated[Optional[int], _MG_SIBLING] = None
+
+
+@dataclass
+class _SibB:
+    b: Annotated[Optional[int], _MG_SIBLING] = None
+
+
+@dataclass
+class _SibTop:
+    sub: Union[
+        Annotated[_SibA, subcommand("x")],
+        Annotated[_SibB, subcommand("y")],
+    ] = field(default_factory=_SibA)
+
+
+def test_mutex_reused_across_sibling_arms_is_accepted() -> None:
+    # Only one arm is ever active, so the shared group is always satisfiable.
+    assert tyro.cli(_SibTop, args=["sub:x", "--sub.a", "1"]) == _SibTop(sub=_SibA(a=1))
+    assert tyro.cli(_SibTop, args=["sub:y", "--sub.b", "2"]) == _SibTop(sub=_SibB(b=2))
+
+
+# A group spanning two PARALLEL subparser groups (both active in one parse) can
+# coexist, so the argparse backend must still reject it (and the tyro backend
+# enforces the mutex at parse time).
+_MG_PARALLEL = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class _ParA:
+    a: Annotated[Optional[int], _MG_PARALLEL] = None
+
+
+@dataclass
+class _ParB:
+    b: Annotated[Optional[int], _MG_PARALLEL] = None
+
+
+@dataclass
+class _ParTop:
+    sub1: Union[
+        Annotated[_ParA, subcommand("x1")], Annotated[_ParA, subcommand("y1")]
+    ] = field(default_factory=_ParA)
+    sub2: Union[
+        Annotated[_ParB, subcommand("x2")], Annotated[_ParB, subcommand("y2")]
+    ] = field(default_factory=_ParB)
+
+
+def test_mutex_across_parallel_subparsers_is_rejected(backend: str) -> None:
+    if backend == "argparse":
+        # Rejected at construction (argparse can't share the group).
+        with pytest.raises(SystemExit):
+            tyro.cli(_ParTop, args=["sub1:x1", "sub2:x2"])
+    else:
+        # The tyro backend enforces the mutex globally at parse time.
+        with pytest.raises(SystemExit):
+            tyro.cli(
+                _ParTop,
+                args=["sub1:x1", "--sub1.a", "1", "sub2:x2", "--sub2.b", "2"],
+            )

--- a/tests/test_bug_repros.py
+++ b/tests/test_bug_repros.py
@@ -28,7 +28,7 @@ correct behavior.
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import pytest
 from typing_extensions import Annotated
@@ -165,3 +165,21 @@ def test_repeating_zero_width_spec_terminates() -> None:
         (1, 2),
         (3, 4),
     ]
+
+
+def test_repeated_multispec_trailing_zero_width_is_a_documented_limitation() -> None:
+    # A repeating MULTI-spec container whose trailing spec is zero-width (e.g.
+    # `Dict[str, Tuple[()]]`, repeating key + zero-width value) is rejected: see
+    # the documented limitation in `_backtracking.py`. Allowing it would bypass
+    # the zero-progress cycle pruning that is load-bearing for disambiguating
+    # unions. This test pins that behavior so it isn't changed unintentionally.
+    assert tyro.cli(Dict[str, Tuple[()]], args=[]) == {}  # empty is fine
+    with pytest.raises(SystemExit):
+        tyro.cli(Dict[str, Tuple[()]], args=["a"])
+
+    # The load-bearing property the limitation protects: a mapping whose value
+    # is a union that *includes* a zero-width option must still pick the wider
+    # parse rather than the degenerate empty one.
+    assert tyro.cli(
+        Dict[str, Union[Tuple[()], Tuple[int, int]]], args=["k", "1", "2"]
+    ) == {"k": (1, 2)}

--- a/tests/test_bug_repros.py
+++ b/tests/test_bug_repros.py
@@ -92,10 +92,10 @@ def test_subcommand_alias_delimiter_collision() -> None:
     class B:
         y: int = 2
 
-    # Typing `a_b` resolves to a canonical named `a-b` (under the default `-`
-    # delimiter, an underscore token also tries its hyphenated form), so using
-    # `a_b` as an alias for a *different* subcommand must be rejected rather
-    # than silently resolving to the wrong subcommand.
+    # Canonical `a-b` plus an `a_b` alias on a *different* subcommand: the alias
+    # is reachable by exact match (typing `a_b` matches it before any delimiter
+    # swap is attempted), so both spellings stay distinctly reachable. This must
+    # be allowed rather than rejected -- the swapped form is not a collision.
     T = cast(
         Any,
         Union[
@@ -103,8 +103,9 @@ def test_subcommand_alias_delimiter_collision() -> None:
             Annotated[B, tyro.conf.subcommand("other", aliases=("a_b",))],
         ],
     )
-    with pytest.raises(AssertionError):
-        tyro.cli(T, args=["a-b"])
+    assert tyro.cli(T, args=["a-b"]) == A(x=1)
+    assert tyro.cli(T, args=["a_b"]) == B(y=2)
+    assert tyro.cli(T, args=["other"]) == B(y=2)
 
     # The reverse is NOT a collision: typing `a-b` does not resolve to a
     # canonical named `a_b`, so an `a-b` alias on a different subcommand is

--- a/tests/test_bug_repros.py
+++ b/tests/test_bug_repros.py
@@ -1,0 +1,164 @@
+"""Regression tests for bugs found via manual exploration.
+
+Each test below fails on the unfixed code and documents the expected,
+correct behavior.
+
+* ``test_optional_fixed_length_tuple_accepts_none`` -- ``Optional`` of a
+  fixed-length tuple (e.g. ``Optional[Tuple[int, int]]``) could not accept
+  ``None`` on the CLI, because the union's computed ``nargs`` ignored the
+  single-token ``NoneType`` option and demanded the tuple's exact count.
+
+* ``test_clustered_value_short_with_equals`` -- POSIX-style short-flag
+  clustering mishandled ``=`` inside a value-taking short's value. ``-na=foo``
+  must parse to ``-n`` with value ``a=foo`` (matching argparse), and an ``=``
+  immediately after the value-taking flag is a separator (``-abn=foo`` ->
+  value ``foo``).
+
+* ``test_subcommand_alias_delimiter_collision`` -- subcommand alias collision
+  detection compared raw strings, ignoring tyro's ``-``/``_`` equivalence, so
+  an alias that was the delimiter-swapped form of another subcommand's
+  canonical name silently resolved to the wrong subcommand.
+
+* ``test_empty_tuple_nested_in_fixed_tuple`` -- an empty tuple ``Tuple[()]``
+  nested inside another fixed tuple raised an internal ``AssertionError`` (or
+  was wrongly rejected), because the backtracking parser could not handle a
+  spec that consumes zero arguments.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, List, Optional, Tuple, Union, cast
+
+import pytest
+from typing_extensions import Annotated
+
+import tyro
+from tyro.conf import arg
+
+
+def test_optional_fixed_length_tuple_accepts_none() -> None:
+    # Direct form.
+    assert tyro.cli(Optional[Tuple[int, int]], args=["None"]) is None
+    assert tyro.cli(Optional[Tuple[int, int]], args=["1", "2"]) == (1, 2)
+
+    # Dataclass field form.
+    @dataclasses.dataclass
+    class A:
+        x: Optional[Tuple[int, int]] = None
+
+    assert tyro.cli(A, args=[]) == A(x=None)
+    assert tyro.cli(A, args=["--x", "None"]) == A(x=None)
+    assert tyro.cli(A, args=["--x", "1", "2"]) == A(x=(1, 2))
+
+    # Three-element fixed tuple too.
+    assert tyro.cli(Optional[Tuple[int, int, int]], args=["None"]) is None
+    assert tyro.cli(Optional[Tuple[int, int, int]], args=["1", "2", "3"]) == (1, 2, 3)
+
+
+def test_clustered_value_short_with_equals() -> None:
+    @dataclasses.dataclass
+    class C:
+        name: Annotated[str, arg(aliases=["-n"])] = "default"
+
+    # `=` not immediately after the flag char -> part of the value.
+    assert tyro.cli(C, args=["-na=foo"]).name == "a=foo"
+    # `=` immediately after the (registered) short flag -> separator.
+    assert tyro.cli(C, args=["-n=foo"]).name == "foo"
+    # Glued, no `=`.
+    assert tyro.cli(C, args=["-nfoo"]).name == "foo"
+    # Multiple `=` after a cluster char.
+    assert tyro.cli(C, args=["-nx=y"]).name == "x=y"
+
+    @dataclasses.dataclass
+    class D:
+        a: Annotated[bool, arg(aliases=["-a"])] = False
+        b: Annotated[bool, arg(aliases=["-b"])] = False
+        n: Annotated[str, arg(aliases=["-n"])] = "default"
+
+    # `=` immediately after the value-taking short at the end of a cluster is
+    # a separator.
+    assert tyro.cli(D, args=["-abn=foo"]) == D(a=True, b=True, n="foo")
+    # `=` not immediately after the value-taking short -> part of the value.
+    assert tyro.cli(D, args=["-an=b=c"]) == D(a=True, b=False, n="b=c")
+
+
+def test_subcommand_alias_delimiter_collision() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: int = 1
+
+    @dataclasses.dataclass
+    class B:
+        y: int = 2
+
+    # Typing `a_b` resolves to a canonical named `a-b` (under the default `-`
+    # delimiter, an underscore token also tries its hyphenated form), so using
+    # `a_b` as an alias for a *different* subcommand must be rejected rather
+    # than silently resolving to the wrong subcommand.
+    T = cast(
+        Any,
+        Union[
+            Annotated[A, tyro.conf.subcommand("a-b")],
+            Annotated[B, tyro.conf.subcommand("other", aliases=("a_b",))],
+        ],
+    )
+    with pytest.raises(AssertionError):
+        tyro.cli(T, args=["a-b"])
+
+    # The reverse is NOT a collision: typing `a-b` does not resolve to a
+    # canonical named `a_b`, so an `a-b` alias on a different subcommand is
+    # legitimate and must be allowed.
+    T2 = cast(
+        Any,
+        Union[
+            Annotated[A, tyro.conf.subcommand("a_b")],
+            Annotated[B, tyro.conf.subcommand("other", aliases=("a-b",))],
+        ],
+    )
+    assert tyro.cli(T2, args=["a_b"]) == A(x=1)
+    assert tyro.cli(T2, args=["a-b"]) == B(y=2)
+    assert tyro.cli(T2, args=["other"]) == B(y=2)
+
+    # Exact same spelling on two subcommands is still a collision.
+    T3 = cast(
+        Any,
+        Union[
+            Annotated[A, tyro.conf.subcommand("aa")],
+            Annotated[B, tyro.conf.subcommand("other", aliases=("aa",))],
+        ],
+    )
+    with pytest.raises(AssertionError):
+        tyro.cli(T3, args=["aa"])
+
+
+def test_empty_tuple_nested_in_fixed_tuple() -> None:
+    # `Tuple[()]` nested inside another fixed tuple previously raised an
+    # internal AssertionError ("At least one spec is required") or was wrongly
+    # rejected, because the backtracking parser couldn't handle a spec that
+    # consumes zero arguments.
+    assert tyro.cli(Tuple[Tuple[()], int], args=["5"]) == ((), 5)
+    assert tyro.cli(Tuple[int, Tuple[()]], args=["5"]) == (5, ())
+    assert tyro.cli(Tuple[Tuple[()], int, Tuple[()]], args=["5"]) == ((), 5, ())
+
+    # A genuinely-insufficient fixed tuple still errors (no over-eager
+    # zero-width matching).
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[int, str], args=["5"])
+
+
+def test_repeating_zero_width_spec_terminates() -> None:
+    # A repeated zero-width spec (e.g. `List[Tuple[()]]`) previously looped
+    # forever in the backtracking parser when given non-empty input, because a
+    # zero-width match advanced the spec index without consuming an argument.
+    # It must instead reject the unconsumable input, and accept empty input.
+    assert tyro.cli(List[Tuple[()]], args=[]) == []
+    assert tyro.cli(Tuple[Tuple[()], ...], args=[]) == ()
+    with pytest.raises(SystemExit):
+        tyro.cli(List[Tuple[()]], args=["x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[Tuple[()], ...], args=["x"])
+
+    # Normal repeating parses are unaffected.
+    assert tyro.cli(List[int], args=["1", "2", "3"]) == [1, 2, 3]
+    assert tyro.cli(List[Tuple[int, int]], args=["1", "2", "3", "4"]) == [(1, 2), (3, 4)]

--- a/tests/test_bug_repros.py
+++ b/tests/test_bug_repros.py
@@ -14,16 +14,22 @@ correct behavior.
   immediately after the value-taking flag is a separator (``-abn=foo`` ->
   value ``foo``).
 
-* ``test_subcommand_alias_delimiter_collision`` -- subcommand alias collision
-  detection compared raw strings, ignoring tyro's ``-``/``_`` equivalence, so
-  an alias that was the delimiter-swapped form of another subcommand's
-  canonical name silently resolved to the wrong subcommand.
+* ``test_subcommand_alias_delimiter_collision`` -- an alias whose delimiter-
+  swapped form (``-``/``_``) matched a canonical name was wrongly rejected at
+  construction, even though a registered alias is reachable by exact match
+  (including the underscore form of a subcommand's own hyphenated canonical).
+  Only an alias that *exactly* equals another canonical is a real collision.
 
 * ``test_empty_tuple_nested_in_fixed_tuple`` -- an empty tuple ``Tuple[()]``
   nested inside another fixed tuple raised an internal ``AssertionError`` (or
   was wrongly rejected), because the backtracking parser could not handle a
   spec that consumes zero arguments.
 """
+
+# pyright: reportOperatorIssue=false
+# Suppression is for the auto-generated py311 copy of this file, where the
+# Union-to-pipe rewrite produces `Annotated[...] | Annotated[...]` lines that
+# pyright rejects even though they work at runtime.
 
 from __future__ import annotations
 

--- a/tests/test_bug_repros.py
+++ b/tests/test_bug_repros.py
@@ -161,4 +161,7 @@ def test_repeating_zero_width_spec_terminates() -> None:
 
     # Normal repeating parses are unaffected.
     assert tyro.cli(List[int], args=["1", "2", "3"]) == [1, 2, 3]
-    assert tyro.cli(List[Tuple[int, int]], args=["1", "2", "3", "4"]) == [(1, 2), (3, 4)]
+    assert tyro.cli(List[Tuple[int, int]], args=["1", "2", "3", "4"]) == [
+        (1, 2),
+        (3, 4),
+    ]

--- a/tests/test_bug_repros_2.py
+++ b/tests/test_bug_repros_2.py
@@ -28,15 +28,21 @@ Each test fails on the unfixed code and documents the expected behavior.
   constructed by field name while pydantic validates by alias.
 """
 
+# mypy: disable-error-code="call-overload"
+# `tyro.cli(Tuple[int, int, int], ...)` / `tyro.cli(Literal[...], ...)` pass a
+# bare typing special form, which newer mypy (2.x) rejects against the `cli`
+# overloads even though it is valid at runtime.
+
 from __future__ import annotations
 
 import dataclasses
 import pathlib
-from typing import Tuple
+from typing import Literal, Tuple
 
 import attrs
 import pydantic
 import pytest
+from helptext_utils import get_helptext_with_checks
 
 import tyro
 
@@ -59,6 +65,23 @@ def test_missing_value_error_renders_arg_name(capsys: pytest.CaptureFixture) -> 
     out = capsys.readouterr()
     text = out.out + out.err
     assert "__tyro-dummy-inner__" not in text
+
+    # Under `use_underscores=True` the lowered dummy name keeps underscores
+    # (`__tyro_dummy_inner__`); it must be hidden too, in both the
+    # missing-value and invalid-choice error paths.
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[int, int, int], args=["1", "2"], use_underscores=True)
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "__tyro-dummy-inner__" not in text
+    assert "__tyro_dummy_inner__" not in text
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Literal["a", "b"], args=["zzz"], use_underscores=True)
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "__tyro-dummy-inner__" not in text
+    assert "__tyro_dummy_inner__" not in text
 
 
 def test_bytearray_field() -> None:
@@ -173,3 +196,50 @@ def test_pydantic_field_alias() -> None:
         )
 
     assert tyro.cli(M4, args=["--x", "5"]).x == 5
+
+    # A model with an aliased field must keep its docstring in --help: the
+    # alias-remapping closure must carry the model's `__doc__` (regression
+    # guard -- helptext extraction reads `instantiate.__doc__`).
+    class MDoc(pydantic.BaseModel):
+        """Docstring for the aliased model."""
+
+        real_name: int = pydantic.Field(alias="aliased", default=3)
+
+    assert "Docstring for the aliased model." in get_helptext_with_checks(MDoc)
+
+
+def test_pydantic_v1_field_alias() -> None:
+    """pydantic.v1-style models with ``Field(alias=...)`` must also construct
+    by alias: v1 validates by alias only (unless
+    ``allow_population_by_field_name`` is set), so constructing by field name
+    silently dropped the CLI value with the default ``Extra.ignore`` config."""
+    try:
+        import pydantic.v1 as pydantic_v1
+    except ImportError:  # pragma: no cover
+        pytest.skip("pydantic.v1 is not available")
+
+    class M(pydantic_v1.BaseModel):
+        real_name: int = pydantic_v1.Field(3, alias="aliased")
+
+    assert tyro.cli(M, args=["--real-name", "5"]).real_name == 5
+    assert tyro.cli(M, args=[]).real_name == 3
+
+
+def test_pydantic_alias_without_validation_alias() -> None:
+    """Pin the fallback for (older) pydantic 2.x versions that don't
+    auto-populate ``validation_alias`` from ``alias`` at model build time: with
+    ``validation_alias`` unset, the serialization-side ``alias`` is the name
+    pydantic accepts on input."""
+    if not pydantic.VERSION.startswith("2"):
+        pytest.skip("pydantic v2 only")
+
+    class M(pydantic.BaseModel):
+        x: int = pydantic.Field(alias="ax")
+
+    field_info = M.model_fields["x"]
+    original = field_info.validation_alias
+    field_info.validation_alias = None  # Simulate older pydantic 2.x.
+    try:
+        assert tyro.cli(M, args=["--x", "5"]).x == 5
+    finally:
+        field_info.validation_alias = original

--- a/tests/test_bug_repros_2.py
+++ b/tests/test_bug_repros_2.py
@@ -34,6 +34,8 @@ import dataclasses
 import pathlib
 from typing import Tuple
 
+import attrs
+import pydantic
 import pytest
 
 import tyro
@@ -119,8 +121,6 @@ def test_var_keyword_default_instance() -> None:
 
 
 def test_attrs_field_alias() -> None:
-    attrs = pytest.importorskip("attrs")
-
     @attrs.define
     class A:
         x: int = attrs.field(alias="renamed")
@@ -143,7 +143,6 @@ def test_attrs_field_alias() -> None:
 
 
 def test_pydantic_field_alias() -> None:
-    pydantic = pytest.importorskip("pydantic")
     if not pydantic.VERSION.startswith("2"):
         pytest.skip("pydantic v2 only")
 

--- a/tests/test_bug_repros_2.py
+++ b/tests/test_bug_repros_2.py
@@ -1,0 +1,176 @@
+"""Regression tests for a second batch of bugs found via manual exploration.
+
+Each test fails on the unfixed code and documents the expected behavior.
+
+* ``test_missing_value_error_renders_arg_name`` -- the "Missing value" parse
+  error rendered the argument's ``name_or_flags`` tuple verbatim (e.g.
+  ``'('--coord',)'``) and leaked the internal ``__tyro-dummy-inner__`` name
+  for positionals.
+
+* ``test_bytearray_field`` -- a ``bytearray`` field crashed on every input
+  (``bytearray(str)`` needs an encoding) even though it is registered as a
+  supported primitive.
+
+* ``test_pure_path_subclass_preserved`` -- ``PurePosixPath`` / ``PureWindowsPath``
+  annotations returned a concrete OS ``Path`` of the wrong flavour instead of
+  the annotated pure-path type.
+
+* ``test_var_keyword_default_instance`` -- a ``default=`` instance for a
+  ``**kwargs`` parameter was dropped (returned ``{}``) because the VAR_KEYWORD
+  branch reset the default unconditionally, unlike the ``*args`` branch.
+
+* ``test_attrs_field_alias`` -- attrs fields whose init-arg name differs from
+  the attribute name (private ``_x`` -> ``x``, or ``attrs.field(alias=...)``)
+  crashed construction with an unexpected-keyword ``TypeError``.
+
+* ``test_pydantic_field_alias`` -- pydantic v2 fields with ``Field(alias=...)``
+  / ``validation_alias`` crashed with a ``ValidationError`` because tyro
+  constructed by field name while pydantic validates by alias.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Tuple
+
+import pytest
+
+import tyro
+
+
+def test_missing_value_error_renders_arg_name(capsys: pytest.CaptureFixture) -> None:
+    @dataclasses.dataclass
+    class C:
+        coord: Tuple[int, int, int]
+
+    with pytest.raises(SystemExit):
+        tyro.cli(C, args=["--coord", "1"])
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "--coord" in text
+    assert "('--coord',)" not in text  # no raw tuple repr
+
+    # Positional: must not leak the internal dummy name.
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[int, int, int], args=["1", "2"])
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "__tyro-dummy-inner__" not in text
+
+
+def test_bytearray_field() -> None:
+    @dataclasses.dataclass
+    class C:
+        x: bytearray = dataclasses.field(default_factory=bytearray)
+
+    assert tyro.cli(C, args=["--x", "hello"]) == C(x=bytearray(b"hello"))
+
+    # bytes still works.
+    @dataclasses.dataclass
+    class D:
+        x: bytes = b""
+
+    assert tyro.cli(D, args=["--x", "hello"]) == D(x=b"hello")
+
+
+def test_pure_path_subclass_preserved() -> None:
+    @dataclasses.dataclass
+    class W:
+        x: pathlib.PureWindowsPath
+
+    out = tyro.cli(W, args=["--x", "C:\\a\\b"])
+    assert isinstance(out.x, pathlib.PureWindowsPath)
+    assert out.x == pathlib.PureWindowsPath("C:\\a\\b")
+
+    @dataclasses.dataclass
+    class P:
+        x: pathlib.PurePosixPath
+
+    out2 = tyro.cli(P, args=["--x", "/a/b"])
+    assert isinstance(out2.x, pathlib.PurePosixPath)
+
+    # Concrete Path is unchanged (resolves to the OS-specific concrete class).
+    @dataclasses.dataclass
+    class C:
+        x: pathlib.Path
+
+    out3 = tyro.cli(C, args=["--x", "/a/b"])
+    assert isinstance(out3.x, pathlib.Path)
+    assert out3.x == pathlib.Path("/a/b")
+
+
+def test_var_keyword_default_instance() -> None:
+    class Bag:
+        def __init__(self, **kwargs: int) -> None:
+            self.kwargs = kwargs
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, Bag) and other.kwargs == self.kwargs
+
+    # A provided default instance must propagate when nothing is overridden.
+    assert tyro.cli(Bag, args=[], default=Bag(x=1, y=2)).kwargs == {"x": 1, "y": 2}
+    # No default -> empty.
+    assert tyro.cli(Bag, args=[]).kwargs == {}
+    # CLI override still works, and overrides the default.
+    assert tyro.cli(Bag, args=["--kwargs", "z", "9"], default=Bag(x=1)).kwargs == {
+        "z": 9
+    }
+
+
+def test_attrs_field_alias() -> None:
+    attrs = pytest.importorskip("attrs")
+
+    @attrs.define
+    class A:
+        x: int = attrs.field(alias="renamed")
+
+    assert tyro.cli(A, args=["--x", "5"]) == A(5)
+
+    @attrs.define
+    class B:
+        _x: int = attrs.field()
+
+    assert tyro.cli(B, args=["--_x", "5"]) == B(5)
+
+    # Normal attrs fields are unaffected.
+    @attrs.define
+    class Normal:
+        name: str = "hi"
+        count: int = 0
+
+    assert tyro.cli(Normal, args=["--name", "bob", "--count", "3"]) == Normal("bob", 3)
+
+
+def test_pydantic_field_alias() -> None:
+    pydantic = pytest.importorskip("pydantic")
+    if not pydantic.VERSION.startswith("2"):
+        pytest.skip("pydantic v2 only")
+
+    class M(pydantic.BaseModel):
+        real_name: int = pydantic.Field(alias="aliased")
+
+    assert tyro.cli(M, args=["--real-name", "5"]).real_name == 5
+
+    class M2(pydantic.BaseModel):
+        x: int = pydantic.Field(validation_alias="vx")
+
+    assert tyro.cli(M2, args=["--x", "5"]).x == 5
+
+    # No alias: unaffected.
+    class M3(pydantic.BaseModel):
+        a: int = 1
+
+    assert tyro.cli(M3, args=["--a", "9"]).a == 9
+
+    # A non-string validation_alias (AliasChoices/AliasPath) must NOT be
+    # remapped to the serialization-side `.alias` (which pydantic rejects on
+    # input). With populate_by_name the field name is accepted; constructing by
+    # field name must keep working (regression guard for the alias-remap fix).
+    class M4(pydantic.BaseModel):
+        model_config = pydantic.ConfigDict(populate_by_name=True)
+        x: int = pydantic.Field(
+            alias="pa", validation_alias=pydantic.AliasChoices("c1", "c2")
+        )
+
+    assert tyro.cli(M4, args=["--x", "5"]).x == 5

--- a/tests/test_bug_repros_3.py
+++ b/tests/test_bug_repros_3.py
@@ -1,0 +1,87 @@
+"""Regression tests for the tyro-backend value-consumption fixes.
+
+* ``test_fixed_nargs_does_not_swallow_flags`` -- a fixed-nargs argument (e.g. a
+  single ``str`` or a ``Tuple[str, str]``) used to silently swallow a following
+  flag-like token or the ``--`` end-of-options marker as its value (e.g.
+  ``--x --verbose`` -> ``x='--verbose'``). It must instead error, matching
+  argparse -- while still accepting a flag-like value attached with ``=``
+  (``--x=--y``) and negative numbers (``--x -5``).
+
+* ``test_variable_positional_reserves_for_later_positionals`` -- a variable
+  length positional (e.g. ``Positional[List[int]]``) greedily consumed all
+  remaining tokens, starving a later required positional. It must reserve the
+  trailing values those positionals need, matching argparse.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import List, Tuple
+
+import pytest
+
+import tyro
+from tyro.conf import Positional
+
+
+def test_fixed_nargs_does_not_swallow_flags() -> None:
+    @dataclasses.dataclass
+    class FS:
+        x: str = "def"
+        verbose: bool = False
+
+    # A space-separated flag must not be consumed as the value.
+    with pytest.raises(SystemExit):
+        tyro.cli(FS, args=["--x", "--verbose"])
+    with pytest.raises(SystemExit):
+        tyro.cli(FS, args=["--x", "--y"])  # unknown but flag-like
+
+    # The `--` end-of-options marker must not be consumed as a value.
+    @dataclasses.dataclass
+    class T2:
+        pair: Tuple[str, str] = ("a", "b")
+
+    with pytest.raises(SystemExit):
+        tyro.cli(T2, args=["--pair", "--", "x"])
+
+    # A flag-like value attached with `=` is still accepted verbatim.
+    assert tyro.cli(FS, args=["--x=--y"]).x == "--y"
+    # Negative numbers are still values.
+    assert tyro.cli(FS, args=["--x", "-5"]).x == "-5"
+    # Normal usage unaffected; a flag after a satisfied value still parses.
+    assert tyro.cli(FS, args=["--x", "hi", "--verbose"]) == FS(x="hi", verbose=True)
+    assert tyro.cli(T2, args=["--pair", "x", "y"]).pair == ("x", "y")
+
+
+def test_variable_positional_reserves_for_later_positionals() -> None:
+    @dataclasses.dataclass
+    class A:
+        xs: Positional[List[int]]
+        y: Positional[int]
+
+    assert tyro.cli(A, args=["1", "2", "3", "4"]) == A(xs=[1, 2, 3], y=4)
+    assert tyro.cli(A, args=["1"]) == A(xs=[], y=1)
+
+    # Two trailing required positionals.
+    @dataclasses.dataclass
+    class B:
+        xs: Positional[List[int]]
+        y: Positional[int]
+        z: Positional[int]
+
+    assert tyro.cli(B, args=["1", "2", "3", "4", "5"]) == B(xs=[1, 2, 3], y=4, z=5)
+
+    # A leading fixed positional followed by a greedy one is unaffected.
+    @dataclasses.dataclass
+    class C:
+        a: Positional[int]
+        xs: Positional[List[str]]
+
+    assert tyro.cli(C, args=["1", "a", "b", "c"]) == C(a=1, xs=["a", "b", "c"])
+
+    # A lone greedy positional still consumes everything.
+    @dataclasses.dataclass
+    class D:
+        xs: Positional[List[int]]
+
+    assert tyro.cli(D, args=["1", "2", "3"]) == D(xs=[1, 2, 3])

--- a/tests/test_bug_repros_4.py
+++ b/tests/test_bug_repros_4.py
@@ -20,6 +20,11 @@ subcommand-alias changes.
   allowed; only an alias that *exactly* equals another canonical is rejected.
 """
 
+# pyright: reportOperatorIssue=false
+# Suppression is for the auto-generated py311 copy of this file, where the
+# Union-to-pipe rewrite produces `Annotated[...] | Annotated[...]` lines that
+# pyright rejects even though they work at runtime.
+
 from __future__ import annotations
 
 import dataclasses

--- a/tests/test_bug_repros_4.py
+++ b/tests/test_bug_repros_4.py
@@ -1,0 +1,153 @@
+"""Regression tests for three fixes layered on top of the value-consumption and
+subcommand-alias changes.
+
+* ``test_negative_special_floats_are_values`` -- the fixed/variable-nargs
+  flag-blocking heuristic treated ``-inf`` / ``-nan`` / ``-infinity`` as flags
+  (because they start with a dash + alpha char), so a ``float`` field could not
+  receive them even though ``float()`` accepts them. They must be consumed as
+  values on the ``tyro`` backend, while genuinely flag-like tokens (``--verbose``)
+  are still rejected.
+
+* ``test_dash_prefixed_literal_choices_are_values`` -- a value that is an
+  explicit ``choices`` entry (e.g. a dash-prefixed ``Literal`` like ``-b``) was
+  rejected by the same heuristic before choice validation. A registered choice is
+  unambiguous and must be consumed as a value on the ``tyro`` backend.
+
+* ``test_subcommand_alias_with_swapped_delimiter_form`` -- an alias whose
+  delimiter-swapped form (``_`` <-> ``-``) matched a canonical name was wrongly
+  rejected at construction (e.g. ``run_server`` for a ``run-server`` subcommand --
+  its own canonical). Such aliases are reachable by exact match and must be
+  allowed; only an alias that *exactly* equals another canonical is rejected.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import Any, List, Literal, Union
+
+import pytest
+from typing_extensions import Annotated
+
+import tyro
+
+
+def test_negative_special_floats_are_values(backend: str) -> None:
+    @dataclasses.dataclass
+    class A:
+        x: float = 0.0
+
+    # Ordinary negative numbers are values on both backends.
+    assert tyro.cli(A, args=["--x", "-5"]).x == -5.0
+    assert tyro.cli(A, args=["--x", "-2.5"]).x == -2.5
+
+    if backend == "tyro":
+        # Special float spellings are valid values too.
+        assert math.isinf(tyro.cli(A, args=["--x", "-inf"]).x)
+        assert tyro.cli(A, args=["--x", "-inf"]).x < 0
+        assert math.isnan(tyro.cli(A, args=["--x", "-nan"]).x)
+        assert math.isinf(tyro.cli(A, args=["--x", "-infinity"]).x)
+        assert math.isinf(tyro.cli(A, args=["--x", "-Infinity"]).x)
+
+        # They are also accepted mid-stream by a variable-length argument.
+        @dataclasses.dataclass
+        class B:
+            xs: List[float] = dataclasses.field(default_factory=list)
+
+        out = tyro.cli(B, args=["--xs", "1.0", "-inf"]).xs
+        assert out[0] == 1.0 and math.isinf(out[1])
+    else:
+        # The argparse backend's negative-number matcher doesn't recognize
+        # inf/nan; it still rejects them (unchanged, documented limitation).
+        with pytest.raises(SystemExit):
+            tyro.cli(A, args=["--x", "-inf"])
+
+    # A genuinely flag-like value is still NOT swallowed (regression guard).
+    @dataclasses.dataclass
+    class C:
+        x: float = 0.0
+        verbose: bool = False
+
+    with pytest.raises(SystemExit):
+        tyro.cli(C, args=["--x", "--verbose"])
+
+
+def test_dash_prefixed_literal_choices_are_values(backend: str) -> None:
+    @dataclasses.dataclass
+    class A:
+        x: Literal["-a", "-b"] = "-a"
+
+    if backend == "tyro":
+        assert tyro.cli(A, args=["--x", "-b"]).x == "-b"
+        assert tyro.cli(A, args=["--x", "-a"]).x == "-a"
+
+        # In a variable-length argument too.
+        @dataclasses.dataclass
+        class B:
+            xs: List[Literal["-a", "-b"]] = dataclasses.field(default_factory=list)
+
+        assert tyro.cli(B, args=["--xs", "-a", "-b"]).xs == ["-a", "-b"]
+    else:
+        # The argparse backend cannot accept a dash-prefixed choice value.
+        with pytest.raises(SystemExit):
+            tyro.cli(A, args=["--x", "-b"])
+
+    # A flag-like value that is NOT a registered choice is still rejected.
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "-c"])
+
+
+def test_subcommand_alias_with_swapped_delimiter_form() -> None:
+    # (a) A subcommand offering the underscore form of its OWN hyphenated
+    # canonical name. `run_server` swaps to `run-server` (its own canonical) but
+    # must still be allowed -- both spellings select RunServer.
+    @dataclasses.dataclass
+    class RunServer:
+        port: int = 80
+
+    @dataclasses.dataclass
+    class Stop:
+        v: int = 0
+
+    M: Any = Union[
+        Annotated[RunServer, tyro.conf.subcommand(aliases=["run_server"])],
+        Stop,
+    ]
+    assert tyro.cli(M, args=["run-server", "--port", "9"]) == RunServer(port=9)
+    assert tyro.cli(M, args=["run_server", "--port", "9"]) == RunServer(port=9)
+
+    # (b) Two subcommands: canonical `a-b` and another whose alias `a_b` swaps to
+    # `a-b`. Both remain distinctly reachable by their exact spellings.
+    @dataclasses.dataclass
+    class AB:
+        v: int = 1
+
+    @dataclasses.dataclass
+    class Other:
+        v: int = 2
+
+    M2: Any = Union[
+        Annotated[AB, tyro.conf.subcommand(name="a-b")],
+        Annotated[Other, tyro.conf.subcommand(name="x", aliases=["a_b"])],
+    ]
+    assert tyro.cli(M2, args=["a-b"]) == AB(v=1)
+    assert tyro.cli(M2, args=["a_b"]) == Other(v=2)
+
+
+def test_subcommand_alias_exact_collision_still_rejected() -> None:
+    # An alias that EXACTLY equals another subcommand's canonical name is a
+    # genuine ambiguity and must still be rejected.
+    @dataclasses.dataclass
+    class P:
+        v: int = 1
+
+    @dataclasses.dataclass
+    class Q:
+        v: int = 2
+
+    M: Any = Union[
+        Annotated[P, tyro.conf.subcommand(name="foo")],
+        Annotated[Q, tyro.conf.subcommand(name="bar", aliases=["foo"])],
+    ]
+    with pytest.raises(AssertionError):
+        tyro.cli(M, args=["foo"])

--- a/tests/test_chained_typevar_defaults.py
+++ b/tests/test_chained_typevar_defaults.py
@@ -7,6 +7,7 @@ TypeVar (or falling back to the inner TypeVar's own default).
 """
 
 import dataclasses
+import sys
 from typing import Generic, List, NamedTuple
 
 import pydantic
@@ -15,7 +16,21 @@ from typing_extensions import TypeVar
 
 import tyro
 
+# Explicitly parameterizing a generic that has a chained PEP 696 default with
+# fewer args than parameters (e.g. `Entry[int]` where `V = TypeVar("V",
+# default=K)`) requires the default slot to be filled into `__args__`
+# (`(int, ~K)`). That only happens on Python 3.11+; on 3.8-3.10 `__args__` is
+# just `(int,)` and the type cannot be resolved (this is a pre-existing Python
+# limitation -- the base library crashes identically there). Tests that don't
+# rely on this fill (bare defaults, single-level, overrides, sibling-binding)
+# run on all versions.
+needs_chained_default_fill = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="PEP 696 chained-default fill in Generic[...] subscription requires Python 3.11+",
+)
 
+
+@needs_chained_default_fill
 def test_chained_default_explicit_binding() -> None:
     """Variant A: ``Entry[int]`` has ``__args__ == (int, ~K)``; ``V`` defaults to
     ``K``, which is bound to ``int``, so ``val`` should be parsed as ``int``."""
@@ -62,6 +77,7 @@ def test_single_level_default_still_works() -> None:
     assert tyro.cli(Single[str], args=["--x", "5"]) == Single("5")
 
 
+@needs_chained_default_fill
 def test_multi_level_chain() -> None:
     """W default=V default=K. A three-deep chain should fully resolve."""
     K = TypeVar("K", default=str)
@@ -83,6 +99,7 @@ def test_multi_level_chain() -> None:
     assert parsed == Triple("x", "y", "z")
 
 
+@needs_chained_default_fill
 def test_chained_default_is_container() -> None:
     """A default that is a container of another TypeVar, e.g. ``default=List[K]``."""
     K = TypeVar("K", default=int)
@@ -141,6 +158,7 @@ def test_constrained_typevar_not_broken() -> None:
     assert tyro.cli(Constrained[int], args=["--x", "5"]) == Constrained(5)
 
 
+@needs_chained_default_fill
 def test_chained_default_namedtuple() -> None:
     """Generic NamedTuple with a chained PEP 696 default."""
     K = TypeVar("K", default=str)
@@ -155,6 +173,7 @@ def test_chained_default_namedtuple() -> None:
     assert isinstance(parsed.val, int)
 
 
+@needs_chained_default_fill
 def test_chained_default_pydantic() -> None:
     """Generic pydantic model with a chained PEP 696 default."""
     K = TypeVar("K", default=str)

--- a/tests/test_chained_typevar_defaults.py
+++ b/tests/test_chained_typevar_defaults.py
@@ -1,0 +1,196 @@
+"""Tests for chained PEP 696 TypeVar defaults.
+
+When one TypeVar's default is another TypeVar (for example
+``V = TypeVar("V", default=K)``), tyro should recursively resolve the default
+through the active type parameter bindings rather than returning the raw inner
+TypeVar (or falling back to the inner TypeVar's own default).
+"""
+
+import dataclasses
+from typing import Generic, List, NamedTuple
+
+import pydantic
+import pytest
+from typing_extensions import TypeVar
+
+import tyro
+
+
+def test_chained_default_explicit_binding() -> None:
+    """Variant A: ``Entry[int]`` has ``__args__ == (int, ~K)``; ``V`` defaults to
+    ``K``, which is bound to ``int``, so ``val`` should be parsed as ``int``."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Entry[int], args=["--key", "1", "--val", "2"])
+    assert parsed == Entry(1, 2)
+    assert isinstance(parsed.key, int)
+    assert isinstance(parsed.val, int)
+
+
+def test_chained_default_all_defaults() -> None:
+    """Variant B: both TypeVars fall back to defaults. ``K`` defaults to ``int``
+    and ``V`` defaults to ``K``, so both should resolve to ``int``."""
+    K = TypeVar("K", default=int)
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Entry, args=["--key", "1", "--val", "2"])
+    assert parsed == Entry(1, 2)
+    assert isinstance(parsed.key, int)
+    assert isinstance(parsed.val, int)
+
+
+def test_single_level_default_still_works() -> None:
+    """A plain (non-chained) PEP 696 default should still resolve."""
+    K = TypeVar("K", default=int)
+
+    @dataclasses.dataclass
+    class Single(Generic[K]):
+        x: K
+
+    assert tyro.cli(Single, args=["--x", "5"]) == Single(5)
+    assert tyro.cli(Single[str], args=["--x", "5"]) == Single("5")
+
+
+def test_multi_level_chain() -> None:
+    """W default=V default=K. A three-deep chain should fully resolve."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+    W = TypeVar("W", default=V)
+
+    @dataclasses.dataclass
+    class Triple(Generic[K, V, W]):
+        a: K
+        b: V
+        c: W
+
+    parsed = tyro.cli(Triple[int], args=["--a", "1", "--b", "2", "--c", "3"])
+    assert parsed == Triple(1, 2, 3)
+    assert all(isinstance(v, int) for v in (parsed.a, parsed.b, parsed.c))
+
+    # All defaults: everything chains back to `str`.
+    parsed = tyro.cli(Triple, args=["--a", "x", "--b", "y", "--c", "z"])
+    assert parsed == Triple("x", "y", "z")
+
+
+def test_chained_default_is_container() -> None:
+    """A default that is a container of another TypeVar, e.g. ``default=List[K]``."""
+    K = TypeVar("K", default=int)
+    V = TypeVar("V", default=List[K])
+
+    @dataclasses.dataclass
+    class WithList(Generic[K, V]):
+        key: K
+        vals: V
+
+    parsed = tyro.cli(
+        WithList[float], args=["--key", "1.5", "--vals", "2.0", "3.0"]
+    )
+    assert parsed == WithList(1.5, [2.0, 3.0])
+    assert isinstance(parsed.key, float)
+    assert parsed.vals == [2.0, 3.0]
+
+    # All defaults: K -> int, V -> List[int].
+    parsed = tyro.cli(WithList, args=["--key", "1", "--vals", "2", "3"])
+    assert parsed == WithList(1, [2, 3])
+
+
+def test_explicit_override_of_chained_param() -> None:
+    """When the second parameter is given explicitly, the chain is not used."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Entry[int, bool], args=["--key", "1", "--val", "True"])
+    assert parsed == Entry(1, True)
+    assert isinstance(parsed.key, int)
+    assert isinstance(parsed.val, bool)
+
+
+def test_bound_typevar_not_broken() -> None:
+    """Explicitly-parameterized bound TypeVars should still work."""
+    B = TypeVar("B", bound=int)
+
+    @dataclasses.dataclass
+    class Bounded(Generic[B]):
+        x: B
+
+    assert tyro.cli(Bounded[int], args=["--x", "5"]) == Bounded(5)
+
+
+def test_constrained_typevar_not_broken() -> None:
+    """Explicitly-parameterized constrained TypeVars should still work."""
+    C = TypeVar("C", int, str)
+
+    @dataclasses.dataclass
+    class Constrained(Generic[C]):
+        x: C
+
+    assert tyro.cli(Constrained[int], args=["--x", "5"]) == Constrained(5)
+
+
+def test_chained_default_namedtuple() -> None:
+    """Generic NamedTuple with a chained PEP 696 default."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    class Pair(NamedTuple, Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Pair[int], args=["--key", "1", "--val", "2"])
+    assert parsed == Pair(1, 2)
+    assert isinstance(parsed.val, int)
+
+
+def test_chained_default_pydantic() -> None:
+    """Generic pydantic model with a chained PEP 696 default."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    class Model(pydantic.BaseModel, Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Model[int], args=["--key", "1", "--val", "2"])
+    assert parsed.key == 1
+    assert parsed.val == 2
+    assert isinstance(parsed.val, int)
+
+
+def test_chained_default_no_infinite_loop() -> None:
+    """A self-referential-ish default must not cause an infinite loop.
+
+    ``V`` defaults to ``K`` and ``K`` defaults to ``V`` would be a true cycle,
+    but Python forbids defining that. We instead exercise the guard via a chain
+    where the terminal TypeVar has no resolution, which should terminate and
+    fall back to ``Any`` (with a warning) rather than recursing forever.
+    """
+    K = TypeVar("K")  # No default, bound, or constraints.
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    # Should terminate: the chain bottoms out at an unresolvable TypeVar, which
+    # resolves to `Any`. `Any` is not parsable, so we expect a clean SystemExit
+    # rather than an infinite loop or hang.
+    with pytest.warns(UserWarning):
+        with pytest.raises(SystemExit):
+            tyro.cli(Entry, args=["--key", "a", "--val", "b"])

--- a/tests/test_chained_typevar_defaults.py
+++ b/tests/test_chained_typevar_defaults.py
@@ -8,7 +8,7 @@ TypeVar (or falling back to the inner TypeVar's own default).
 
 import dataclasses
 import sys
-from typing import Generic, List, NamedTuple
+from typing import Any, Generic, List, NamedTuple, cast
 
 import pydantic
 import pytest
@@ -268,3 +268,54 @@ def test_sibling_binding_three_level_nesting() -> None:
     assert out.m.leaf.v == ["p", "q"]
     assert out.m.x == 3
     assert out.b == "w"
+
+
+def test_free_typevar_subscription_falls_back_to_defaults() -> None:
+    """Subscripting a generic with free defaulted TypeVars (its own, or
+    permuted) must apply the PEP 696 defaults rather than failing to resolve.
+
+    Regression test: the sibling-binding context used for chained defaults
+    introduced identity bindings (``V -> V``) and two-cycles (``K -> V -> K``)
+    that previously short-circuited resolution to a raw TypeVar, making these
+    annotations error at parser construction."""
+    K = TypeVar("K", default=int)
+    V = TypeVar("V", default=str)
+
+    @dataclasses.dataclass
+    class Pair(Generic[K, V]):
+        k: K
+        v: V
+
+    @dataclasses.dataclass
+    class Box(Generic[K]):
+        items: List[K]
+
+    # `Any` aliases: type checkers reject free TypeVars in value-level
+    # subscripts, but they are valid at runtime and the case under test.
+    PairT: Any = Pair
+    BoxT: Any = Box
+
+    # Identity bindings: each free TypeVar falls back to its own default.
+    assert tyro.cli(PairT[float, V], args=["--k", "3.5", "--v", "hello"]) == Pair(
+        3.5, "hello"
+    )
+    assert tyro.cli(PairT[K, V], args=["--k", "3", "--v", "hello"]) == Pair(3, "hello")
+    assert tyro.cli(BoxT[K], args=["--items", "1", "2"]) == Box(items=[1, 2])
+
+    # Permuted two-cycle: Pair's K parameter is bound to the free V (default
+    # str) and its V parameter to the free K (default int).
+    assert tyro.cli(PairT[V, K], args=["--k", "hello", "--v", "3"]) == Pair("hello", 3)
+
+
+def test_self_referential_typevar_default_terminates() -> None:
+    """A TypeVar whose ``__default__`` is itself (only constructible by
+    mutation) must terminate and resolve to the TypeVar unchanged."""
+    from tyro._resolver import TypeParamResolver
+
+    make_typevar = cast(Any, TypeVar)
+    tv = make_typevar("SelfDefaultT")
+    try:
+        tv.__default__ = tv
+    except (AttributeError, TypeError):  # pragma: no cover
+        pytest.skip("TypeVar.__default__ is not assignable on this Python")
+    assert TypeParamResolver.resolve_params_and_aliases(tv) is tv

--- a/tests/test_chained_typevar_defaults.py
+++ b/tests/test_chained_typevar_defaults.py
@@ -194,3 +194,60 @@ def test_chained_default_no_infinite_loop() -> None:
     with pytest.warns(UserWarning):
         with pytest.raises(SystemExit):
             tyro.cli(Entry, args=["--key", "a", "--val", "b"])
+
+
+def test_sibling_binding_does_not_shadow_enclosing_typevar() -> None:
+    """Regression: the sibling-binding context pushed for a parameterized
+    generic must not shadow a binding from an enclosing generic when a TypeVar
+    *object* is reused across scopes.
+
+    Here ``T`` is shared between ``OuterNest`` and ``Pair``. While resolving the
+    field ``Pair[int, List[T]]``, the inner ``List[T]`` must keep the enclosing
+    binding ``T -> str`` (from ``OuterNest[str]``), not be rebound to ``int`` by
+    ``Pair``'s concrete first argument.
+    """
+    T = TypeVar("T")
+    U = TypeVar("U")
+
+    @dataclasses.dataclass
+    class Pair(Generic[T, U]):
+        first: T
+        second: U
+
+    @dataclasses.dataclass
+    class OuterNest(Generic[T]):
+        p: Pair[int, List[T]]
+        bare: T
+
+    out = tyro.cli(
+        OuterNest[str],
+        args=["--p.first", "1", "--p.second", "a", "b", "--bare", "z"],
+    )
+    assert out.p.first == 1
+    assert out.p.second == ["a", "b"]  # List[str], not List[int]
+    assert out.bare == "z"
+
+
+def test_sibling_binding_three_level_nesting() -> None:
+    """As above, but the shadowing binding is introduced by a middle generic."""
+    T = TypeVar("T")
+    U = TypeVar("U")
+
+    @dataclasses.dataclass
+    class Leaf(Generic[U]):
+        v: U
+
+    @dataclasses.dataclass
+    class Mid(Generic[T, U]):
+        leaf: Leaf[U]
+        x: T
+
+    @dataclasses.dataclass
+    class Top(Generic[T]):
+        m: Mid[int, List[T]]
+        b: T
+
+    out = tyro.cli(Top[str], args=["--m.leaf.v", "p", "q", "--m.x", "3", "--b", "w"])
+    assert out.m.leaf.v == ["p", "q"]
+    assert out.m.x == 3
+    assert out.b == "w"

--- a/tests/test_chained_typevar_defaults.py
+++ b/tests/test_chained_typevar_defaults.py
@@ -93,9 +93,7 @@ def test_chained_default_is_container() -> None:
         key: K
         vals: V
 
-    parsed = tyro.cli(
-        WithList[float], args=["--key", "1.5", "--vals", "2.0", "3.0"]
-    )
+    parsed = tyro.cli(WithList[float], args=["--key", "1.5", "--vals", "2.0", "3.0"])
     assert parsed == WithList(1.5, [2.0, 3.0])
     assert isinstance(parsed.key, float)
     assert parsed.vals == [2.0, 3.0]

--- a/tests/test_completion_bash.py
+++ b/tests/test_completion_bash.py
@@ -248,6 +248,38 @@ def test_bash_functional_completion_simple(backend: str) -> None:
     )
 
 
+def test_bash_completion_with_quote_in_default(backend: str) -> None:
+    """A spec string with an odd number of quotes (e.g. a default like "don't")
+    must not break the generated bash script.
+
+    The spec is interpolated into a heredoc; previously the heredoc sat inside a
+    `$(...)` command substitution, so bash's quote-balance scan over the
+    substitution body produced a syntax error for any odd-quote spec.
+    """
+    if backend != "tyro":
+        pytest.skip("Testing tyro-specific completion behavior")
+
+    @dataclasses.dataclass
+    class Config:
+        msg: str = "don't"  # odd number of single quotes
+        other: str = 'say "hi"'  # double quotes too
+        mode: Literal["fast", "slow"] = "fast"
+
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stdout(target):
+        tyro.cli(Config, args=["--tyro-print-completion", "bash"])
+
+    completion_script = target.getvalue()
+    # The spec must still be human-readable in the script (not opaque-encoded).
+    assert "--msg" in completion_script
+
+    # Sourcing + running the completion function would raise if the script were
+    # malformed; assert it produces the expected root completions.
+    tester = BashCompletionTester(completion_script)
+    completions = tester.get_completions(["prog", ""], 1)
+    assert {"--msg", "--other", "--mode"}.issubset(set(completions))
+
+
 def test_bash_functional_completion_with_subcommands(backend: str) -> None:
     """Test bash completion with subcommands."""
     if backend != "tyro":

--- a/tests/test_helptext.py
+++ b/tests/test_helptext.py
@@ -1668,3 +1668,22 @@ def test_comment_not_leaking_through_non_field_lines() -> None:
 
     helptext = get_helptext_with_checks(Config)
     assert "This comment is for the internal variable" not in helptext
+
+
+def test_callable_description_without_pydantic_imported() -> None:
+    """Description extraction must work when pydantic has never been imported
+    (the pydantic-specific `__init__` docstring check is skipped)."""
+    from unittest import mock
+
+    from tyro import _docstrings
+
+    @dataclasses.dataclass
+    class FreshForNoPydantic:
+        """Docstring for FreshForNoPydantic."""
+
+        x: int = 0
+
+    with mock.patch.dict(sys.modules):
+        sys.modules.pop("pydantic", None)
+        description = _docstrings.get_callable_description(FreshForNoPydantic)
+    assert "Docstring for FreshForNoPydantic." in description

--- a/tests/test_pep695_generics_min_py312.py
+++ b/tests/test_pep695_generics_min_py312.py
@@ -1,0 +1,173 @@
+"""Regression tests for GitHub issues #474 and #475.
+
+PEP 695 type parameters (``class Foo[T]: ...``, Python 3.12+) live in
+``__type_params__``, not in module globals. Combined with stringized
+annotations (``from __future__ import annotations`` / PEP 563), a field whose
+type references such a parameter used to raise an obscure
+``NameError: name 'T' is not defined`` from ``get_type_hints`` (#475). This also
+surfaced through ``dataclasses.InitVar`` members (#474), which tyro should
+recognize as ordinary constructor arguments.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import tyro
+
+
+@dataclasses.dataclass
+class Container[T]:
+    items: list[T]
+
+
+@dataclasses.dataclass
+class Sequencer[Data]:
+    items: list[Data]
+
+
+type Seq = Sequencer[int]
+
+
+@dataclasses.dataclass
+class Bare[T]:
+    x: T
+
+
+@dataclasses.dataclass
+class Pair[K, V]:
+    k: K
+    v: V
+
+
+@dataclasses.dataclass
+class Compound[T]:
+    mapping: dict[str, T]
+    opt: T | None = None
+    rest: tuple[T, ...] = ()
+
+
+@dataclasses.dataclass
+class Base[T]:
+    base_field: T
+
+
+@dataclasses.dataclass
+class Child[T](Base[T]):
+    child_field: T
+
+
+@dataclasses.dataclass
+class ReifiedChild(Base[int]):
+    extra: str = "x"
+
+
+def test_pep695_generic_stringized_annotation_resolves() -> None:
+    # #475: previously raised `NameError: name 'T' is not defined` because the
+    # stringized `list[T]` annotation couldn't see the PEP 695 type parameter.
+    out = tyro.cli(Container[int], args=["--items", "1", "2", "3"])
+    assert out.items == [1, 2, 3]
+    assert all(isinstance(x, int) for x in out.items)
+
+    out_str = tyro.cli(Container[str], args=["--items", "a", "b"])
+    assert out_str.items == ["a", "b"]
+
+
+def test_initvar_is_recognized_as_constructor_arg() -> None:
+    # #474: InitVar fields are init-only pseudo-fields passed to __init__ /
+    # __post_init__, so tyro should expose them as CLI arguments.
+    @dataclasses.dataclass
+    class WithInit:
+        x: int
+        offset: dataclasses.InitVar[int] = 10
+
+        def __post_init__(self, offset: int) -> None:
+            self.total = self.x + offset
+
+    # If InitVar weren't recognized, `--offset` would be an unrecognized option.
+    out = tyro.cli(WithInit, args=["--x", "1", "--offset", "5"])
+    assert out.x == 1
+    assert out.total == 6
+    # Default is used when not provided.
+    assert tyro.cli(WithInit, args=["--x", "2"]).total == 12
+
+
+def test_initvar_of_pep695_generic_does_not_crash() -> None:
+    # The exact shape from the issue: an InitVar of a (PEP 695) generic, behind
+    # a PEP 695 `type` alias, with stringized annotations. Used to raise the
+    # obscure NameError; should now resolve cleanly.
+    @dataclasses.dataclass
+    class App:
+        name: str = "default"
+        _sequencer: dataclasses.InitVar[Seq | None] = None
+
+        def __post_init__(self, _sequencer: Seq | None) -> None:
+            self.seq = _sequencer
+
+    out = tyro.cli(App, args=["--name", "hi"])
+    assert out.name == "hi"
+    assert out.seq is None
+
+
+def test_pep695_multiple_params_and_compound_refs() -> None:
+    # Multiple PEP 695 params, and type params nested inside dict/Optional/tuple.
+    assert tyro.cli(Pair[int, str], args=["--k", "1", "--v", "a"]) == Pair(1, "a")
+
+    out = tyro.cli(
+        Compound[int],
+        args=["--mapping", "a", "1", "--opt", "2", "--rest", "3", "4"],
+    )
+    assert out.mapping == {"a": 1}
+    assert out.opt == 2 and isinstance(out.opt, int)
+    assert out.rest == (3, 4)
+    # Defaults still work when the param-typed optionals are omitted.
+    assert tyro.cli(Compound[str], args=["--mapping", "k", "v"]) == Compound(
+        {"k": "v"}, None, ()
+    )
+
+
+def test_pep695_inheritance() -> None:
+    # Type parameter forwarded through a base class: Child[int] -> Base[int].
+    assert tyro.cli(
+        Child[int], args=["--base-field", "1", "--child-field", "2"]
+    ) == Child(base_field=1, child_field=2)
+    # Base reified at the inheritance site: ReifiedChild(Base[int]).
+    out = tyro.cli(ReifiedChild, args=["--base-field", "9"])
+    assert out.base_field == 9 and isinstance(out.base_field, int)
+    assert out.extra == "x"
+
+
+def test_pep695_generic_as_nested_field() -> None:
+    @dataclasses.dataclass
+    class Outer:
+        inner: Bare[int]
+
+    out = tyro.cli(Outer, args=["--inner.x", "7"])
+    assert out.inner == Bare(7) and isinstance(out.inner.x, int)
+
+
+def test_pep695_generic_in_subcommand_union() -> None:
+    @dataclasses.dataclass
+    class Outer2:
+        choice: Bare[int] | Pair[int, int]
+
+    assert tyro.cli(Outer2, args=["choice:bare-int", "--choice.x", "3"]) == Outer2(
+        choice=Bare(3)
+    )
+    assert tyro.cli(
+        Outer2, args=["choice:pair-int-int", "--choice.k", "1", "--choice.v", "2"]
+    ) == Outer2(choice=Pair(1, 2))
+
+
+def test_pep695_unreified_generic_gives_clean_error_not_nameerror() -> None:
+    # An *unparameterized* PEP 695 generic field can't bind its type parameter,
+    # so it resolves to `Any` -> a clean "unsupported type" error (SystemExit),
+    # NOT the obscure pre-fix `NameError: name 'T' is not defined`.
+    @dataclasses.dataclass
+    class Outer:
+        inner: Bare
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Outer, args=["--inner.x", "1"])

--- a/tests/test_py311_generated/test_abc_containers_generated.py
+++ b/tests/test_py311_generated/test_abc_containers_generated.py
@@ -8,7 +8,7 @@
 import collections
 import collections.abc
 import dataclasses
-from typing import Counter, DefaultDict, OrderedDict
+from typing import Annotated, Counter, DefaultDict, OrderedDict
 
 import pytest
 
@@ -176,3 +176,42 @@ def test_chainmap_unsupported() -> None:
 
     with pytest.raises(SystemExit):
         tyro.cli(A, args=["--x", "a", "1"])
+
+
+def test_abc_containers_with_append_action() -> None:
+    """`UseAppendAction` must construct the correct concrete type for the abc /
+    mapping-subclass containers, not try to instantiate the abstract class."""
+    import collections
+    from collections import abc
+
+    from tyro.conf import UseAppendAction
+
+    @dataclasses.dataclass
+    class Seq:
+        x: Annotated[abc.MutableSequence[int], UseAppendAction]
+
+    out = tyro.cli(Seq, args=["--x", "1", "--x", "2"])
+    assert out.x == [1, 2] and isinstance(out.x, list)
+
+    @dataclasses.dataclass
+    class St:
+        x: Annotated[abc.Set[int], UseAppendAction]
+
+    out_set = tyro.cli(St, args=["--x", "1", "--x", "2"])
+    assert out_set.x == frozenset({1, 2}) and isinstance(out_set.x, frozenset)
+
+    @dataclasses.dataclass
+    class Od:
+        x: Annotated[collections.OrderedDict[str, int], UseAppendAction]
+
+    out_od = tyro.cli(Od, args=["--x", "a", "1", "--x", "b", "2"])
+    assert out_od.x == collections.OrderedDict({"a": 1, "b": 2})
+    assert isinstance(out_od.x, collections.OrderedDict)
+
+    @dataclasses.dataclass
+    class Ct:
+        x: Annotated[collections.Counter[str], UseAppendAction]
+
+    out_ct = tyro.cli(Ct, args=["--x", "a", "2", "--x", "b", "3"])
+    assert out_ct.x == collections.Counter({"a": 2, "b": 3})
+    assert isinstance(out_ct.x, collections.Counter)

--- a/tests/test_py311_generated/test_abc_containers_generated.py
+++ b/tests/test_py311_generated/test_abc_containers_generated.py
@@ -8,11 +8,21 @@
 import collections
 import collections.abc
 import dataclasses
+import sys
 from typing import Annotated, Counter, DefaultDict, OrderedDict
 
 import pytest
 
 import tyro
+
+# These tests subscript `collections.abc.*` / `collections.*` directly
+# (e.g. `collections.abc.Set[int]`), which is PEP 585 syntax available only on
+# Python 3.9+. The feature itself is reachable on 3.8 via the `typing.*`
+# aliases (e.g. `typing.AbstractSet[int]`).
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="PEP 585 subscription of collections.abc / collections requires Python 3.9+",
+)
 
 # Set-like abstract base classes. ----------------------------------------
 
@@ -166,15 +176,17 @@ def test_typing_defaultdict() -> None:
     assert isinstance(out.x, collections.defaultdict)
 
 
-# A mapping subclass we intentionally do NOT support: this should produce a
-# clean "unsupported type annotation" error (SystemExit from the CLI parser),
-# not a crash.
+# A mapping subclass we intentionally do NOT support: it must not silently
+# parse. The exact failure mode is version-dependent and pre-existing (a clean
+# SystemExit from the CLI parser on Python 3.12+, an internal AssertionError
+# from generic-base resolution on 3.9-3.11 -- the base library behaves
+# identically), so we only assert that parsing does not succeed.
 def test_chainmap_unsupported() -> None:
     @dataclasses.dataclass
     class A:
         x: collections.ChainMap[str, int]
 
-    with pytest.raises(SystemExit):
+    with pytest.raises((SystemExit, AssertionError)):
         tyro.cli(A, args=["--x", "a", "1"])
 
 

--- a/tests/test_py311_generated/test_abc_containers_generated.py
+++ b/tests/test_py311_generated/test_abc_containers_generated.py
@@ -1,0 +1,178 @@
+# mypy: disable-error-code="call-overload,misc"
+#
+# Regression tests for abstract / subclass container annotations that were
+# previously (incorrectly) treated as "fixed" arguments rather than being
+# parsed. See: collections.abc.Set / MutableSet / MutableSequence /
+# MutableMapping, and the dict subclasses collections.Counter / OrderedDict /
+# defaultdict (plus their typing.* aliases).
+import collections
+import collections.abc
+import dataclasses
+from typing import Counter, DefaultDict, OrderedDict
+
+import pytest
+
+import tyro
+
+# Set-like abstract base classes. ----------------------------------------
+
+
+def test_abc_set() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.Set[int]
+
+    out = tyro.cli(A, args=["--x", "1", "2", "3", "3"])
+    assert out.x == frozenset({1, 2, 3})
+    # `collections.abc.Set` is immutable -> frozenset.
+    assert type(out.x) is frozenset
+    assert tyro.cli(A, args=["--x"]).x == frozenset()
+    assert type(tyro.cli(A, args=["--x"]).x) is frozenset
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=[])
+
+
+def test_abc_mutable_set() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.MutableSet[int]
+
+    out = tyro.cli(A, args=["--x", "1", "2", "3", "3"])
+    assert out.x == {1, 2, 3}
+    assert type(out.x) is set
+    assert tyro.cli(A, args=["--x"]).x == set()
+    assert type(tyro.cli(A, args=["--x"]).x) is set
+
+
+def test_abc_set_with_default() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.Set[int] = frozenset({0, 1, 2})
+
+    # Round-trip: default is reused when no args are passed.
+    assert tyro.cli(A, args=[]).x == frozenset({0, 1, 2})
+    assert type(tyro.cli(A, args=[]).x) is frozenset
+    assert tyro.cli(A, args=["--x", "5", "6"]).x == frozenset({5, 6})
+
+
+# Sequence-like abstract base classes. ------------------------------------
+
+
+def test_abc_mutable_sequence() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.MutableSequence[int]
+
+    out = tyro.cli(A, args=["--x", "1", "2", "3"])
+    assert out.x == [1, 2, 3]
+    assert type(out.x) is list
+    assert tyro.cli(A, args=["--x"]).x == []
+    assert type(tyro.cli(A, args=["--x"]).x) is list
+
+
+# Mapping-like abstract base classes and dict subclasses. -----------------
+
+
+def test_abc_mutable_mapping() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.abc.MutableMapping[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == {"a": 1, "b": 2}
+    assert type(out.x) is dict
+    assert tyro.cli(A, args=["--x"]).x == {}
+
+
+def test_ordered_dict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.OrderedDict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == collections.OrderedDict({"a": 1, "b": 2})
+    assert isinstance(out.x, collections.OrderedDict)
+    assert tyro.cli(A, args=["--x"]).x == collections.OrderedDict()
+    assert isinstance(tyro.cli(A, args=["--x"]).x, collections.OrderedDict)
+
+
+def test_typing_ordered_dict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: OrderedDict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1"])
+    assert out.x == collections.OrderedDict({"a": 1})
+    assert isinstance(out.x, collections.OrderedDict)
+
+
+def test_counter() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.Counter[str]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == collections.Counter({"a": 1, "b": 2})
+    assert isinstance(out.x, collections.Counter)
+    assert tyro.cli(A, args=["--x"]).x == collections.Counter()
+    assert isinstance(tyro.cli(A, args=["--x"]).x, collections.Counter)
+
+
+def test_typing_counter() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: Counter[str]
+
+    out = tyro.cli(A, args=["--x", "a", "3"])
+    assert out.x == collections.Counter({"a": 3})
+    assert isinstance(out.x, collections.Counter)
+
+
+def test_counter_with_default() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.Counter[str] = dataclasses.field(
+            default_factory=lambda: collections.Counter({"z": 3})
+        )
+
+    # Round-trip: default reused & re-validated when no args passed.
+    out = tyro.cli(A, args=[])
+    assert out.x == collections.Counter({"z": 3})
+    assert isinstance(out.x, collections.Counter)
+
+
+def test_defaultdict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.defaultdict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1", "b", "2"])
+    assert out.x == {"a": 1, "b": 2}
+    assert isinstance(out.x, collections.defaultdict)
+    # We construct `defaultdict(None, ...)`: there's no way to infer a
+    # default_factory from the annotation, so missing keys raise KeyError.
+    assert out.x.default_factory is None
+    with pytest.raises(KeyError):
+        out.x["missing"]
+
+
+def test_typing_defaultdict() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: DefaultDict[str, int]
+
+    out = tyro.cli(A, args=["--x", "a", "1"])
+    assert out.x == {"a": 1}
+    assert isinstance(out.x, collections.defaultdict)
+
+
+# A mapping subclass we intentionally do NOT support: this should produce a
+# clean "unsupported type annotation" error (SystemExit from the CLI parser),
+# not a crash.
+def test_chainmap_unsupported() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: collections.ChainMap[str, int]
+
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "a", "1"])

--- a/tests/test_py311_generated/test_abc_containers_generated.py
+++ b/tests/test_py311_generated/test_abc_containers_generated.py
@@ -249,7 +249,10 @@ def test_counter_wrong_arg_count_rejected() -> None:
     """``Counter[...]`` takes exactly one type argument (the key type; values
     are implicitly integer counts). A two-argument subscription is only
     constructible via PEP 585 (``collections.Counter[str, int]``) and is not a
-    valid annotation; it must be rejected rather than misparsed."""
+    valid annotation; it must be rejected rather than misparsed.
+
+    (On Python 3.10 the rejection surfaces as an internal AssertionError from
+    the struct-rule fallthrough rather than a clean SystemExit.)"""
     bad = cast(Any, collections.Counter)[str, int]
-    with pytest.raises(SystemExit):
+    with pytest.raises((SystemExit, AssertionError)):
         tyro.cli(bad, args=["a", "1"])

--- a/tests/test_py311_generated/test_abc_containers_generated.py
+++ b/tests/test_py311_generated/test_abc_containers_generated.py
@@ -9,7 +9,7 @@ import collections
 import collections.abc
 import dataclasses
 import sys
-from typing import Annotated, Counter, DefaultDict, OrderedDict
+from typing import Annotated, Any, Counter, DefaultDict, OrderedDict, cast
 
 import pytest
 
@@ -227,3 +227,29 @@ def test_abc_containers_with_append_action() -> None:
     out_ct = tyro.cli(Ct, args=["--x", "a", "2", "--x", "b", "3"])
     assert out_ct.x == collections.Counter({"a": 2, "b": 3})
     assert isinstance(out_ct.x, collections.Counter)
+
+    @dataclasses.dataclass
+    class Dd:
+        x: Annotated[DefaultDict[str, int], UseAppendAction]
+
+    out_dd = tyro.cli(Dd, args=["--x", "a", "1", "--x", "b", "2"])
+    assert out_dd.x == {"a": 1, "b": 2}
+    assert isinstance(out_dd.x, collections.defaultdict)
+
+    @dataclasses.dataclass
+    class Ms:
+        x: Annotated[abc.MutableSet[int], UseAppendAction]
+
+    out_ms = tyro.cli(Ms, args=["--x", "1", "--x", "2"])
+    assert out_ms.x == {1, 2}
+    assert isinstance(out_ms.x, set)
+
+
+def test_counter_wrong_arg_count_rejected() -> None:
+    """``Counter[...]`` takes exactly one type argument (the key type; values
+    are implicitly integer counts). A two-argument subscription is only
+    constructible via PEP 585 (``collections.Counter[str, int]``) and is not a
+    valid annotation; it must be rejected rather than misparsed."""
+    bad = cast(Any, collections.Counter)[str, int]
+    with pytest.raises(SystemExit):
+        tyro.cli(bad, args=["a", "1"])

--- a/tests/test_py311_generated/test_argparse_backend_fixes_generated.py
+++ b/tests/test_py311_generated/test_argparse_backend_fixes_generated.py
@@ -284,3 +284,75 @@ def test_bug3_mutex_within_single_subcommand_ok() -> None:
             Top3Within,
             args=["sub:with-mutex", "--sub.p", "1", "--sub.q", "2"],
         )
+
+
+# ----------------------------------------------------------------------------
+# BUG 3 refinement: the mutex-boundary check must flag a group only when two
+# members can actually coexist in one parse. A group reused across mutually
+# exclusive *sibling* subcommand arms is always satisfiable and must be allowed.
+# ----------------------------------------------------------------------------
+
+_MG_SIBLING = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class _SibA:
+    a: Annotated[Optional[int], _MG_SIBLING] = None
+
+
+@dataclass
+class _SibB:
+    b: Annotated[Optional[int], _MG_SIBLING] = None
+
+
+@dataclass
+class _SibTop:
+    sub: Annotated[_SibA, subcommand("x")] | Annotated[_SibB, subcommand("y")] = field(
+        default_factory=_SibA
+    )
+
+
+def test_mutex_reused_across_sibling_arms_is_accepted() -> None:
+    # Only one arm is ever active, so the shared group is always satisfiable.
+    assert tyro.cli(_SibTop, args=["sub:x", "--sub.a", "1"]) == _SibTop(sub=_SibA(a=1))
+    assert tyro.cli(_SibTop, args=["sub:y", "--sub.b", "2"]) == _SibTop(sub=_SibB(b=2))
+
+
+# A group spanning two PARALLEL subparser groups (both active in one parse) can
+# coexist, so the argparse backend must still reject it (and the tyro backend
+# enforces the mutex at parse time).
+_MG_PARALLEL = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class _ParA:
+    a: Annotated[Optional[int], _MG_PARALLEL] = None
+
+
+@dataclass
+class _ParB:
+    b: Annotated[Optional[int], _MG_PARALLEL] = None
+
+
+@dataclass
+class _ParTop:
+    sub1: Annotated[_ParA, subcommand("x1")] | Annotated[_ParA, subcommand("y1")] = (
+        field(default_factory=_ParA)
+    )
+    sub2: Annotated[_ParB, subcommand("x2")] | Annotated[_ParB, subcommand("y2")] = (
+        field(default_factory=_ParB)
+    )
+
+
+def test_mutex_across_parallel_subparsers_is_rejected(backend: str) -> None:
+    if backend == "argparse":
+        # Rejected at construction (argparse can't share the group).
+        with pytest.raises(SystemExit):
+            tyro.cli(_ParTop, args=["sub1:x1", "sub2:x2"])
+    else:
+        # The tyro backend enforces the mutex globally at parse time.
+        with pytest.raises(SystemExit):
+            tyro.cli(
+                _ParTop,
+                args=["sub1:x1", "--sub1.a", "1", "sub2:x2", "--sub2.b", "2"],
+            )

--- a/tests/test_py311_generated/test_argparse_backend_fixes_generated.py
+++ b/tests/test_py311_generated/test_argparse_backend_fixes_generated.py
@@ -1,0 +1,286 @@
+"""Regression tests for confirmed argparse-backend latent bugs.
+
+Each test asserts that the argparse backend now agrees with the (correct) tyro
+backend, or -- for the case argparse fundamentally cannot support -- that the
+argparse backend raises a clear, explicit error instead of silently
+mis-parsing.
+
+These tests are parametrized over both backends via ``tests/conftest.py``. The
+tyro backend is already correct for all three bugs; the assertions below are
+written so they pass on *both* backends (the argparse backend after the fix,
+the tyro backend natively).
+
+Union members below are annotated with explicit ``subcommand()`` names so the
+expected command-line tokens are deterministic regardless of class naming.
+"""
+
+from dataclasses import dataclass, field
+from typing import Annotated, Optional
+
+import pytest
+
+import tyro
+from tyro.conf import Positional, subcommand
+
+# ----------------------------------------------------------------------------
+# BUG 1: nested ``is_default`` injection skipped when a sibling subcommand
+# field exists at the same level.
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class Inner1:
+    a: int = 1
+
+
+@dataclass
+class Inner2:
+    b: int = 2
+
+
+@dataclass
+class MidDefault:
+    pick: (
+        Annotated[Inner1, subcommand("i1")]
+        | Annotated[Inner2, subcommand("i2", is_default=True)]
+    )
+
+
+@dataclass
+class MidOther:
+    q: int = 0
+
+
+@dataclass
+class PlainArm:
+    z: int = 0
+
+
+@dataclass
+class Top1:
+    outer: (
+        Annotated[MidDefault, subcommand("md", is_default=True)]
+        | Annotated[MidOther, subcommand("mo")]
+    )
+    second: (
+        Annotated[PlainArm, subcommand("plain")]
+        | Annotated[MidOther, subcommand("other")]
+    )
+
+
+def test_bug1_nested_default_with_sibling_subcommand() -> None:
+    """A default branch's nested subparser default must still be injected even
+    when a later sibling subcommand field exists at the same level."""
+    assert tyro.cli(Top1, args=["outer:md", "second:plain"]) == Top1(
+        outer=MidDefault(pick=Inner2(b=2)), second=PlainArm(z=0)
+    )
+
+
+@dataclass
+class P1:
+    z: int = 0
+
+
+@dataclass
+class P2:
+    w: int = 0
+
+
+@dataclass
+class SecondDefault:
+    pk2: (
+        Annotated[P1, subcommand("p1")]
+        | Annotated[P2, subcommand("p2", is_default=True)]
+    )
+
+
+@dataclass
+class Top1b:
+    outer: (
+        Annotated[MidDefault, subcommand("md", is_default=True)]
+        | Annotated[MidOther, subcommand("mo")]
+    )
+    second: (
+        Annotated[SecondDefault, subcommand("sd", is_default=True)]
+        | Annotated[MidOther, subcommand("so")]
+    )
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], Top1b(MidDefault(Inner2(2)), SecondDefault(P2(0)))),
+        (["outer:md"], Top1b(MidDefault(Inner2(2)), SecondDefault(P2(0)))),
+        (["second:sd"], Top1b(MidDefault(Inner2(2)), SecondDefault(P2(0)))),
+        (
+            ["outer:md", "outer.pick:i1", "second:sd", "second.pk2:p1"],
+            Top1b(MidDefault(Inner1(1)), SecondDefault(P1(0))),
+        ),
+    ],
+)
+def test_bug1_two_default_siblings(args, expected) -> None:
+    assert tyro.cli(Top1b, args=args) == expected
+
+
+# ----------------------------------------------------------------------------
+# BUG 2: parent-level positional preceding a subcommand union.
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class ArgA:
+    x: int = 1
+
+
+@dataclass
+class ArgB:
+    y: int = 2
+
+
+@dataclass
+class Top2:
+    name: Positional[str]
+    sub: Annotated[ArgA, subcommand("a")] | Annotated[ArgB, subcommand("b")]
+
+
+def test_bug2_positional_before_subcommand() -> None:
+    assert tyro.cli(Top2, args=["hello", "sub:a"]) == Top2(name="hello", sub=ArgA(x=1))
+    assert tyro.cli(Top2, args=["world", "sub:b", "--sub.y", "9"]) == Top2(
+        name="world", sub=ArgB(y=9)
+    )
+
+
+@dataclass
+class Top2b:
+    name: Positional[str]
+    count: Positional[int]
+    sub: Annotated[ArgA, subcommand("a")] | Annotated[ArgB, subcommand("b")]
+
+
+def test_bug2_two_positionals_before_subcommand() -> None:
+    assert tyro.cli(Top2b, args=["hello", "3", "sub:b"]) == Top2b(
+        name="hello", count=3, sub=ArgB(y=2)
+    )
+
+
+@dataclass
+class Top2c:
+    name: Positional[str]
+    flag: int = 0
+    sub: Annotated[ArgA, subcommand("a")] | Annotated[ArgB, subcommand("b")] = field(
+        default_factory=ArgA
+    )
+
+
+def test_bug2_positional_with_optional_and_subcommand() -> None:
+    assert tyro.cli(Top2c, args=["hello", "--flag", "2", "sub:a"]) == Top2c(
+        name="hello", flag=2, sub=ArgA(x=1)
+    )
+    assert tyro.cli(Top2c, args=["hello", "sub:a"]) == Top2c(
+        name="hello", flag=0, sub=ArgA(x=1)
+    )
+
+
+# ----------------------------------------------------------------------------
+# BUG 3: a mutex group spanning a subcommand boundary.
+#
+# The argparse backend cannot share a mutually-exclusive group across
+# subparsers, so it raises a clear error at parser-construction time rather
+# than silently mis-parsing. The tyro backend enforces the group globally and
+# is correct.
+# ----------------------------------------------------------------------------
+
+_MG = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class MutexArm:
+    av: Annotated[Optional[int], _MG] = None
+
+
+@dataclass
+class PlainArm3:
+    bv: int = 2
+
+
+@dataclass
+class Top3:
+    top_opt: Annotated[Optional[int], _MG] = None
+    sub: (
+        Annotated[MutexArm, subcommand("mutex")]
+        | Annotated[PlainArm3, subcommand("plain")]
+    ) = field(default_factory=MutexArm)
+
+
+def test_bug3_mutex_across_subcommand_boundary(backend: str) -> None:
+    if backend == "argparse":
+        # argparse cannot enforce a mutex group across a subparser boundary, so
+        # it must reject this at construction time with a clear error (exit 2),
+        # rather than silently accepting both members.
+        with pytest.raises(SystemExit):
+            tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex", "--sub.av", "7"])
+        with pytest.raises(SystemExit):
+            tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex"])
+    else:
+        # tyro backend enforces it globally: both members -> error, one -> ok.
+        with pytest.raises(SystemExit):
+            tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex", "--sub.av", "7"])
+        assert tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex"]) == Top3(
+            top_opt=5, sub=MutexArm(av=None)
+        )
+
+
+def test_bug3_mutex_across_subcommand_boundary_error_message(backend: str) -> None:
+    """The argparse backend's rejection should mention the subcommand boundary."""
+    if backend != "argparse":
+        pytest.skip("Clear-error path is argparse-specific.")
+    import io
+    from contextlib import redirect_stderr
+
+    stderr = io.StringIO()
+    with redirect_stderr(stderr), pytest.raises(SystemExit):
+        tyro.cli(Top3, args=["--top-opt", "5", "sub:mutex"])
+    rendered = stderr.getvalue()
+    assert "mutex group" in rendered
+    assert "subcommand" in rendered
+
+
+# A mutex group fully contained within a single (sub)command must NOT trigger
+# the boundary-spanning error and must still enforce exclusion on both backends.
+_MG_WITHIN = tyro.conf.create_mutex_group(required=False)
+
+
+@dataclass
+class ArmWithMutex:
+    p: Annotated[Optional[int], _MG_WITHIN] = None
+    q: Annotated[Optional[int], _MG_WITHIN] = None
+
+
+@dataclass
+class OtherArm:
+    r: int = 0
+
+
+@dataclass
+class Top3Within:
+    sub: (
+        Annotated[ArmWithMutex, subcommand("with-mutex")]
+        | Annotated[OtherArm, subcommand("other")]
+    ) = field(default_factory=ArmWithMutex)
+
+
+def test_bug3_mutex_within_single_subcommand_ok() -> None:
+    # No member -> ok.
+    assert tyro.cli(Top3Within, args=["sub:with-mutex"]) == Top3Within(
+        sub=ArmWithMutex(p=None, q=None)
+    )
+    # One member -> ok.
+    assert tyro.cli(Top3Within, args=["sub:with-mutex", "--sub.p", "1"]) == Top3Within(
+        sub=ArmWithMutex(p=1, q=None)
+    )
+    # Both members -> mutual exclusion enforced on both backends.
+    with pytest.raises(SystemExit):
+        tyro.cli(
+            Top3Within,
+            args=["sub:with-mutex", "--sub.p", "1", "--sub.q", "2"],
+        )

--- a/tests/test_py311_generated/test_bug_repros_2_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_2_generated.py
@@ -28,15 +28,21 @@ Each test fails on the unfixed code and documents the expected behavior.
   constructed by field name while pydantic validates by alias.
 """
 
+# mypy: disable-error-code="call-overload"
+# `tyro.cli(Tuple[int, int, int], ...)` / `tyro.cli(Literal[...], ...)` pass a
+# bare typing special form, which newer mypy (2.x) rejects against the `cli`
+# overloads even though it is valid at runtime.
+
 from __future__ import annotations
 
 import dataclasses
 import pathlib
-from typing import Tuple
+from typing import Literal, Tuple
 
 import attrs
 import pydantic
 import pytest
+from helptext_utils import get_helptext_with_checks
 
 import tyro
 
@@ -59,6 +65,23 @@ def test_missing_value_error_renders_arg_name(capsys: pytest.CaptureFixture) -> 
     out = capsys.readouterr()
     text = out.out + out.err
     assert "__tyro-dummy-inner__" not in text
+
+    # Under `use_underscores=True` the lowered dummy name keeps underscores
+    # (`__tyro_dummy_inner__`); it must be hidden too, in both the
+    # missing-value and invalid-choice error paths.
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[int, int, int], args=["1", "2"], use_underscores=True)
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "__tyro-dummy-inner__" not in text
+    assert "__tyro_dummy_inner__" not in text
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Literal["a", "b"], args=["zzz"], use_underscores=True)
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "__tyro-dummy-inner__" not in text
+    assert "__tyro_dummy_inner__" not in text
 
 
 def test_bytearray_field() -> None:
@@ -173,3 +196,50 @@ def test_pydantic_field_alias() -> None:
         )
 
     assert tyro.cli(M4, args=["--x", "5"]).x == 5
+
+    # A model with an aliased field must keep its docstring in --help: the
+    # alias-remapping closure must carry the model's `__doc__` (regression
+    # guard -- helptext extraction reads `instantiate.__doc__`).
+    class MDoc(pydantic.BaseModel):
+        """Docstring for the aliased model."""
+
+        real_name: int = pydantic.Field(alias="aliased", default=3)
+
+    assert "Docstring for the aliased model." in get_helptext_with_checks(MDoc)
+
+
+def test_pydantic_v1_field_alias() -> None:
+    """pydantic.v1-style models with ``Field(alias=...)`` must also construct
+    by alias: v1 validates by alias only (unless
+    ``allow_population_by_field_name`` is set), so constructing by field name
+    silently dropped the CLI value with the default ``Extra.ignore`` config."""
+    try:
+        import pydantic.v1 as pydantic_v1
+    except ImportError:  # pragma: no cover
+        pytest.skip("pydantic.v1 is not available")
+
+    class M(pydantic_v1.BaseModel):
+        real_name: int = pydantic_v1.Field(3, alias="aliased")
+
+    assert tyro.cli(M, args=["--real-name", "5"]).real_name == 5
+    assert tyro.cli(M, args=[]).real_name == 3
+
+
+def test_pydantic_alias_without_validation_alias() -> None:
+    """Pin the fallback for (older) pydantic 2.x versions that don't
+    auto-populate ``validation_alias`` from ``alias`` at model build time: with
+    ``validation_alias`` unset, the serialization-side ``alias`` is the name
+    pydantic accepts on input."""
+    if not pydantic.VERSION.startswith("2"):
+        pytest.skip("pydantic v2 only")
+
+    class M(pydantic.BaseModel):
+        x: int = pydantic.Field(alias="ax")
+
+    field_info = M.model_fields["x"]
+    original = field_info.validation_alias
+    field_info.validation_alias = None  # Simulate older pydantic 2.x.
+    try:
+        assert tyro.cli(M, args=["--x", "5"]).x == 5
+    finally:
+        field_info.validation_alias = original

--- a/tests/test_py311_generated/test_bug_repros_2_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_2_generated.py
@@ -34,6 +34,8 @@ import dataclasses
 import pathlib
 from typing import Tuple
 
+import attrs
+import pydantic
 import pytest
 
 import tyro
@@ -119,8 +121,6 @@ def test_var_keyword_default_instance() -> None:
 
 
 def test_attrs_field_alias() -> None:
-    attrs = pytest.importorskip("attrs")
-
     @attrs.define
     class A:
         x: int = attrs.field(alias="renamed")
@@ -143,7 +143,6 @@ def test_attrs_field_alias() -> None:
 
 
 def test_pydantic_field_alias() -> None:
-    pydantic = pytest.importorskip("pydantic")
     if not pydantic.VERSION.startswith("2"):
         pytest.skip("pydantic v2 only")
 

--- a/tests/test_py311_generated/test_bug_repros_2_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_2_generated.py
@@ -1,0 +1,176 @@
+"""Regression tests for a second batch of bugs found via manual exploration.
+
+Each test fails on the unfixed code and documents the expected behavior.
+
+* ``test_missing_value_error_renders_arg_name`` -- the "Missing value" parse
+  error rendered the argument's ``name_or_flags`` tuple verbatim (e.g.
+  ``'('--coord',)'``) and leaked the internal ``__tyro-dummy-inner__`` name
+  for positionals.
+
+* ``test_bytearray_field`` -- a ``bytearray`` field crashed on every input
+  (``bytearray(str)`` needs an encoding) even though it is registered as a
+  supported primitive.
+
+* ``test_pure_path_subclass_preserved`` -- ``PurePosixPath`` / ``PureWindowsPath``
+  annotations returned a concrete OS ``Path`` of the wrong flavour instead of
+  the annotated pure-path type.
+
+* ``test_var_keyword_default_instance`` -- a ``default=`` instance for a
+  ``**kwargs`` parameter was dropped (returned ``{}``) because the VAR_KEYWORD
+  branch reset the default unconditionally, unlike the ``*args`` branch.
+
+* ``test_attrs_field_alias`` -- attrs fields whose init-arg name differs from
+  the attribute name (private ``_x`` -> ``x``, or ``attrs.field(alias=...)``)
+  crashed construction with an unexpected-keyword ``TypeError``.
+
+* ``test_pydantic_field_alias`` -- pydantic v2 fields with ``Field(alias=...)``
+  / ``validation_alias`` crashed with a ``ValidationError`` because tyro
+  constructed by field name while pydantic validates by alias.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Tuple
+
+import pytest
+
+import tyro
+
+
+def test_missing_value_error_renders_arg_name(capsys: pytest.CaptureFixture) -> None:
+    @dataclasses.dataclass
+    class C:
+        coord: Tuple[int, int, int]
+
+    with pytest.raises(SystemExit):
+        tyro.cli(C, args=["--coord", "1"])
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "--coord" in text
+    assert "('--coord',)" not in text  # no raw tuple repr
+
+    # Positional: must not leak the internal dummy name.
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[int, int, int], args=["1", "2"])
+    out = capsys.readouterr()
+    text = out.out + out.err
+    assert "__tyro-dummy-inner__" not in text
+
+
+def test_bytearray_field() -> None:
+    @dataclasses.dataclass
+    class C:
+        x: bytearray = dataclasses.field(default_factory=bytearray)
+
+    assert tyro.cli(C, args=["--x", "hello"]) == C(x=bytearray(b"hello"))
+
+    # bytes still works.
+    @dataclasses.dataclass
+    class D:
+        x: bytes = b""
+
+    assert tyro.cli(D, args=["--x", "hello"]) == D(x=b"hello")
+
+
+def test_pure_path_subclass_preserved() -> None:
+    @dataclasses.dataclass
+    class W:
+        x: pathlib.PureWindowsPath
+
+    out = tyro.cli(W, args=["--x", "C:\\a\\b"])
+    assert isinstance(out.x, pathlib.PureWindowsPath)
+    assert out.x == pathlib.PureWindowsPath("C:\\a\\b")
+
+    @dataclasses.dataclass
+    class P:
+        x: pathlib.PurePosixPath
+
+    out2 = tyro.cli(P, args=["--x", "/a/b"])
+    assert isinstance(out2.x, pathlib.PurePosixPath)
+
+    # Concrete Path is unchanged (resolves to the OS-specific concrete class).
+    @dataclasses.dataclass
+    class C:
+        x: pathlib.Path
+
+    out3 = tyro.cli(C, args=["--x", "/a/b"])
+    assert isinstance(out3.x, pathlib.Path)
+    assert out3.x == pathlib.Path("/a/b")
+
+
+def test_var_keyword_default_instance() -> None:
+    class Bag:
+        def __init__(self, **kwargs: int) -> None:
+            self.kwargs = kwargs
+
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, Bag) and other.kwargs == self.kwargs
+
+    # A provided default instance must propagate when nothing is overridden.
+    assert tyro.cli(Bag, args=[], default=Bag(x=1, y=2)).kwargs == {"x": 1, "y": 2}
+    # No default -> empty.
+    assert tyro.cli(Bag, args=[]).kwargs == {}
+    # CLI override still works, and overrides the default.
+    assert tyro.cli(Bag, args=["--kwargs", "z", "9"], default=Bag(x=1)).kwargs == {
+        "z": 9
+    }
+
+
+def test_attrs_field_alias() -> None:
+    attrs = pytest.importorskip("attrs")
+
+    @attrs.define
+    class A:
+        x: int = attrs.field(alias="renamed")
+
+    assert tyro.cli(A, args=["--x", "5"]) == A(5)
+
+    @attrs.define
+    class B:
+        _x: int = attrs.field()
+
+    assert tyro.cli(B, args=["--_x", "5"]) == B(5)
+
+    # Normal attrs fields are unaffected.
+    @attrs.define
+    class Normal:
+        name: str = "hi"
+        count: int = 0
+
+    assert tyro.cli(Normal, args=["--name", "bob", "--count", "3"]) == Normal("bob", 3)
+
+
+def test_pydantic_field_alias() -> None:
+    pydantic = pytest.importorskip("pydantic")
+    if not pydantic.VERSION.startswith("2"):
+        pytest.skip("pydantic v2 only")
+
+    class M(pydantic.BaseModel):
+        real_name: int = pydantic.Field(alias="aliased")
+
+    assert tyro.cli(M, args=["--real-name", "5"]).real_name == 5
+
+    class M2(pydantic.BaseModel):
+        x: int = pydantic.Field(validation_alias="vx")
+
+    assert tyro.cli(M2, args=["--x", "5"]).x == 5
+
+    # No alias: unaffected.
+    class M3(pydantic.BaseModel):
+        a: int = 1
+
+    assert tyro.cli(M3, args=["--a", "9"]).a == 9
+
+    # A non-string validation_alias (AliasChoices/AliasPath) must NOT be
+    # remapped to the serialization-side `.alias` (which pydantic rejects on
+    # input). With populate_by_name the field name is accepted; constructing by
+    # field name must keep working (regression guard for the alias-remap fix).
+    class M4(pydantic.BaseModel):
+        model_config = pydantic.ConfigDict(populate_by_name=True)
+        x: int = pydantic.Field(
+            alias="pa", validation_alias=pydantic.AliasChoices("c1", "c2")
+        )
+
+    assert tyro.cli(M4, args=["--x", "5"]).x == 5

--- a/tests/test_py311_generated/test_bug_repros_3_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_3_generated.py
@@ -1,0 +1,87 @@
+"""Regression tests for the tyro-backend value-consumption fixes.
+
+* ``test_fixed_nargs_does_not_swallow_flags`` -- a fixed-nargs argument (e.g. a
+  single ``str`` or a ``Tuple[str, str]``) used to silently swallow a following
+  flag-like token or the ``--`` end-of-options marker as its value (e.g.
+  ``--x --verbose`` -> ``x='--verbose'``). It must instead error, matching
+  argparse -- while still accepting a flag-like value attached with ``=``
+  (``--x=--y``) and negative numbers (``--x -5``).
+
+* ``test_variable_positional_reserves_for_later_positionals`` -- a variable
+  length positional (e.g. ``Positional[List[int]]``) greedily consumed all
+  remaining tokens, starving a later required positional. It must reserve the
+  trailing values those positionals need, matching argparse.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import List, Tuple
+
+import pytest
+
+import tyro
+from tyro.conf import Positional
+
+
+def test_fixed_nargs_does_not_swallow_flags() -> None:
+    @dataclasses.dataclass
+    class FS:
+        x: str = "def"
+        verbose: bool = False
+
+    # A space-separated flag must not be consumed as the value.
+    with pytest.raises(SystemExit):
+        tyro.cli(FS, args=["--x", "--verbose"])
+    with pytest.raises(SystemExit):
+        tyro.cli(FS, args=["--x", "--y"])  # unknown but flag-like
+
+    # The `--` end-of-options marker must not be consumed as a value.
+    @dataclasses.dataclass
+    class T2:
+        pair: Tuple[str, str] = ("a", "b")
+
+    with pytest.raises(SystemExit):
+        tyro.cli(T2, args=["--pair", "--", "x"])
+
+    # A flag-like value attached with `=` is still accepted verbatim.
+    assert tyro.cli(FS, args=["--x=--y"]).x == "--y"
+    # Negative numbers are still values.
+    assert tyro.cli(FS, args=["--x", "-5"]).x == "-5"
+    # Normal usage unaffected; a flag after a satisfied value still parses.
+    assert tyro.cli(FS, args=["--x", "hi", "--verbose"]) == FS(x="hi", verbose=True)
+    assert tyro.cli(T2, args=["--pair", "x", "y"]).pair == ("x", "y")
+
+
+def test_variable_positional_reserves_for_later_positionals() -> None:
+    @dataclasses.dataclass
+    class A:
+        xs: Positional[List[int]]
+        y: Positional[int]
+
+    assert tyro.cli(A, args=["1", "2", "3", "4"]) == A(xs=[1, 2, 3], y=4)
+    assert tyro.cli(A, args=["1"]) == A(xs=[], y=1)
+
+    # Two trailing required positionals.
+    @dataclasses.dataclass
+    class B:
+        xs: Positional[List[int]]
+        y: Positional[int]
+        z: Positional[int]
+
+    assert tyro.cli(B, args=["1", "2", "3", "4", "5"]) == B(xs=[1, 2, 3], y=4, z=5)
+
+    # A leading fixed positional followed by a greedy one is unaffected.
+    @dataclasses.dataclass
+    class C:
+        a: Positional[int]
+        xs: Positional[List[str]]
+
+    assert tyro.cli(C, args=["1", "a", "b", "c"]) == C(a=1, xs=["a", "b", "c"])
+
+    # A lone greedy positional still consumes everything.
+    @dataclasses.dataclass
+    class D:
+        xs: Positional[List[int]]
+
+    assert tyro.cli(D, args=["1", "2", "3"]) == D(xs=[1, 2, 3])

--- a/tests/test_py311_generated/test_bug_repros_4_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_4_generated.py
@@ -1,0 +1,149 @@
+"""Regression tests for three fixes layered on top of the value-consumption and
+subcommand-alias changes.
+
+* ``test_negative_special_floats_are_values`` -- the fixed/variable-nargs
+  flag-blocking heuristic treated ``-inf`` / ``-nan`` / ``-infinity`` as flags
+  (because they start with a dash + alpha char), so a ``float`` field could not
+  receive them even though ``float()`` accepts them. They must be consumed as
+  values on the ``tyro`` backend, while genuinely flag-like tokens (``--verbose``)
+  are still rejected.
+
+* ``test_dash_prefixed_literal_choices_are_values`` -- a value that is an
+  explicit ``choices`` entry (e.g. a dash-prefixed ``Literal`` like ``-b``) was
+  rejected by the same heuristic before choice validation. A registered choice is
+  unambiguous and must be consumed as a value on the ``tyro`` backend.
+
+* ``test_subcommand_alias_with_swapped_delimiter_form`` -- an alias whose
+  delimiter-swapped form (``_`` <-> ``-``) matched a canonical name was wrongly
+  rejected at construction (e.g. ``run_server`` for a ``run-server`` subcommand --
+  its own canonical). Such aliases are reachable by exact match and must be
+  allowed; only an alias that *exactly* equals another canonical is rejected.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from typing import Annotated, Any, List, Literal
+
+import pytest
+
+import tyro
+
+
+def test_negative_special_floats_are_values(backend: str) -> None:
+    @dataclasses.dataclass
+    class A:
+        x: float = 0.0
+
+    # Ordinary negative numbers are values on both backends.
+    assert tyro.cli(A, args=["--x", "-5"]).x == -5.0
+    assert tyro.cli(A, args=["--x", "-2.5"]).x == -2.5
+
+    if backend == "tyro":
+        # Special float spellings are valid values too.
+        assert math.isinf(tyro.cli(A, args=["--x", "-inf"]).x)
+        assert tyro.cli(A, args=["--x", "-inf"]).x < 0
+        assert math.isnan(tyro.cli(A, args=["--x", "-nan"]).x)
+        assert math.isinf(tyro.cli(A, args=["--x", "-infinity"]).x)
+        assert math.isinf(tyro.cli(A, args=["--x", "-Infinity"]).x)
+
+        # They are also accepted mid-stream by a variable-length argument.
+        @dataclasses.dataclass
+        class B:
+            xs: List[float] = dataclasses.field(default_factory=list)
+
+        out = tyro.cli(B, args=["--xs", "1.0", "-inf"]).xs
+        assert out[0] == 1.0 and math.isinf(out[1])
+    else:
+        # The argparse backend's negative-number matcher doesn't recognize
+        # inf/nan; it still rejects them (unchanged, documented limitation).
+        with pytest.raises(SystemExit):
+            tyro.cli(A, args=["--x", "-inf"])
+
+    # A genuinely flag-like value is still NOT swallowed (regression guard).
+    @dataclasses.dataclass
+    class C:
+        x: float = 0.0
+        verbose: bool = False
+
+    with pytest.raises(SystemExit):
+        tyro.cli(C, args=["--x", "--verbose"])
+
+
+def test_dash_prefixed_literal_choices_are_values(backend: str) -> None:
+    @dataclasses.dataclass
+    class A:
+        x: Literal["-a", "-b"] = "-a"
+
+    if backend == "tyro":
+        assert tyro.cli(A, args=["--x", "-b"]).x == "-b"
+        assert tyro.cli(A, args=["--x", "-a"]).x == "-a"
+
+        # In a variable-length argument too.
+        @dataclasses.dataclass
+        class B:
+            xs: List[Literal["-a", "-b"]] = dataclasses.field(default_factory=list)
+
+        assert tyro.cli(B, args=["--xs", "-a", "-b"]).xs == ["-a", "-b"]
+    else:
+        # The argparse backend cannot accept a dash-prefixed choice value.
+        with pytest.raises(SystemExit):
+            tyro.cli(A, args=["--x", "-b"])
+
+    # A flag-like value that is NOT a registered choice is still rejected.
+    with pytest.raises(SystemExit):
+        tyro.cli(A, args=["--x", "-c"])
+
+
+def test_subcommand_alias_with_swapped_delimiter_form() -> None:
+    # (a) A subcommand offering the underscore form of its OWN hyphenated
+    # canonical name. `run_server` swaps to `run-server` (its own canonical) but
+    # must still be allowed -- both spellings select RunServer.
+    @dataclasses.dataclass
+    class RunServer:
+        port: int = 80
+
+    @dataclasses.dataclass
+    class Stop:
+        v: int = 0
+
+    M: Any = Annotated[RunServer, tyro.conf.subcommand(aliases=["run_server"])] | Stop
+    assert tyro.cli(M, args=["run-server", "--port", "9"]) == RunServer(port=9)
+    assert tyro.cli(M, args=["run_server", "--port", "9"]) == RunServer(port=9)
+
+    # (b) Two subcommands: canonical `a-b` and another whose alias `a_b` swaps to
+    # `a-b`. Both remain distinctly reachable by their exact spellings.
+    @dataclasses.dataclass
+    class AB:
+        v: int = 1
+
+    @dataclasses.dataclass
+    class Other:
+        v: int = 2
+
+    M2: Any = (
+        Annotated[AB, tyro.conf.subcommand(name="a-b")]
+        | Annotated[Other, tyro.conf.subcommand(name="x", aliases=["a_b"])]
+    )
+    assert tyro.cli(M2, args=["a-b"]) == AB(v=1)
+    assert tyro.cli(M2, args=["a_b"]) == Other(v=2)
+
+
+def test_subcommand_alias_exact_collision_still_rejected() -> None:
+    # An alias that EXACTLY equals another subcommand's canonical name is a
+    # genuine ambiguity and must still be rejected.
+    @dataclasses.dataclass
+    class P:
+        v: int = 1
+
+    @dataclasses.dataclass
+    class Q:
+        v: int = 2
+
+    M: Any = (
+        Annotated[P, tyro.conf.subcommand(name="foo")]
+        | Annotated[Q, tyro.conf.subcommand(name="bar", aliases=["foo"])]
+    )
+    with pytest.raises(AssertionError):
+        tyro.cli(M, args=["foo"])

--- a/tests/test_py311_generated/test_bug_repros_4_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_4_generated.py
@@ -20,6 +20,11 @@ subcommand-alias changes.
   allowed; only an alias that *exactly* equals another canonical is rejected.
 """
 
+# pyright: reportOperatorIssue=false
+# Suppression is for the auto-generated py311 copy of this file, where the
+# Union-to-pipe rewrite produces `Annotated[...] | Annotated[...]` lines that
+# pyright rejects even though they work at runtime.
+
 from __future__ import annotations
 
 import dataclasses

--- a/tests/test_py311_generated/test_bug_repros_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_generated.py
@@ -91,17 +91,18 @@ def test_subcommand_alias_delimiter_collision() -> None:
     class B:
         y: int = 2
 
-    # Typing `a_b` resolves to a canonical named `a-b` (under the default `-`
-    # delimiter, an underscore token also tries its hyphenated form), so using
-    # `a_b` as an alias for a *different* subcommand must be rejected rather
-    # than silently resolving to the wrong subcommand.
+    # Canonical `a-b` plus an `a_b` alias on a *different* subcommand: the alias
+    # is reachable by exact match (typing `a_b` matches it before any delimiter
+    # swap is attempted), so both spellings stay distinctly reachable. This must
+    # be allowed rather than rejected -- the swapped form is not a collision.
     T = cast(
         Any,
         Annotated[A, tyro.conf.subcommand("a-b")]
         | Annotated[B, tyro.conf.subcommand("other", aliases=("a_b",))],
     )
-    with pytest.raises(AssertionError):
-        tyro.cli(T, args=["a-b"])
+    assert tyro.cli(T, args=["a-b"]) == A(x=1)
+    assert tyro.cli(T, args=["a_b"]) == B(y=2)
+    assert tyro.cli(T, args=["other"]) == B(y=2)
 
     # The reverse is NOT a collision: typing `a-b` does not resolve to a
     # canonical named `a_b`, so an `a-b` alias on a different subcommand is

--- a/tests/test_py311_generated/test_bug_repros_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_generated.py
@@ -14,16 +14,22 @@ correct behavior.
   immediately after the value-taking flag is a separator (``-abn=foo`` ->
   value ``foo``).
 
-* ``test_subcommand_alias_delimiter_collision`` -- subcommand alias collision
-  detection compared raw strings, ignoring tyro's ``-``/``_`` equivalence, so
-  an alias that was the delimiter-swapped form of another subcommand's
-  canonical name silently resolved to the wrong subcommand.
+* ``test_subcommand_alias_delimiter_collision`` -- an alias whose delimiter-
+  swapped form (``-``/``_``) matched a canonical name was wrongly rejected at
+  construction, even though a registered alias is reachable by exact match
+  (including the underscore form of a subcommand's own hyphenated canonical).
+  Only an alias that *exactly* equals another canonical is a real collision.
 
 * ``test_empty_tuple_nested_in_fixed_tuple`` -- an empty tuple ``Tuple[()]``
   nested inside another fixed tuple raised an internal ``AssertionError`` (or
   was wrongly rejected), because the backtracking parser could not handle a
   spec that consumes zero arguments.
 """
+
+# pyright: reportOperatorIssue=false
+# Suppression is for the auto-generated py311 copy of this file, where the
+# Union-to-pipe rewrite produces `Annotated[...] | Annotated[...]` lines that
+# pyright rejects even though they work at runtime.
 
 from __future__ import annotations
 

--- a/tests/test_py311_generated/test_bug_repros_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_generated.py
@@ -1,0 +1,160 @@
+"""Regression tests for bugs found via manual exploration.
+
+Each test below fails on the unfixed code and documents the expected,
+correct behavior.
+
+* ``test_optional_fixed_length_tuple_accepts_none`` -- ``Optional`` of a
+  fixed-length tuple (e.g. ``Optional[Tuple[int, int]]``) could not accept
+  ``None`` on the CLI, because the union's computed ``nargs`` ignored the
+  single-token ``NoneType`` option and demanded the tuple's exact count.
+
+* ``test_clustered_value_short_with_equals`` -- POSIX-style short-flag
+  clustering mishandled ``=`` inside a value-taking short's value. ``-na=foo``
+  must parse to ``-n`` with value ``a=foo`` (matching argparse), and an ``=``
+  immediately after the value-taking flag is a separator (``-abn=foo`` ->
+  value ``foo``).
+
+* ``test_subcommand_alias_delimiter_collision`` -- subcommand alias collision
+  detection compared raw strings, ignoring tyro's ``-``/``_`` equivalence, so
+  an alias that was the delimiter-swapped form of another subcommand's
+  canonical name silently resolved to the wrong subcommand.
+
+* ``test_empty_tuple_nested_in_fixed_tuple`` -- an empty tuple ``Tuple[()]``
+  nested inside another fixed tuple raised an internal ``AssertionError`` (or
+  was wrongly rejected), because the backtracking parser could not handle a
+  spec that consumes zero arguments.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Annotated, Any, List, Optional, Tuple, cast
+
+import pytest
+
+import tyro
+from tyro.conf import arg
+
+
+def test_optional_fixed_length_tuple_accepts_none() -> None:
+    # Direct form.
+    assert tyro.cli(Optional[Tuple[int, int]], args=["None"]) is None
+    assert tyro.cli(Optional[Tuple[int, int]], args=["1", "2"]) == (1, 2)
+
+    # Dataclass field form.
+    @dataclasses.dataclass
+    class A:
+        x: Optional[Tuple[int, int]] = None
+
+    assert tyro.cli(A, args=[]) == A(x=None)
+    assert tyro.cli(A, args=["--x", "None"]) == A(x=None)
+    assert tyro.cli(A, args=["--x", "1", "2"]) == A(x=(1, 2))
+
+    # Three-element fixed tuple too.
+    assert tyro.cli(Optional[Tuple[int, int, int]], args=["None"]) is None
+    assert tyro.cli(Optional[Tuple[int, int, int]], args=["1", "2", "3"]) == (1, 2, 3)
+
+
+def test_clustered_value_short_with_equals() -> None:
+    @dataclasses.dataclass
+    class C:
+        name: Annotated[str, arg(aliases=["-n"])] = "default"
+
+    # `=` not immediately after the flag char -> part of the value.
+    assert tyro.cli(C, args=["-na=foo"]).name == "a=foo"
+    # `=` immediately after the (registered) short flag -> separator.
+    assert tyro.cli(C, args=["-n=foo"]).name == "foo"
+    # Glued, no `=`.
+    assert tyro.cli(C, args=["-nfoo"]).name == "foo"
+    # Multiple `=` after a cluster char.
+    assert tyro.cli(C, args=["-nx=y"]).name == "x=y"
+
+    @dataclasses.dataclass
+    class D:
+        a: Annotated[bool, arg(aliases=["-a"])] = False
+        b: Annotated[bool, arg(aliases=["-b"])] = False
+        n: Annotated[str, arg(aliases=["-n"])] = "default"
+
+    # `=` immediately after the value-taking short at the end of a cluster is
+    # a separator.
+    assert tyro.cli(D, args=["-abn=foo"]) == D(a=True, b=True, n="foo")
+    # `=` not immediately after the value-taking short -> part of the value.
+    assert tyro.cli(D, args=["-an=b=c"]) == D(a=True, b=False, n="b=c")
+
+
+def test_subcommand_alias_delimiter_collision() -> None:
+    @dataclasses.dataclass
+    class A:
+        x: int = 1
+
+    @dataclasses.dataclass
+    class B:
+        y: int = 2
+
+    # Typing `a_b` resolves to a canonical named `a-b` (under the default `-`
+    # delimiter, an underscore token also tries its hyphenated form), so using
+    # `a_b` as an alias for a *different* subcommand must be rejected rather
+    # than silently resolving to the wrong subcommand.
+    T = cast(
+        Any,
+        Annotated[A, tyro.conf.subcommand("a-b")]
+        | Annotated[B, tyro.conf.subcommand("other", aliases=("a_b",))],
+    )
+    with pytest.raises(AssertionError):
+        tyro.cli(T, args=["a-b"])
+
+    # The reverse is NOT a collision: typing `a-b` does not resolve to a
+    # canonical named `a_b`, so an `a-b` alias on a different subcommand is
+    # legitimate and must be allowed.
+    T2 = cast(
+        Any,
+        Annotated[A, tyro.conf.subcommand("a_b")]
+        | Annotated[B, tyro.conf.subcommand("other", aliases=("a-b",))],
+    )
+    assert tyro.cli(T2, args=["a_b"]) == A(x=1)
+    assert tyro.cli(T2, args=["a-b"]) == B(y=2)
+    assert tyro.cli(T2, args=["other"]) == B(y=2)
+
+    # Exact same spelling on two subcommands is still a collision.
+    T3 = cast(
+        Any,
+        Annotated[A, tyro.conf.subcommand("aa")]
+        | Annotated[B, tyro.conf.subcommand("other", aliases=("aa",))],
+    )
+    with pytest.raises(AssertionError):
+        tyro.cli(T3, args=["aa"])
+
+
+def test_empty_tuple_nested_in_fixed_tuple() -> None:
+    # `Tuple[()]` nested inside another fixed tuple previously raised an
+    # internal AssertionError ("At least one spec is required") or was wrongly
+    # rejected, because the backtracking parser couldn't handle a spec that
+    # consumes zero arguments.
+    assert tyro.cli(Tuple[Tuple[()], int], args=["5"]) == ((), 5)
+    assert tyro.cli(Tuple[int, Tuple[()]], args=["5"]) == (5, ())
+    assert tyro.cli(Tuple[Tuple[()], int, Tuple[()]], args=["5"]) == ((), 5, ())
+
+    # A genuinely-insufficient fixed tuple still errors (no over-eager
+    # zero-width matching).
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[int, str], args=["5"])
+
+
+def test_repeating_zero_width_spec_terminates() -> None:
+    # A repeated zero-width spec (e.g. `List[Tuple[()]]`) previously looped
+    # forever in the backtracking parser when given non-empty input, because a
+    # zero-width match advanced the spec index without consuming an argument.
+    # It must instead reject the unconsumable input, and accept empty input.
+    assert tyro.cli(List[Tuple[()]], args=[]) == []
+    assert tyro.cli(Tuple[Tuple[()], ...], args=[]) == ()
+    with pytest.raises(SystemExit):
+        tyro.cli(List[Tuple[()]], args=["x"])
+    with pytest.raises(SystemExit):
+        tyro.cli(Tuple[Tuple[()], ...], args=["x"])
+
+    # Normal repeating parses are unaffected.
+    assert tyro.cli(List[int], args=["1", "2", "3"]) == [1, 2, 3]
+    assert tyro.cli(List[Tuple[int, int]], args=["1", "2", "3", "4"]) == [
+        (1, 2),
+        (3, 4),
+    ]

--- a/tests/test_py311_generated/test_bug_repros_generated.py
+++ b/tests/test_py311_generated/test_bug_repros_generated.py
@@ -28,7 +28,7 @@ correct behavior.
 from __future__ import annotations
 
 import dataclasses
-from typing import Annotated, Any, List, Optional, Tuple, cast
+from typing import Annotated, Any, Dict, List, Optional, Tuple, cast
 
 import pytest
 
@@ -158,3 +158,21 @@ def test_repeating_zero_width_spec_terminates() -> None:
         (1, 2),
         (3, 4),
     ]
+
+
+def test_repeated_multispec_trailing_zero_width_is_a_documented_limitation() -> None:
+    # A repeating MULTI-spec container whose trailing spec is zero-width (e.g.
+    # `Dict[str, Tuple[()]]`, repeating key + zero-width value) is rejected: see
+    # the documented limitation in `_backtracking.py`. Allowing it would bypass
+    # the zero-progress cycle pruning that is load-bearing for disambiguating
+    # unions. This test pins that behavior so it isn't changed unintentionally.
+    assert tyro.cli(Dict[str, Tuple[()]], args=[]) == {}  # empty is fine
+    with pytest.raises(SystemExit):
+        tyro.cli(Dict[str, Tuple[()]], args=["a"])
+
+    # The load-bearing property the limitation protects: a mapping whose value
+    # is a union that *includes* a zero-width option must still pick the wider
+    # parse rather than the degenerate empty one.
+    assert tyro.cli(Dict[str, Tuple[()] | Tuple[int, int]], args=["k", "1", "2"]) == {
+        "k": (1, 2)
+    }

--- a/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
+++ b/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
@@ -1,0 +1,194 @@
+"""Tests for chained PEP 696 TypeVar defaults.
+
+When one TypeVar's default is another TypeVar (for example
+``V = TypeVar("V", default=K)``), tyro should recursively resolve the default
+through the active type parameter bindings rather than returning the raw inner
+TypeVar (or falling back to the inner TypeVar's own default).
+"""
+
+import dataclasses
+from typing import Generic, List, NamedTuple
+
+import pydantic
+import pytest
+from typing_extensions import TypeVar
+
+import tyro
+
+
+def test_chained_default_explicit_binding() -> None:
+    """Variant A: ``Entry[int]`` has ``__args__ == (int, ~K)``; ``V`` defaults to
+    ``K``, which is bound to ``int``, so ``val`` should be parsed as ``int``."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Entry[int], args=["--key", "1", "--val", "2"])
+    assert parsed == Entry(1, 2)
+    assert isinstance(parsed.key, int)
+    assert isinstance(parsed.val, int)
+
+
+def test_chained_default_all_defaults() -> None:
+    """Variant B: both TypeVars fall back to defaults. ``K`` defaults to ``int``
+    and ``V`` defaults to ``K``, so both should resolve to ``int``."""
+    K = TypeVar("K", default=int)
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Entry, args=["--key", "1", "--val", "2"])
+    assert parsed == Entry(1, 2)
+    assert isinstance(parsed.key, int)
+    assert isinstance(parsed.val, int)
+
+
+def test_single_level_default_still_works() -> None:
+    """A plain (non-chained) PEP 696 default should still resolve."""
+    K = TypeVar("K", default=int)
+
+    @dataclasses.dataclass
+    class Single(Generic[K]):
+        x: K
+
+    assert tyro.cli(Single, args=["--x", "5"]) == Single(5)
+    assert tyro.cli(Single[str], args=["--x", "5"]) == Single("5")
+
+
+def test_multi_level_chain() -> None:
+    """W default=V default=K. A three-deep chain should fully resolve."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+    W = TypeVar("W", default=V)
+
+    @dataclasses.dataclass
+    class Triple(Generic[K, V, W]):
+        a: K
+        b: V
+        c: W
+
+    parsed = tyro.cli(Triple[int], args=["--a", "1", "--b", "2", "--c", "3"])
+    assert parsed == Triple(1, 2, 3)
+    assert all(isinstance(v, int) for v in (parsed.a, parsed.b, parsed.c))
+
+    # All defaults: everything chains back to `str`.
+    parsed = tyro.cli(Triple, args=["--a", "x", "--b", "y", "--c", "z"])
+    assert parsed == Triple("x", "y", "z")
+
+
+def test_chained_default_is_container() -> None:
+    """A default that is a container of another TypeVar, e.g. ``default=List[K]``."""
+    K = TypeVar("K", default=int)
+    V = TypeVar("V", default=List[K])
+
+    @dataclasses.dataclass
+    class WithList(Generic[K, V]):
+        key: K
+        vals: V
+
+    parsed = tyro.cli(WithList[float], args=["--key", "1.5", "--vals", "2.0", "3.0"])
+    assert parsed == WithList(1.5, [2.0, 3.0])
+    assert isinstance(parsed.key, float)
+    assert parsed.vals == [2.0, 3.0]
+
+    # All defaults: K -> int, V -> List[int].
+    parsed = tyro.cli(WithList, args=["--key", "1", "--vals", "2", "3"])
+    assert parsed == WithList(1, [2, 3])
+
+
+def test_explicit_override_of_chained_param() -> None:
+    """When the second parameter is given explicitly, the chain is not used."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Entry[int, bool], args=["--key", "1", "--val", "True"])
+    assert parsed == Entry(1, True)
+    assert isinstance(parsed.key, int)
+    assert isinstance(parsed.val, bool)
+
+
+def test_bound_typevar_not_broken() -> None:
+    """Explicitly-parameterized bound TypeVars should still work."""
+    B = TypeVar("B", bound=int)
+
+    @dataclasses.dataclass
+    class Bounded(Generic[B]):
+        x: B
+
+    assert tyro.cli(Bounded[int], args=["--x", "5"]) == Bounded(5)
+
+
+def test_constrained_typevar_not_broken() -> None:
+    """Explicitly-parameterized constrained TypeVars should still work."""
+    C = TypeVar("C", int, str)
+
+    @dataclasses.dataclass
+    class Constrained(Generic[C]):
+        x: C
+
+    assert tyro.cli(Constrained[int], args=["--x", "5"]) == Constrained(5)
+
+
+def test_chained_default_namedtuple() -> None:
+    """Generic NamedTuple with a chained PEP 696 default."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    class Pair(NamedTuple, Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Pair[int], args=["--key", "1", "--val", "2"])
+    assert parsed == Pair(1, 2)
+    assert isinstance(parsed.val, int)
+
+
+def test_chained_default_pydantic() -> None:
+    """Generic pydantic model with a chained PEP 696 default."""
+    K = TypeVar("K", default=str)
+    V = TypeVar("V", default=K)
+
+    class Model(pydantic.BaseModel, Generic[K, V]):
+        key: K
+        val: V
+
+    parsed = tyro.cli(Model[int], args=["--key", "1", "--val", "2"])
+    assert parsed.key == 1
+    assert parsed.val == 2
+    assert isinstance(parsed.val, int)
+
+
+def test_chained_default_no_infinite_loop() -> None:
+    """A self-referential-ish default must not cause an infinite loop.
+
+    ``V`` defaults to ``K`` and ``K`` defaults to ``V`` would be a true cycle,
+    but Python forbids defining that. We instead exercise the guard via a chain
+    where the terminal TypeVar has no resolution, which should terminate and
+    fall back to ``Any`` (with a warning) rather than recursing forever.
+    """
+    K = TypeVar("K")  # No default, bound, or constraints.
+    V = TypeVar("V", default=K)
+
+    @dataclasses.dataclass
+    class Entry(Generic[K, V]):
+        key: K
+        val: V
+
+    # Should terminate: the chain bottoms out at an unresolvable TypeVar, which
+    # resolves to `Any`. `Any` is not parsable, so we expect a clean SystemExit
+    # rather than an infinite loop or hang.
+    with pytest.warns(UserWarning):
+        with pytest.raises(SystemExit):
+            tyro.cli(Entry, args=["--key", "a", "--val", "b"])

--- a/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
+++ b/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
@@ -7,6 +7,7 @@ TypeVar (or falling back to the inner TypeVar's own default).
 """
 
 import dataclasses
+import sys
 from typing import Generic, List, NamedTuple
 
 import pydantic
@@ -15,7 +16,21 @@ from typing_extensions import TypeVar
 
 import tyro
 
+# Explicitly parameterizing a generic that has a chained PEP 696 default with
+# fewer args than parameters (e.g. `Entry[int]` where `V = TypeVar("V",
+# default=K)`) requires the default slot to be filled into `__args__`
+# (`(int, ~K)`). That only happens on Python 3.11+; on 3.8-3.10 `__args__` is
+# just `(int,)` and the type cannot be resolved (this is a pre-existing Python
+# limitation -- the base library crashes identically there). Tests that don't
+# rely on this fill (bare defaults, single-level, overrides, sibling-binding)
+# run on all versions.
+needs_chained_default_fill = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="PEP 696 chained-default fill in Generic[...] subscription requires Python 3.11+",
+)
 
+
+@needs_chained_default_fill
 def test_chained_default_explicit_binding() -> None:
     """Variant A: ``Entry[int]`` has ``__args__ == (int, ~K)``; ``V`` defaults to
     ``K``, which is bound to ``int``, so ``val`` should be parsed as ``int``."""
@@ -62,6 +77,7 @@ def test_single_level_default_still_works() -> None:
     assert tyro.cli(Single[str], args=["--x", "5"]) == Single("5")
 
 
+@needs_chained_default_fill
 def test_multi_level_chain() -> None:
     """W default=V default=K. A three-deep chain should fully resolve."""
     K = TypeVar("K", default=str)
@@ -83,6 +99,7 @@ def test_multi_level_chain() -> None:
     assert parsed == Triple("x", "y", "z")
 
 
+@needs_chained_default_fill
 def test_chained_default_is_container() -> None:
     """A default that is a container of another TypeVar, e.g. ``default=List[K]``."""
     K = TypeVar("K", default=int)
@@ -141,6 +158,7 @@ def test_constrained_typevar_not_broken() -> None:
     assert tyro.cli(Constrained[int], args=["--x", "5"]) == Constrained(5)
 
 
+@needs_chained_default_fill
 def test_chained_default_namedtuple() -> None:
     """Generic NamedTuple with a chained PEP 696 default."""
     K = TypeVar("K", default=str)
@@ -155,6 +173,7 @@ def test_chained_default_namedtuple() -> None:
     assert isinstance(parsed.val, int)
 
 
+@needs_chained_default_fill
 def test_chained_default_pydantic() -> None:
     """Generic pydantic model with a chained PEP 696 default."""
     K = TypeVar("K", default=str)

--- a/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
+++ b/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
@@ -8,7 +8,7 @@ TypeVar (or falling back to the inner TypeVar's own default).
 
 import dataclasses
 import sys
-from typing import Generic, List, NamedTuple
+from typing import Any, Generic, List, NamedTuple, cast
 
 import pydantic
 import pytest
@@ -268,3 +268,54 @@ def test_sibling_binding_three_level_nesting() -> None:
     assert out.m.leaf.v == ["p", "q"]
     assert out.m.x == 3
     assert out.b == "w"
+
+
+def test_free_typevar_subscription_falls_back_to_defaults() -> None:
+    """Subscripting a generic with free defaulted TypeVars (its own, or
+    permuted) must apply the PEP 696 defaults rather than failing to resolve.
+
+    Regression test: the sibling-binding context used for chained defaults
+    introduced identity bindings (``V -> V``) and two-cycles (``K -> V -> K``)
+    that previously short-circuited resolution to a raw TypeVar, making these
+    annotations error at parser construction."""
+    K = TypeVar("K", default=int)
+    V = TypeVar("V", default=str)
+
+    @dataclasses.dataclass
+    class Pair(Generic[K, V]):
+        k: K
+        v: V
+
+    @dataclasses.dataclass
+    class Box(Generic[K]):
+        items: List[K]
+
+    # `Any` aliases: type checkers reject free TypeVars in value-level
+    # subscripts, but they are valid at runtime and the case under test.
+    PairT: Any = Pair
+    BoxT: Any = Box
+
+    # Identity bindings: each free TypeVar falls back to its own default.
+    assert tyro.cli(PairT[float, V], args=["--k", "3.5", "--v", "hello"]) == Pair(
+        3.5, "hello"
+    )
+    assert tyro.cli(PairT[K, V], args=["--k", "3", "--v", "hello"]) == Pair(3, "hello")
+    assert tyro.cli(BoxT[K], args=["--items", "1", "2"]) == Box(items=[1, 2])
+
+    # Permuted two-cycle: Pair's K parameter is bound to the free V (default
+    # str) and its V parameter to the free K (default int).
+    assert tyro.cli(PairT[V, K], args=["--k", "hello", "--v", "3"]) == Pair("hello", 3)
+
+
+def test_self_referential_typevar_default_terminates() -> None:
+    """A TypeVar whose ``__default__`` is itself (only constructible by
+    mutation) must terminate and resolve to the TypeVar unchanged."""
+    from tyro._resolver import TypeParamResolver
+
+    make_typevar = cast(Any, TypeVar)
+    tv = make_typevar("SelfDefaultT")
+    try:
+        tv.__default__ = tv
+    except (AttributeError, TypeError):  # pragma: no cover
+        pytest.skip("TypeVar.__default__ is not assignable on this Python")
+    assert TypeParamResolver.resolve_params_and_aliases(tv) is tv

--- a/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
+++ b/tests/test_py311_generated/test_chained_typevar_defaults_generated.py
@@ -192,3 +192,60 @@ def test_chained_default_no_infinite_loop() -> None:
     with pytest.warns(UserWarning):
         with pytest.raises(SystemExit):
             tyro.cli(Entry, args=["--key", "a", "--val", "b"])
+
+
+def test_sibling_binding_does_not_shadow_enclosing_typevar() -> None:
+    """Regression: the sibling-binding context pushed for a parameterized
+    generic must not shadow a binding from an enclosing generic when a TypeVar
+    *object* is reused across scopes.
+
+    Here ``T`` is shared between ``OuterNest`` and ``Pair``. While resolving the
+    field ``Pair[int, List[T]]``, the inner ``List[T]`` must keep the enclosing
+    binding ``T -> str`` (from ``OuterNest[str]``), not be rebound to ``int`` by
+    ``Pair``'s concrete first argument.
+    """
+    T = TypeVar("T")
+    U = TypeVar("U")
+
+    @dataclasses.dataclass
+    class Pair(Generic[T, U]):
+        first: T
+        second: U
+
+    @dataclasses.dataclass
+    class OuterNest(Generic[T]):
+        p: Pair[int, List[T]]
+        bare: T
+
+    out = tyro.cli(
+        OuterNest[str],
+        args=["--p.first", "1", "--p.second", "a", "b", "--bare", "z"],
+    )
+    assert out.p.first == 1
+    assert out.p.second == ["a", "b"]  # List[str], not List[int]
+    assert out.bare == "z"
+
+
+def test_sibling_binding_three_level_nesting() -> None:
+    """As above, but the shadowing binding is introduced by a middle generic."""
+    T = TypeVar("T")
+    U = TypeVar("U")
+
+    @dataclasses.dataclass
+    class Leaf(Generic[U]):
+        v: U
+
+    @dataclasses.dataclass
+    class Mid(Generic[T, U]):
+        leaf: Leaf[U]
+        x: T
+
+    @dataclasses.dataclass
+    class Top(Generic[T]):
+        m: Mid[int, List[T]]
+        b: T
+
+    out = tyro.cli(Top[str], args=["--m.leaf.v", "p", "q", "--m.x", "3", "--b", "w"])
+    assert out.m.leaf.v == ["p", "q"]
+    assert out.m.x == 3
+    assert out.b == "w"

--- a/tests/test_py311_generated/test_completion_bash_generated.py
+++ b/tests/test_py311_generated/test_completion_bash_generated.py
@@ -247,6 +247,38 @@ def test_bash_functional_completion_simple(backend: str) -> None:
     )
 
 
+def test_bash_completion_with_quote_in_default(backend: str) -> None:
+    """A spec string with an odd number of quotes (e.g. a default like "don't")
+    must not break the generated bash script.
+
+    The spec is interpolated into a heredoc; previously the heredoc sat inside a
+    `$(...)` command substitution, so bash's quote-balance scan over the
+    substitution body produced a syntax error for any odd-quote spec.
+    """
+    if backend != "tyro":
+        pytest.skip("Testing tyro-specific completion behavior")
+
+    @dataclasses.dataclass
+    class Config:
+        msg: str = "don't"  # odd number of single quotes
+        other: str = 'say "hi"'  # double quotes too
+        mode: Literal["fast", "slow"] = "fast"
+
+    target = io.StringIO()
+    with pytest.raises(SystemExit), contextlib.redirect_stdout(target):
+        tyro.cli(Config, args=["--tyro-print-completion", "bash"])
+
+    completion_script = target.getvalue()
+    # The spec must still be human-readable in the script (not opaque-encoded).
+    assert "--msg" in completion_script
+
+    # Sourcing + running the completion function would raise if the script were
+    # malformed; assert it produces the expected root completions.
+    tester = BashCompletionTester(completion_script)
+    completions = tester.get_completions(["prog", ""], 1)
+    assert {"--msg", "--other", "--mode"}.issubset(set(completions))
+
+
 def test_bash_functional_completion_with_subcommands(backend: str) -> None:
     """Test bash completion with subcommands."""
     if backend != "tyro":

--- a/tests/test_py311_generated/test_helptext_generated.py
+++ b/tests/test_py311_generated/test_helptext_generated.py
@@ -1668,3 +1668,22 @@ def test_comment_not_leaking_through_non_field_lines() -> None:
 
     helptext = get_helptext_with_checks(Config)
     assert "This comment is for the internal variable" not in helptext
+
+
+def test_callable_description_without_pydantic_imported() -> None:
+    """Description extraction must work when pydantic has never been imported
+    (the pydantic-specific `__init__` docstring check is skipped)."""
+    from unittest import mock
+
+    from tyro import _docstrings
+
+    @dataclasses.dataclass
+    class FreshForNoPydantic:
+        """Docstring for FreshForNoPydantic."""
+
+        x: int = 0
+
+    with mock.patch.dict(sys.modules):
+        sys.modules.pop("pydantic", None)
+        description = _docstrings.get_callable_description(FreshForNoPydantic)
+    assert "Docstring for FreshForNoPydantic." in description

--- a/tests/test_py311_generated/test_pep695_generics_min_py312_generated.py
+++ b/tests/test_py311_generated/test_pep695_generics_min_py312_generated.py
@@ -1,0 +1,173 @@
+"""Regression tests for GitHub issues #474 and #475.
+
+PEP 695 type parameters (``class Foo[T]: ...``, Python 3.12+) live in
+``__type_params__``, not in module globals. Combined with stringized
+annotations (``from __future__ import annotations`` / PEP 563), a field whose
+type references such a parameter used to raise an obscure
+``NameError: name 'T' is not defined`` from ``get_type_hints`` (#475). This also
+surfaced through ``dataclasses.InitVar`` members (#474), which tyro should
+recognize as ordinary constructor arguments.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import tyro
+
+
+@dataclasses.dataclass
+class Container[T]:
+    items: list[T]
+
+
+@dataclasses.dataclass
+class Sequencer[Data]:
+    items: list[Data]
+
+
+type Seq = Sequencer[int]
+
+
+@dataclasses.dataclass
+class Bare[T]:
+    x: T
+
+
+@dataclasses.dataclass
+class Pair[K, V]:
+    k: K
+    v: V
+
+
+@dataclasses.dataclass
+class Compound[T]:
+    mapping: dict[str, T]
+    opt: T | None = None
+    rest: tuple[T, ...] = ()
+
+
+@dataclasses.dataclass
+class Base[T]:
+    base_field: T
+
+
+@dataclasses.dataclass
+class Child[T](Base[T]):
+    child_field: T
+
+
+@dataclasses.dataclass
+class ReifiedChild(Base[int]):
+    extra: str = "x"
+
+
+def test_pep695_generic_stringized_annotation_resolves() -> None:
+    # #475: previously raised `NameError: name 'T' is not defined` because the
+    # stringized `list[T]` annotation couldn't see the PEP 695 type parameter.
+    out = tyro.cli(Container[int], args=["--items", "1", "2", "3"])
+    assert out.items == [1, 2, 3]
+    assert all(isinstance(x, int) for x in out.items)
+
+    out_str = tyro.cli(Container[str], args=["--items", "a", "b"])
+    assert out_str.items == ["a", "b"]
+
+
+def test_initvar_is_recognized_as_constructor_arg() -> None:
+    # #474: InitVar fields are init-only pseudo-fields passed to __init__ /
+    # __post_init__, so tyro should expose them as CLI arguments.
+    @dataclasses.dataclass
+    class WithInit:
+        x: int
+        offset: dataclasses.InitVar[int] = 10
+
+        def __post_init__(self, offset: int) -> None:
+            self.total = self.x + offset
+
+    # If InitVar weren't recognized, `--offset` would be an unrecognized option.
+    out = tyro.cli(WithInit, args=["--x", "1", "--offset", "5"])
+    assert out.x == 1
+    assert out.total == 6
+    # Default is used when not provided.
+    assert tyro.cli(WithInit, args=["--x", "2"]).total == 12
+
+
+def test_initvar_of_pep695_generic_does_not_crash() -> None:
+    # The exact shape from the issue: an InitVar of a (PEP 695) generic, behind
+    # a PEP 695 `type` alias, with stringized annotations. Used to raise the
+    # obscure NameError; should now resolve cleanly.
+    @dataclasses.dataclass
+    class App:
+        name: str = "default"
+        _sequencer: dataclasses.InitVar[Seq | None] = None
+
+        def __post_init__(self, _sequencer: Seq | None) -> None:
+            self.seq = _sequencer
+
+    out = tyro.cli(App, args=["--name", "hi"])
+    assert out.name == "hi"
+    assert out.seq is None
+
+
+def test_pep695_multiple_params_and_compound_refs() -> None:
+    # Multiple PEP 695 params, and type params nested inside dict/Optional/tuple.
+    assert tyro.cli(Pair[int, str], args=["--k", "1", "--v", "a"]) == Pair(1, "a")
+
+    out = tyro.cli(
+        Compound[int],
+        args=["--mapping", "a", "1", "--opt", "2", "--rest", "3", "4"],
+    )
+    assert out.mapping == {"a": 1}
+    assert out.opt == 2 and isinstance(out.opt, int)
+    assert out.rest == (3, 4)
+    # Defaults still work when the param-typed optionals are omitted.
+    assert tyro.cli(Compound[str], args=["--mapping", "k", "v"]) == Compound(
+        {"k": "v"}, None, ()
+    )
+
+
+def test_pep695_inheritance() -> None:
+    # Type parameter forwarded through a base class: Child[int] -> Base[int].
+    assert tyro.cli(
+        Child[int], args=["--base-field", "1", "--child-field", "2"]
+    ) == Child(base_field=1, child_field=2)
+    # Base reified at the inheritance site: ReifiedChild(Base[int]).
+    out = tyro.cli(ReifiedChild, args=["--base-field", "9"])
+    assert out.base_field == 9 and isinstance(out.base_field, int)
+    assert out.extra == "x"
+
+
+def test_pep695_generic_as_nested_field() -> None:
+    @dataclasses.dataclass
+    class Outer:
+        inner: Bare[int]
+
+    out = tyro.cli(Outer, args=["--inner.x", "7"])
+    assert out.inner == Bare(7) and isinstance(out.inner.x, int)
+
+
+def test_pep695_generic_in_subcommand_union() -> None:
+    @dataclasses.dataclass
+    class Outer2:
+        choice: Bare[int] | Pair[int, int]
+
+    assert tyro.cli(Outer2, args=["choice:bare-int", "--choice.x", "3"]) == Outer2(
+        choice=Bare(3)
+    )
+    assert tyro.cli(
+        Outer2, args=["choice:pair-int-int", "--choice.k", "1", "--choice.v", "2"]
+    ) == Outer2(choice=Pair(1, 2))
+
+
+def test_pep695_unreified_generic_gives_clean_error_not_nameerror() -> None:
+    # An *unparameterized* PEP 695 generic field can't bind its type parameter,
+    # so it resolves to `Any` -> a clean "unsupported type" error (SystemExit),
+    # NOT the obscure pre-fix `NameError: name 'T' is not defined`.
+    @dataclasses.dataclass
+    class Outer:
+        inner: Bare
+
+    with pytest.raises(SystemExit):
+        tyro.cli(Outer, args=["--inner.x", "1"])

--- a/tests/test_py311_generated/test_short_flag_clustering_generated.py
+++ b/tests/test_py311_generated/test_short_flag_clustering_generated.py
@@ -247,3 +247,22 @@ def test_help_short_unaffected() -> None:
     with pytest.raises(SystemExit) as exc_info:
         tyro.cli(C, args=["-h"])
     assert exc_info.value.code == 0
+
+
+def test_glued_value_starting_with_dash() -> None:
+    """A glued value attached to a value-taking short flag is consumed verbatim,
+    even when it looks like a flag (e.g. ``-n-x`` -> ``-n`` with value ``-x``).
+    This matches argparse; the value must NOT be rejected by the flag-like
+    value-consumption guard."""
+
+    @dataclasses.dataclass
+    class C:
+        name: Annotated[str, arg(aliases=["-n"])] = "default"
+
+    assert tyro.cli(C, args=["-n-x"]).name == "-x"
+    assert tyro.cli(C, args=["-n--x"]).name == "--x"
+    assert tyro.cli(C, args=["-nab-c"]).name == "ab-c"
+    assert tyro.cli(C, args=["-n=-x"]).name == "-x"
+    # A separate (non-glued) flag-like token is still not a value.
+    with pytest.raises(SystemExit):
+        tyro.cli(C, args=["-n", "-x"])

--- a/tests/test_short_flag_clustering.py
+++ b/tests/test_short_flag_clustering.py
@@ -248,3 +248,22 @@ def test_help_short_unaffected() -> None:
     with pytest.raises(SystemExit) as exc_info:
         tyro.cli(C, args=["-h"])
     assert exc_info.value.code == 0
+
+
+def test_glued_value_starting_with_dash() -> None:
+    """A glued value attached to a value-taking short flag is consumed verbatim,
+    even when it looks like a flag (e.g. ``-n-x`` -> ``-n`` with value ``-x``).
+    This matches argparse; the value must NOT be rejected by the flag-like
+    value-consumption guard."""
+
+    @dataclasses.dataclass
+    class C:
+        name: Annotated[str, arg(aliases=["-n"])] = "default"
+
+    assert tyro.cli(C, args=["-n-x"]).name == "-x"
+    assert tyro.cli(C, args=["-n--x"]).name == "--x"
+    assert tyro.cli(C, args=["-nab-c"]).name == "ab-c"
+    assert tyro.cli(C, args=["-n=-x"]).name == "-x"
+    # A separate (non-glued) flag-like token is still not a value.
+    with pytest.raises(SystemExit):
+        tyro.cli(C, args=["-n", "-x"])


### PR DESCRIPTION
Had Claude probe for edge cases. This PR includes manually-checked fixes: ~18 minor bugs, including #474 and #475. Added tests for each fix.

**Argument parsing**
- `Optional[Tuple[int, int]]` now accepts `None`.
- Short-flag clustering handles `=` correctly (`-na=foo` => `-n a=foo`); glued values that look like flags work too (`-n-x` => `-n -x`).
- Fixed-nargs args no longer swallow a following flag or `--` as their value.
- A variable-length positional no longer starves a later required positional (`Positional[List[int]]` + `Positional[int]`, `1 2 3 4` → `[1,2,3], 4`).
- Empty tuples (`Tuple[()]`) nested in tuples no longer crash or hang.
- "Missing value" / invalid-choice errors show the real flag name instead of a raw tuple, and no longer leak internal names.

**Types & generics**
- Chained PEP 696 `TypeVar` defaults resolve (`V = TypeVar("V", default=K)`).
- PEP 695 generics (`class Foo[T]`) resolve under `from __future__ import annotations`; no more `NameError: name 'T' is not defined` (#474, #475).

**Containers**
- Parameterized `collections.abc.*` and `Counter` / `OrderedDict` / `defaultdict` now parse instead of erroring, including with `UseAppendAction`.

**Structs**
- attrs fields with a renamed init arg (`_x`, `alias=`) no longer crash.
- pydantic v2 `Field(alias=...)` / `validation_alias` no longer crash.
- A `default=` instance for a `**kwargs` parameter is no longer dropped.

**Misc**
- `bytearray` fields work; pure paths keep their flavour (`PureWindowsPath` etc.).
- Subcommand alias collisions are caught with `-`/`_` awareness.
- Bash completion no longer breaks on quotes in a default (e.g. `"don't"`).

**argparse backend (for testing)**
- Nested `is_default` subcommands, a positional before a subcommand, and cross-subcommand mutex groups are now handled or clearly rejected.